### PR TITLE
fix(login): Uses the form tenant-id at login

### DIFF
--- a/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -18,7 +18,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { HttpRequest, HttpHandlerFn, HttpResponse } from '@angular/common/http';
+import { HttpHeaders, HttpRequest, HttpHandlerFn, HttpResponse } from '@angular/common/http';
 import { authInterceptor } from './auth.interceptor';
 import { AuthService } from '../services/auth.service';
 import { signal } from '@angular/core';
@@ -58,6 +58,31 @@ describe('authInterceptor', () => {
     const request = new HttpRequest('GET', testUrl);
     const next: HttpHandlerFn = (req) => {
       expect(req.headers.get('Authorization')).toBe('Basic mock-token');
+      return of(new HttpResponse({ status: 200 }));
+    };
+
+    TestBed.runInInjectionContext(() => {
+      authInterceptor(request, next).subscribe(() => done());
+    });
+  });
+
+  it('should not overwrite tenant headers when the request already specifies them', (done) => {
+    authServiceSpy.getAuthToken.and.returnValue(null);
+    const loginTenant = 'from-login-form';
+    const request = new HttpRequest(
+      'POST',
+      testUrl,
+      {},
+      {
+        headers: new HttpHeaders({
+          'Fineract-Platform-TenantId': loginTenant,
+          'X-Mifos-Platform-TenantId': loginTenant,
+        }),
+      },
+    );
+    const next: HttpHandlerFn = (req) => {
+      expect(req.headers.get('Fineract-Platform-TenantId')).toBe(loginTenant);
+      expect(req.headers.get('X-Mifos-Platform-TenantId')).toBe(loginTenant);
       return of(new HttpResponse({ status: 200 }));
     };
 

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -21,11 +21,23 @@ import { HttpInterceptorFn, HttpRequest, HttpHandlerFn } from '@angular/common/h
 import { inject } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 
+/** True when the request already carries a tenant (e.g. login with user-entered tenant). */
+function hasExplicitTenantHeaders(req: HttpRequest<unknown>): boolean {
+  return (
+    !!req.headers.get('Fineract-Platform-TenantId') ||
+    !!req.headers.get('X-Mifos-Platform-TenantId') ||
+    !!req.headers.get('fineract-platform-tenantid')
+  );
+}
+
 /**
  * Functional HTTP Interceptor that handles authentication and multi-tenancy.
  *
  * Injects the mandatory `Fineract-Platform-TenantId` header and the
  * `Authorization` header (if an active session exists) into every outgoing request.
+ *
+ * Requests that already specify tenant headers are left unchanged for those headers so
+ * login can send the tenant from the form before `currentTenantId` is updated.
  *
  * @param req - The outgoing HTTP request
  * @param next - The next handler in the interceptor chain
@@ -39,13 +51,15 @@ export const authInterceptor: HttpInterceptorFn = (
   const token = authService.getAuthToken();
   const tenantId = authService.currentTenantId();
 
-  // Always include Tenant headers for Fineract/Mifos compatibility
-  let authReq = req.clone({
-    setHeaders: {
-      'Fineract-Platform-TenantId': tenantId,
-      'X-Mifos-Platform-TenantId': tenantId,
-    },
-  });
+  let authReq = req;
+  if (!hasExplicitTenantHeaders(req)) {
+    authReq = req.clone({
+      setHeaders: {
+        'Fineract-Platform-TenantId': tenantId,
+        'X-Mifos-Platform-TenantId': tenantId,
+      },
+    });
+  }
 
   // Inject Basic Auth token if the user is logged in
   if (token) {


### PR DESCRIPTION
This PR changes the way the interceptor captures the login call so that the backoffice app can connect to backends with custom `tenant-id` header. Currently the value received in the form is ignored and the environment one is used.