### PR TITLE
trim and dedupe backend permission codes at session ingestion

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -147,4 +147,48 @@ describe('AuthService', () => {
       expect(service.hasPermission(['READ_CLIENT', 'CREATE_CLIENT'], true)).toBeTrue();
     });
   });
+
+  describe('permission normalization (trailing-space backend duplicates)', () => {
+    it('trims a trailing-space permission on setSession so a clean check matches', () => {
+      (service as unknown as { setSession: (s: UserSession) => void }).setSession({
+        ...mockSession,
+        permissions: ['READ_STANDINGINSTRUCTION '],
+      });
+      expect(service.hasPermission('READ_STANDINGINSTRUCTION')).toBeTrue();
+    });
+
+    it('dedupes a clean/trailing-space duplicate pair into a single entry on setSession', () => {
+      (service as unknown as { setSession: (s: UserSession) => void }).setSession({
+        ...mockSession,
+        permissions: ['READ_CLIENT ', 'READ_CLIENT'],
+      });
+      expect(service.currentUser()?.permissions).toEqual(['READ_CLIENT']);
+      expect(service.hasPermission('READ_CLIENT')).toBeTrue();
+    });
+
+    it('normalizes a dirty session read back from sessionStorage on init', () => {
+      sessionStorage.setItem(
+        'fineract_session',
+        JSON.stringify({
+          ...mockSession,
+          permissions: ['CREATE_STANDINGINSTRUCTION', 'CREATE_STANDINGINSTRUCTION ', 'READ_X '],
+        }),
+      );
+
+      // Reset and reconfigure the testing module so AuthService is
+      // constructed fresh, reading the dirty sessionStorage entry above via
+      // getStoredSession() during its signal initialization.
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [AuthService, ConfigService, provideHttpClient(), provideHttpClientTesting()],
+      });
+      const freshService = TestBed.inject(AuthService);
+
+      expect(freshService.currentUser()?.permissions).toEqual([
+        'CREATE_STANDINGINSTRUCTION',
+        'READ_X',
+      ]);
+      expect(freshService.hasPermission('READ_X')).toBeTrue();
+    });
+  });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -134,8 +134,12 @@ export class AuthService {
    * @param session - The user session to store
    */
   private setSession(session: UserSession): void {
-    sessionStorage.setItem(this.sessionKey, JSON.stringify(session));
-    this.currentUser.set(session);
+    const normalized: UserSession = {
+      ...session,
+      permissions: this.normalizePermissions(session.permissions),
+    };
+    sessionStorage.setItem(this.sessionKey, JSON.stringify(normalized));
+    this.currentUser.set(normalized);
     this.isAuthenticated.set(true);
   }
 
@@ -145,7 +149,22 @@ export class AuthService {
    */
   private getStoredSession(): UserSession | null {
     const stored = sessionStorage.getItem(this.sessionKey);
-    return stored ? (JSON.parse(stored) as UserSession) : null;
+    if (!stored) {
+      return null;
+    }
+    const session = JSON.parse(stored) as UserSession;
+    return { ...session, permissions: this.normalizePermissions(session.permissions) };
+  }
+
+  /**
+   * Trims whitespace from each permission code and removes duplicates that
+   * only differ by leading/trailing whitespace. Fineract's permission seed
+   * data has known trailing-space entries (e.g. "CREATE_X" and "CREATE_X ")
+   * which would otherwise break exact-match permission checks.
+   * @param permissions - Raw permission codes as returned by the backend
+   */
+  private normalizePermissions(permissions: string[]): string[] {
+    return Array.from(new Set(permissions.map((p) => p.trim())));
   }
 
   /**


### PR DESCRIPTION
Fixes a class of silent permission-check failures caused by trailing-space duplicates in Fineract's backend permission data (e.g. `"CREATE_STANDINGINSTRUCTION"` vs `"CREATE_STANDINGINSTRUCTION "`). `AuthService.hasPermission()` does exact string matching, so a clean requirement string would fail to match if the backend only returned the dirty variant for a given role — the gated UI element stays hidden even though the user actually has the permission.

Discovered while gating Standing Instructions nav items in #142.

## Changes

- **`src/app/core/services/auth.service.ts`** — added a private `normalizePermissions()` helper (trim each code, dedupe via `Set`), applied in:
  - `setSession()` — normalizes a fresh login response before persisting to `sessionStorage`/the signal
  - `getStoredSession()` — normalizes on read from `sessionStorage`, so sessions already open in a user's browser before this fix ships also self-correct, without needing to log out/in
- **`src/app/core/services/auth.service.spec.ts`** — 3 new tests: trims a trailing-space permission on `setSession`, dedupes a clean/dirty duplicate pair, and normalizes a dirty session read back from `sessionStorage` on fresh construction (via `TestBed.resetTestingModule()` to genuinely exercise `getStoredSession()`, not just re-inject the same instance)

## Why fix it here, not per call-site

`user.permissions` is read in exactly one place in the codebase — `AuthService.hasPermission()` (verified via grep). Fixing normalization at the single ingestion point means every consumer (`*appHasPermission`, `NavigationConfigService`) is correct automatically, with zero changes needed anywhere else.

## Testing

- Unit: `npm test -- --watch=false` — 565/565 passing (3 new)
- Lint: `npm run lint` — clean
- Format: `npm run format:check` — clean

## Out of scope

- Not fixing Fineract's backend seed data itself (server-side, different repo)