### PR TITLE
Gate Interop, Campaigns, Working Capital, and Transfers nav items

### DIFF
--- a/src/app/core/services/navigation-config.service.spec.ts
+++ b/src/app/core/services/navigation-config.service.spec.ts
@@ -198,6 +198,107 @@ describe('NavigationConfigService', () => {
     expect(findRoute(items, '/clients')).toBeTrue();
   });
 
+  describe('issue #142 — Interop, Campaigns, Working Capital, Account Transfer gates', () => {
+    const INTEROP_PARTIES_ROUTE = '/interop/parties';
+    const INTEROP_QUOTES_ROUTE = '/interop/quotes';
+    const INTEROP_TRANSFERS_ROUTE = '/interop/transfers';
+    const CAMPAIGNS_EMAIL_ROUTE = '/campaigns/email';
+    const CAMPAIGNS_SMS_ROUTE = '/campaigns/sms';
+    const WC_LOANS_ROUTE = '/working-capital/loans';
+    const WC_LOAN_PRODUCTS_ROUTE = '/working-capital/loan-products';
+    const WC_BREACH_ROUTE = '/working-capital/breach';
+    const WC_NEAR_BREACH_ROUTE = '/working-capital/near-breach';
+    const ACCOUNT_TRANSFER_ROUTE = '/transfers/account-transfer';
+    const STANDING_INSTRUCTIONS_ROUTE = '/transfers/standing-instructions';
+    const STANDING_INSTRUCTIONS_HISTORY_ROUTE = '/transfers/standing-instructions/history';
+
+    it('hides all 12 newly-gated routes from a user with no matching permissions, leaving their ungated siblings visible', () => {
+      setPermissions([]);
+      const items = service.filteredNavItems();
+
+      // gated
+      expect(findRoute(items, INTEROP_PARTIES_ROUTE)).toBeFalse();
+      expect(findRoute(items, INTEROP_QUOTES_ROUTE)).toBeFalse();
+      expect(findRoute(items, INTEROP_TRANSFERS_ROUTE)).toBeFalse();
+      expect(findRoute(items, CAMPAIGNS_EMAIL_ROUTE)).toBeFalse();
+      expect(findRoute(items, CAMPAIGNS_SMS_ROUTE)).toBeFalse();
+      expect(findRoute(items, WC_LOANS_ROUTE)).toBeFalse();
+      expect(findRoute(items, WC_LOAN_PRODUCTS_ROUTE)).toBeFalse();
+      expect(findRoute(items, WC_BREACH_ROUTE)).toBeFalse();
+      expect(findRoute(items, WC_NEAR_BREACH_ROUTE)).toBeFalse();
+      expect(findRoute(items, ACCOUNT_TRANSFER_ROUTE)).toBeFalse();
+      expect(findRoute(items, STANDING_INSTRUCTIONS_ROUTE)).toBeFalse();
+      expect(findRoute(items, STANDING_INSTRUCTIONS_HISTORY_ROUTE)).toBeFalse();
+
+      // ungated siblings within the same groups remain visible
+      expect(findRoute(items, '/interop/accounts')).toBeTrue();
+      expect(findRoute(items, '/interop/health')).toBeTrue();
+      expect(findRoute(items, '/campaigns/email-messages')).toBeTrue();
+      expect(findRoute(items, '/working-capital/loans/account-locks')).toBeTrue();
+      expect(findRoute(items, '/working-capital/loans/cob-catchup')).toBeTrue();
+      expect(findRoute(items, '/admin/wc-cob-tools')).toBeTrue();
+      expect(findRoute(items, '/transfers/history')).toBeTrue();
+    });
+
+    it('shows only the specific interop routes the user has permission for', () => {
+      setPermissions(['READ_INTERID']);
+      const items = service.filteredNavItems();
+      expect(findRoute(items, INTEROP_PARTIES_ROUTE)).toBeTrue();
+      expect(findRoute(items, INTEROP_QUOTES_ROUTE)).toBeFalse();
+      expect(findRoute(items, INTEROP_TRANSFERS_ROUTE)).toBeFalse();
+    });
+
+    it('shows only the specific campaign routes the user has permission for', () => {
+      setPermissions(['READ_SMSCAMPAIGN']);
+      const items = service.filteredNavItems();
+      expect(findRoute(items, CAMPAIGNS_SMS_ROUTE)).toBeTrue();
+      expect(findRoute(items, CAMPAIGNS_EMAIL_ROUTE)).toBeFalse();
+    });
+
+    it('shows only the specific working capital routes the user has permission for', () => {
+      setPermissions(['READ_WORKINGCAPITALBREACH']);
+      const items = service.filteredNavItems();
+      expect(findRoute(items, WC_BREACH_ROUTE)).toBeTrue();
+      expect(findRoute(items, WC_LOANS_ROUTE)).toBeFalse();
+      expect(findRoute(items, WC_LOAN_PRODUCTS_ROUTE)).toBeFalse();
+      expect(findRoute(items, WC_NEAR_BREACH_ROUTE)).toBeFalse();
+    });
+
+    it('shows Account Transfer once the user has READ_ACCOUNTTRANSFER, without granting sibling gates', () => {
+      setPermissions(['READ_ACCOUNTTRANSFER']);
+      const items = service.filteredNavItems();
+      expect(findRoute(items, ACCOUNT_TRANSFER_ROUTE)).toBeTrue();
+      expect(findRoute(items, STANDING_INSTRUCTIONS_ROUTE)).toBeFalse();
+      // ungated sibling still visible regardless
+      expect(findRoute(items, '/transfers/history')).toBeTrue();
+    });
+
+    it('shows both Standing Instructions routes once the user has READ_STANDINGINSTRUCTION', () => {
+      setPermissions(['READ_STANDINGINSTRUCTION']);
+      const items = service.filteredNavItems();
+      expect(findRoute(items, STANDING_INSTRUCTIONS_ROUTE)).toBeTrue();
+      expect(findRoute(items, STANDING_INSTRUCTIONS_HISTORY_ROUTE)).toBeTrue();
+      expect(findRoute(items, ACCOUNT_TRANSFER_ROUTE)).toBeFalse();
+    });
+
+    it('a superuser (ALL_FUNCTIONS) sees all 12 newly-gated routes', () => {
+      setPermissions(['ALL_FUNCTIONS']);
+      const items = service.filteredNavItems();
+      expect(findRoute(items, INTEROP_PARTIES_ROUTE)).toBeTrue();
+      expect(findRoute(items, INTEROP_QUOTES_ROUTE)).toBeTrue();
+      expect(findRoute(items, INTEROP_TRANSFERS_ROUTE)).toBeTrue();
+      expect(findRoute(items, CAMPAIGNS_EMAIL_ROUTE)).toBeTrue();
+      expect(findRoute(items, CAMPAIGNS_SMS_ROUTE)).toBeTrue();
+      expect(findRoute(items, WC_LOANS_ROUTE)).toBeTrue();
+      expect(findRoute(items, WC_LOAN_PRODUCTS_ROUTE)).toBeTrue();
+      expect(findRoute(items, WC_BREACH_ROUTE)).toBeTrue();
+      expect(findRoute(items, WC_NEAR_BREACH_ROUTE)).toBeTrue();
+      expect(findRoute(items, ACCOUNT_TRANSFER_ROUTE)).toBeTrue();
+      expect(findRoute(items, STANDING_INSTRUCTIONS_ROUTE)).toBeTrue();
+      expect(findRoute(items, STANDING_INSTRUCTIONS_HISTORY_ROUTE)).toBeTrue();
+    });
+  });
+
   describe('isItemVisible (synthetic items)', () => {
     const isVisible = (item: NavItemConfig): boolean =>
       (service as unknown as { isItemVisible: (i: NavItemConfig) => boolean }).isItemVisible(item);

--- a/src/app/core/services/navigation-config.service.ts
+++ b/src/app/core/services/navigation-config.service.ts
@@ -83,16 +83,19 @@ const NAV_CONFIG: readonly NavItemConfig[] = [
         route: '/transfers/account-transfer',
         labelKey: 'nav.accountTransfer',
         icon: 'swap_horiz',
+        requiredPermissions: 'READ_ACCOUNTTRANSFER',
       },
       {
         route: '/transfers/standing-instructions',
         labelKey: 'nav.standingInstructions',
         icon: 'schedule_send',
+        requiredPermissions: 'READ_STANDINGINSTRUCTION',
       },
       {
         route: '/transfers/standing-instructions/history',
         labelKey: 'nav.standingInstructionsHistory',
         icon: 'history',
+        requiredPermissions: 'READ_STANDINGINSTRUCTION',
       },
       { route: '/transfers/history', labelKey: 'nav.transferHistory', icon: 'history' },
     ],
@@ -138,17 +141,29 @@ const NAV_CONFIG: readonly NavItemConfig[] = [
   {
     labelKey: 'nav.workingCapital',
     children: [
-      { route: '/working-capital/loans', labelKey: 'nav.wcLoans', icon: 'account_balance' },
+      {
+        route: '/working-capital/loans',
+        labelKey: 'nav.wcLoans',
+        icon: 'account_balance',
+        requiredPermissions: 'READ_WORKINGCAPITALLOAN',
+      },
       {
         route: '/working-capital/loan-products',
         labelKey: 'nav.wcLoanProducts',
         icon: 'account_balance_wallet',
+        requiredPermissions: 'READ_WORKINGCAPITALLOANPRODUCT',
       },
-      { route: '/working-capital/breach', labelKey: 'nav.wcBreach', icon: 'report_problem' },
+      {
+        route: '/working-capital/breach',
+        labelKey: 'nav.wcBreach',
+        icon: 'report_problem',
+        requiredPermissions: 'READ_WORKINGCAPITALBREACH',
+      },
       {
         route: '/working-capital/near-breach',
         labelKey: 'nav.wcNearBreach',
         icon: 'warning_amber',
+        requiredPermissions: 'READ_WORKINGCAPITALNEARBREACH',
       },
       {
         route: '/working-capital/loans/account-locks',
@@ -178,21 +193,42 @@ const NAV_CONFIG: readonly NavItemConfig[] = [
   {
     labelKey: 'Campaigns',
     children: [
-      { route: '/campaigns/email', labelKey: 'EMAIL_CAMPAIGNS.TITLE', icon: 'campaign' },
-      { route: '/campaigns/sms', labelKey: 'SMS_CAMPAIGNS.TITLE', icon: 'sms' },
+      {
+        route: '/campaigns/email',
+        labelKey: 'EMAIL_CAMPAIGNS.TITLE',
+        icon: 'campaign',
+        requiredPermissions: 'READ_EMAIL_CAMPAIGN',
+      },
+      {
+        route: '/campaigns/sms',
+        labelKey: 'SMS_CAMPAIGNS.TITLE',
+        icon: 'sms',
+        requiredPermissions: 'READ_SMSCAMPAIGN',
+      },
       { route: '/campaigns/email-messages', labelKey: 'EMAIL_MESSAGES.TITLE', icon: 'mail' },
     ],
   },
   {
     labelKey: 'Interop',
     children: [
-      { route: '/interop/parties', labelKey: 'INTEROP.PARTY_TITLE', icon: 'people' },
+      {
+        route: '/interop/parties',
+        labelKey: 'INTEROP.PARTY_TITLE',
+        icon: 'people',
+        requiredPermissions: 'READ_INTERID',
+      },
       { route: '/interop/accounts', labelKey: 'INTEROP.ACCOUNT_TITLE', icon: 'account_balance' },
-      { route: '/interop/quotes', labelKey: 'INTEROP.QUOTES_TITLE', icon: 'request_quote' },
+      {
+        route: '/interop/quotes',
+        labelKey: 'INTEROP.QUOTES_TITLE',
+        icon: 'request_quote',
+        requiredPermissions: 'READ_INTERQUOTE',
+      },
       {
         route: '/interop/transfers',
         labelKey: 'INTEROP.TRANSFER_TITLE',
         icon: 'transfer_within_a_station',
+        requiredPermissions: 'READ_INTERTRANSFER',
       },
       { route: '/interop/health', labelKey: 'INTEROP.HEALTH_TITLE', icon: 'monitor_heart' },
     ],


### PR DESCRIPTION
Add requiredPermissions to the 12 sidebar routes with a verified,
existing backend permission: 

1. Interop (Parties/Quotes/Transfers),
2. Campaigns (Email/SMS), 
3. Working Capital (Loans/Loan Products/Breach/Near Breach)
4. Transfers (Account Transfer, Standing, Instructions, Standing Instructions History). 

**Their ungated siblings** (Interop Accounts/Health, Campaigns Email Messages, WC Loan Account
Lock/COB Catchup/COB Tools, Transfer History) are left untouched — no backend permission exists for them yet.

Adds 7 unit tests covering hide/show behavior per permission, the ALL_FUNCTIONS superuser path, and that ungated siblings stay visible regardless of the new gates.