### PR TITLE
add InstitutionConfigService for mode-based feature toggles (#119)

### DIFF
--- a/src/app/core/services/institution-config.service.spec.ts
+++ b/src/app/core/services/institution-config.service.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { InstitutionConfigService, InstitutionType } from './institution-config.service';
+
+describe('InstitutionConfigService', () => {
+  const STORAGE_KEY = 'fineract_institution_type';
+
+  let service: InstitutionConfigService;
+
+  const createService = () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [InstitutionConfigService],
+    });
+    service = TestBed.inject(InstitutionConfigService);
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    createService();
+    expect(service).toBeTruthy();
+  });
+
+  it('should default to "universal" when nothing is stored', () => {
+    createService();
+    expect(service.institutionType()).toBe('universal');
+    expect(service.isFeatureEnabled('groups')).toBeTrue();
+    expect(service.isFeatureEnabled('centers')).toBeTrue();
+    expect(service.isFeatureEnabled('collection_sheet')).toBeTrue();
+  });
+
+  it('should read a valid persisted institution type on init', () => {
+    localStorage.setItem(STORAGE_KEY, 'cb');
+    createService();
+    expect(service.institutionType()).toBe('cb');
+  });
+
+  it('should fall back to "universal" when the stored value is invalid', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-a-real-type');
+    createService();
+    expect(service.institutionType()).toBe('universal');
+  });
+
+  it('should persist to local storage and update the signal on set', () => {
+    createService();
+    service.setInstitutionType('mfis');
+    expect(service.institutionType()).toBe('mfis');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('mfis');
+  });
+
+  describe('isFeatureEnabled matrix', () => {
+    const cases: Array<{
+      type: InstitutionType;
+      groups: boolean;
+      centers: boolean;
+      collection_sheet: boolean;
+    }> = [
+      { type: 'mfis', groups: true, centers: true, collection_sheet: true },
+      { type: 'cb', groups: false, centers: false, collection_sheet: false },
+      { type: 'cu', groups: true, centers: false, collection_sheet: false },
+      { type: 'universal', groups: true, centers: true, collection_sheet: true },
+    ];
+
+    cases.forEach(({ type, groups, centers, collection_sheet }) => {
+      it(`should resolve features correctly for "${type}"`, () => {
+        createService();
+        service.setInstitutionType(type);
+        expect(service.isFeatureEnabled('groups')).toBe(groups);
+        expect(service.isFeatureEnabled('centers')).toBe(centers);
+        expect(service.isFeatureEnabled('collection_sheet')).toBe(collection_sheet);
+      });
+    });
+  });
+});

--- a/src/app/core/services/institution-config.service.spec.ts
+++ b/src/app/core/services/institution-config.service.spec.ts
@@ -74,12 +74,12 @@ describe('InstitutionConfigService', () => {
   });
 
   describe('isFeatureEnabled matrix', () => {
-    const cases: Array<{
+    const cases: {
       type: InstitutionType;
       groups: boolean;
       centers: boolean;
       collection_sheet: boolean;
-    }> = [
+    }[] = [
       { type: 'mfis', groups: true, centers: true, collection_sheet: true },
       { type: 'cb', groups: false, centers: false, collection_sheet: false },
       { type: 'cu', groups: true, centers: false, collection_sheet: false },

--- a/src/app/core/services/institution-config.service.ts
+++ b/src/app/core/services/institution-config.service.ts
@@ -91,6 +91,6 @@ export class InstitutionConfigService {
    * @param value - The value read from local storage
    */
   private isInstitutionType(value: string | null): value is InstitutionType {
-    return value === 'mfis' || value === 'cb' || value === 'cu' || value === 'universal';
+    return value !== null && Object.keys(this.featureMatrix).includes(value);
   }
 }

--- a/src/app/core/services/institution-config.service.ts
+++ b/src/app/core/services/institution-config.service.ts
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Category of institution the deployment serves. Determines which
+ * product features (see {@link InstitutionFeature}) are exposed.
+ */
+export type InstitutionType = 'mfis' | 'cb' | 'cu' | 'universal';
+
+/**
+ * Group-lending product features that can be toggled by institution type.
+ */
+export type InstitutionFeature = 'groups' | 'centers' | 'collection_sheet';
+
+/**
+ * Service that persists the deployment's institution type to local storage
+ * and answers whether a given group-lending feature is enabled for it.
+ *
+ * This is the single source of truth for mode-based feature toggles. It is
+ * consumed by RBAC sidebar filtering (issue #113) alongside permission checks.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class InstitutionConfigService {
+  private readonly storageKey = 'fineract_institution_type';
+
+  /** Institution type used when none is persisted (backward-compatible default). */
+  private readonly defaultType: InstitutionType = 'universal';
+
+  /** Which features each institution type exposes. */
+  private readonly featureMatrix: Record<InstitutionType, readonly InstitutionFeature[]> = {
+    mfis: ['groups', 'centers', 'collection_sheet'],
+    cb: [],
+    cu: ['groups'],
+    universal: ['groups', 'centers', 'collection_sheet'],
+  };
+
+  private readonly _institutionType = signal<InstitutionType>(this.getStored());
+
+  /** Readonly access to the current institution type signal. */
+  readonly institutionType = this._institutionType.asReadonly();
+
+  /**
+   * Persists the institution type to local storage and updates the signal.
+   * @param type - The institution type to set
+   */
+  setInstitutionType(type: InstitutionType): void {
+    localStorage.setItem(this.storageKey, type);
+    this._institutionType.set(type);
+  }
+
+  /**
+   * Returns whether the given feature is enabled for the current institution type.
+   * @param feature - The feature to check
+   */
+  isFeatureEnabled(feature: InstitutionFeature): boolean {
+    return this.featureMatrix[this._institutionType()].includes(feature);
+  }
+
+  /**
+   * Retrieves the initial institution type from local storage, falling back to
+   * the default when absent or invalid (e.g. a tampered or legacy value).
+   * @returns The resolved institution type
+   */
+  private getStored(): InstitutionType {
+    const stored = localStorage.getItem(this.storageKey);
+    return this.isInstitutionType(stored) ? stored : this.defaultType;
+  }
+
+  /**
+   * Type guard validating a raw string against the {@link InstitutionType} union.
+   * @param value - The value read from local storage
+   */
+  private isInstitutionType(value: string | null): value is InstitutionType {
+    return value === 'mfis' || value === 'cb' || value === 'cu' || value === 'universal';
+  }
+}


### PR DESCRIPTION
## What was done

Adds `InstitutionConfigService`, a signal-based Angular service that tracks the
deployment's institution type and exposes which group-lending features are
enabled for it.

- Persists institution type (`'mfis' | 'cb' | 'cu' | 'universal'`) to
  `localStorage` under the key `fineract_institution_type`.
- Exposes a readonly `institutionType` signal and a `setInstitutionType()`
  method to update and persist it.
- Exposes `isFeatureEnabled('groups' | 'centers' | 'collection_sheet')`,
  resolved against a per-institution-type feature matrix:

  | Institution type | groups | centers | collection_sheet |
  |------------------|:------:|:-------:|:-----------------:|
  | `mfis`           | yes    | yes     | yes                |
  | `cb`             | no     | no      | no                 |
  | `cu`             | yes    | no      | no                 |
  | `universal`      | yes    | yes     | yes                |

- Defaults to `'universal'` (all features enabled) when nothing is persisted,
  for backward compatibility with existing deployments.
- Validates the stored value against the known union before trusting it,
  falling back to the default if the value is missing, invalid, or tampered.


## Testing

Added `institution-config.service.spec.ts` covering:
- Service creation
- Default institution type when storage is empty
- Reading a valid persisted value on init
- Falling back to default on an invalid/unrecognized stored value
- Persisting + updating the signal via `setInstitutionType()`
- Full matrix coverage of `isFeatureEnabled()` across all 4 institution types
  × 3 features

Full suite: `552/552` passing, no regressions.


Closes #119.