### PR TITLE
Scope ALL_FUNCTIONS_READ to read-only permissions in AuthService (#120)

### DIFF
--- a/e2e/all-functions-read-shortcut.spec.ts
+++ b/e2e/all-functions-read-shortcut.spec.ts
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * End-to-end coverage for issue #120 / #114 — the `ALL_FUNCTIONS_READ`
+ * shortcut on `AuthService.hasPermission()`.
+ *
+ * A user holding `ALL_FUNCTIONS_READ` should see every READ_* gated element
+ * (e.g. list/detail screens) without the app needing to enumerate every read
+ * permission individually, but must never see elements gated by a write
+ * permission such as `CREATE_CLIENT`. This is exercised against the real
+ * "Create Client" button on the Clients list page
+ * (`*appHasPermission="'CREATE_CLIENT'"` in `clients-list.component.ts`),
+ * which is hidden or shown purely by `AuthService.hasPermission()`.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+
+const API_BASE = '/api/v1';
+const TENANT_DEFAULT = 'default';
+const TEST_USER = 'mifos';
+const TEST_PASSWORD = 'password';
+const RESP_EMPTY_PAGINATED = JSON.stringify({ totalFilteredRecords: 0, pageItems: [] });
+const CREATE_CLIENT_BUTTON = /Create Client/;
+
+async function login(page: Page, permissions: string[]): Promise<void> {
+  await page.route('**/config.json', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ fineractApiUrl: API_BASE, defaultTenantId: TENANT_DEFAULT }),
+    });
+  });
+
+  await page.route('**/api/v1/authentication**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        username: TEST_USER,
+        userId: 1,
+        base64EncodedAuthenticationKey: 'YmFzZTY0',
+        authenticated: true,
+        officeId: 1,
+        officeName: 'Head Office',
+        roles: [{ id: 1, name: 'Test Role', description: 'Test role' }],
+        permissions,
+      }),
+    });
+  });
+
+  await page.route('**/api/v1/clients*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: RESP_EMPTY_PAGINATED,
+    });
+  });
+
+  await page.goto('/login');
+  await page.locator('#tenantId').fill(TENANT_DEFAULT);
+  await page.locator('#username').fill(TEST_USER);
+  await page.locator('#password').fill(TEST_PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL('/dashboard');
+}
+
+test.describe('ALL_FUNCTIONS_READ shortcut', () => {
+  test('grants read access to the Clients list without any explicit READ_CLIENT permission', async ({
+    page,
+  }) => {
+    await login(page, ['ALL_FUNCTIONS_READ']);
+    await page.getByRole('link', { name: 'Clients', exact: true }).click();
+    await expect(page).toHaveURL('/clients');
+  });
+
+  test('does not grant the Create Client action', async ({ page }) => {
+    await login(page, ['ALL_FUNCTIONS_READ']);
+    await page.getByRole('link', { name: 'Clients', exact: true }).click();
+    await expect(page).toHaveURL('/clients');
+
+    await expect(page.getByRole('button', { name: CREATE_CLIENT_BUTTON })).toHaveCount(0);
+  });
+
+  test('does not grant Create Client even combined with an explicit READ_CLIENT permission', async ({
+    page,
+  }) => {
+    await login(page, ['ALL_FUNCTIONS_READ', 'READ_CLIENT']);
+    await page.getByRole('link', { name: 'Clients', exact: true }).click();
+    await expect(page).toHaveURL('/clients');
+
+    await expect(page.getByRole('button', { name: CREATE_CLIENT_BUTTON })).toHaveCount(0);
+  });
+
+  test('a user with the real CREATE_CLIENT permission still sees the button', async ({ page }) => {
+    await login(page, ['READ_CLIENT', 'CREATE_CLIENT']);
+    await page.getByRole('link', { name: 'Clients', exact: true }).click();
+    await expect(page).toHaveURL('/clients');
+
+    await expect(page.getByRole('button', { name: CREATE_CLIENT_BUTTON })).toBeVisible();
+  });
+
+  test('ALL_FUNCTIONS (full superuser) still sees the Create Client button', async ({ page }) => {
+    await login(page, ['ALL_FUNCTIONS']);
+    await page.getByRole('link', { name: 'Clients', exact: true }).click();
+    await expect(page).toHaveURL('/clients');
+
+    await expect(page.getByRole('button', { name: CREATE_CLIENT_BUTTON })).toBeVisible();
+  });
+});

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -108,5 +108,43 @@ describe('AuthService', () => {
       expect(service.hasPermission(['READ_CLIENT', 'CREATE_CLIENT'], true)).toBeTrue();
       expect(service.hasPermission(['READ_CLIENT', 'DELETE_LOAN'], true)).toBeFalse();
     });
+
+    describe('ALL_FUNCTIONS_READ shortcut', () => {
+      beforeEach(() => {
+        (service as unknown as { setSession: (s: UserSession) => void }).setSession({
+          ...mockSession,
+          permissions: ['ALL_FUNCTIONS_READ'],
+        });
+      });
+
+      it('grants any single READ_* permission', () => {
+        expect(service.hasPermission('READ_CLIENT')).toBeTrue();
+        expect(service.hasPermission('READ_LOAN')).toBeTrue();
+      });
+
+      it('denies a single non-READ_* permission', () => {
+        expect(service.hasPermission('CREATE_CLIENT')).toBeFalse();
+        expect(service.hasPermission('DELETE_LOAN')).toBeFalse();
+        expect(service.hasPermission('APPROVE_LOAN')).toBeFalse();
+      });
+
+      it('grants an array made up entirely of READ_* permissions', () => {
+        expect(service.hasPermission(['READ_CLIENT', 'READ_LOAN'])).toBeTrue();
+        expect(service.hasPermission(['READ_CLIENT', 'READ_LOAN'], true)).toBeTrue();
+      });
+
+      it('does not grant a mixed array via the shortcut, falling back to real permissions', () => {
+        expect(service.hasPermission(['READ_CLIENT', 'CREATE_CLIENT'])).toBeFalse();
+        expect(service.hasPermission(['READ_CLIENT', 'CREATE_CLIENT'], true)).toBeFalse();
+      });
+    });
+
+    it('ALL_FUNCTIONS still bypasses non-READ permissions (unlike ALL_FUNCTIONS_READ)', () => {
+      (service as unknown as { setSession: (s: UserSession) => void }).setSession({
+        ...mockSession,
+        permissions: ['ALL_FUNCTIONS'],
+      });
+      expect(service.hasPermission(['READ_CLIENT', 'CREATE_CLIENT'], true)).toBeTrue();
+    });
   });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -169,21 +169,27 @@ export class AuthService {
       return false;
     }
 
-    // Special superuser permission "ALL_FUNCTIONS" bypasses check
+    // Special superuser permission "ALL_FUNCTIONS" bypasses every check.
+    if (user.permissions.includes('ALL_FUNCTIONS')) {
+      return true;
+    }
+
+    const required = Array.isArray(permission) ? permission : [permission];
+
+    // Read-only superuser shortcut: grants any request made up entirely of
+    // READ_* permissions, but never write/approve actions. A mixed request
+    // (e.g. a READ_* permission combined with a non-READ_* one) falls through
+    // to the normal permission-list check below.
     if (
-      user.permissions.includes('ALL_FUNCTIONS') ||
-      user.permissions.includes('ALL_FUNCTIONS_READ')
+      user.permissions.includes('ALL_FUNCTIONS_READ') &&
+      required.every((p) => p.startsWith('READ_'))
     ) {
       return true;
     }
 
-    if (Array.isArray(permission)) {
-      if (matchAll) {
-        return permission.every((p) => user.permissions.includes(p));
-      }
-      return permission.some((p) => user.permissions.includes(p));
+    if (matchAll) {
+      return required.every((p) => user.permissions.includes(p));
     }
-
-    return user.permissions.includes(permission);
+    return required.some((p) => user.permissions.includes(p));
   }
 }


### PR DESCRIPTION
AuthService.hasPermission() previously treated ALL_FUNCTIONS_READ as a
full superuser bypass, identical to ALL_FUNCTIONS — granting create,
update, delete, and approve actions to a permission meant to signal
read-only access (e.g. an auditor role).

Scope the shortcut so it only satisfies requests made up entirely of
READ_* permissions; any request containing a non-READ_* permission now
falls through to normal permission-list evaluation. ALL_FUNCTIONS
behavior is unchanged.

## Test

- Add unit coverage in auth.service.spec.ts 
- an e2e spec (all-functions-read-shortcut.spec.ts) exercising the real
"Create Client" *appHasPermission gate, confirmed to fail against the
pre-fix code and pass against the fix.