### PR TITLE
Convert data-table and permission directives to signal inputs and queries

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -355,19 +355,6 @@
       "count": 1
     }
   },
-  "src/app/shared/components/data-table/cell-template.directive.ts": {
-    "@angular-eslint/prefer-signals": {
-      "count": 1
-    }
-  },
-  "src/app/shared/components/data-table/data-table.component.ts": {
-    "@angular-eslint/prefer-output-emitter-ref": {
-      "count": 4
-    },
-    "@angular-eslint/prefer-signals": {
-      "count": 15
-    }
-  },
   "src/app/shared/components/datatable-entry-dialog/datatable-entry-dialog.component.ts": {
     "@angular-eslint/prefer-signals": {
       "count": 1
@@ -394,16 +381,6 @@
   "src/app/shared/components/status-badge/status-badge.component.ts": {
     "@angular-eslint/prefer-signals": {
       "count": 1
-    }
-  },
-  "src/app/shared/directives/has-institution-feature.directive.ts": {
-    "@angular-eslint/prefer-signals": {
-      "count": 1
-    }
-  },
-  "src/app/shared/directives/has-permission.directive.ts": {
-    "@angular-eslint/prefer-signals": {
-      "count": 2
     }
   },
   "src/app/shared/directives/tooltip.directive.ts": {

--- a/src/app/shared/components/data-table/cell-template.directive.spec.ts
+++ b/src/app/shared/components/data-table/cell-template.directive.spec.ts
@@ -50,7 +50,7 @@ describe('CellTemplateDirective', () => {
 
   it('should create the directive and capture the template and columnName', () => {
     expect(component.cellTemplateDirective).toBeTruthy();
-    expect(component.cellTemplateDirective.columnName).toBe('testColumn');
+    expect(component.cellTemplateDirective.columnName()).toBe('testColumn');
     expect(component.cellTemplateDirective.template).toBeInstanceOf(TemplateRef);
   });
 });

--- a/src/app/shared/components/data-table/cell-template.directive.ts
+++ b/src/app/shared/components/data-table/cell-template.directive.ts
@@ -17,14 +17,20 @@
  * under the License.
  */
 
-import { Directive, Input, TemplateRef, inject } from '@angular/core';
+import { Directive, TemplateRef, inject, input } from '@angular/core';
 
 @Directive({
   selector: '[appCellTemplate]',
   standalone: true,
 })
 export class CellTemplateDirective {
-  @Input('appCellTemplate') columnName!: string;
+  /**
+   * Column this template renders, named by the directive's own selector.
+   *
+   * A signal input so that the map `DataTableComponent` builds from these stays correct if a
+   * template's column is itself bound to an expression.
+   */
+  readonly columnName = input.required<string>({ alias: 'appCellTemplate' });
 
   public readonly template = inject(TemplateRef<unknown>);
 }

--- a/src/app/shared/components/data-table/data-table.component.spec.ts
+++ b/src/app/shared/components/data-table/data-table.component.spec.ts
@@ -17,9 +17,11 @@
  * under the License.
  */
 
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { DataTableComponent, ColumnDef } from './data-table.component';
+import { CellTemplateDirective } from './cell-template.directive';
 import { PageEvent, SortEvent } from '../../models/table.model';
 import { provideIonicTesting } from '../../../testing/ionic-testing';
 
@@ -39,6 +41,8 @@ const ROWS: TestData[] = [
   { id: 1, name: 'Alice', status: { value: 'Active', code: 'active' } },
   { id: 2, name: 'Bob', status: { value: 'Inactive', code: 'inactive' } },
 ];
+
+const CUSTOM_CELL = '.custom-cell';
 
 describe('DataTableComponent', () => {
   let fixture: ComponentFixture<DataTableComponent<TestData>>;
@@ -239,7 +243,10 @@ describe('DataTableComponent', () => {
     });
 
     it('still lets a parent drive the page index through the input', () => {
+      // Parents mirror the index back from (pageChange) — see onPage() in clients-list and
+      // centers-list — so the bound value tracks the table while the user pages.
       component.onPage({ pageIndex: 3, pageSize: 10, length: 250 });
+      setInputs({ pageIndex: 3 });
       expect(component.effectivePageIndex).toBe(3);
 
       // What a parent does when a filter changes and it refetches from offset 0.
@@ -340,6 +347,45 @@ describe('DataTableComponent', () => {
 
       expect(errorPanel()).toBeNull();
       expect(renderedNames()).toEqual(['Alice', 'Bob']);
+    });
+  });
+  describe('projected cell templates', () => {
+    /**
+     * The template for `name` sits inside an `@if`, so it registers after the table's first
+     * content pass. Under `@ContentChildren` + `QueryList` this is the case that silently
+     * failed: `QueryList.changes` does not mark an OnPush view dirty, so the late template
+     * was never picked up and the column kept rendering its plain value.
+     */
+    @Component({
+      standalone: true,
+      imports: [DataTableComponent, CellTemplateDirective],
+      template: `
+        <app-data-table [columns]="columns" [data]="data" [localLogic]="true">
+          @if (showCustom()) {
+            <ng-template appCellTemplate="name" let-row>
+              <span class="custom-cell">custom:{{ row.name }}</span>
+            </ng-template>
+          }
+        </app-data-table>
+      `,
+    })
+    class HostComponent {
+      readonly columns = COLUMNS;
+      readonly data = ROWS;
+      readonly showCustom = signal(false);
+    }
+
+    it('picks up a template that registers after the first pass', () => {
+      const host = TestBed.createComponent(HostComponent);
+      host.detectChanges();
+
+      expect(host.nativeElement.querySelectorAll(CUSTOM_CELL)).toHaveSize(0);
+
+      host.componentInstance.showCustom.set(true);
+      host.detectChanges();
+
+      expect(host.nativeElement.querySelectorAll(CUSTOM_CELL)).toHaveSize(2);
+      expect(host.nativeElement.querySelector(CUSTOM_CELL).textContent.trim()).toBe('custom:Alice');
     });
   });
 });

--- a/src/app/shared/components/data-table/data-table.component.ts
+++ b/src/app/shared/components/data-table/data-table.component.ts
@@ -19,18 +19,13 @@
 
 import {
   Component,
-  Input,
-  signal,
-  Output,
-  EventEmitter,
-  ContentChildren,
-  QueryList,
-  AfterContentInit,
   TemplateRef,
-  OnChanges,
-  SimpleChanges,
+  computed,
+  contentChildren,
   input,
+  linkedSignal,
   output,
+  signal,
 } from '@angular/core';
 import { CdkTableModule } from '@angular/cdk/table';
 import { NgTemplateOutlet } from '@angular/common';
@@ -99,23 +94,23 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
   ],
   template: `
     <ion-card class="data-table-card">
-      @if (isLoading) {
+      @if (isLoading()) {
         <div class="loading-overlay">
           <ion-spinner name="crescent" data-testid="data-table-spinner"></ion-spinner>
         </div>
       }
       <ion-card-header>
         <ion-card-title>
-          {{ title | translate }}
-          @if (helpTextKey) {
-            <app-help-icon [helpTextKey]="helpTextKey"></app-help-icon>
+          {{ title() | translate }}
+          @if (helpTextKey()) {
+            <app-help-icon [helpTextKey]="helpTextKey()"></app-help-icon>
           }
         </ion-card-title>
         <div class="header-actions">
-          @if (createButtonLabel) {
+          @if (createButtonLabel()) {
             <ion-button data-testid="data-table-create" color="primary" (click)="onCreate()">
               <ion-icon name="add-outline" slot="start"></ion-icon>
-              {{ createButtonLabel | translate }}
+              {{ createButtonLabel() | translate }}
             </ion-button>
           }
           <ng-content select="[headerActions]"></ng-content>
@@ -124,11 +119,11 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
 
       <ion-card-content>
         <div class="table-header">
-          @if (showSearch) {
+          @if (showSearch()) {
             <div class="search-container">
               <app-search-filter
-                [label]="searchLabel | translate"
-                [placeholder]="searchPlaceholder | translate"
+                [label]="searchLabel() | translate"
+                [placeholder]="searchPlaceholder() | translate"
                 (searchChange)="onSearch($event)"
               >
               </app-search-filter>
@@ -158,7 +153,7 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
         } @else {
           <div class="table-container">
             <table cdk-table [dataSource]="rows()" class="data-table">
-              @for (col of columns; track col.key) {
+              @for (col of columns(); track col.key) {
                 <ng-container [cdkColumnDef]="col.key">
                   <th
                     cdk-header-cell
@@ -179,9 +174,9 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
                     }
                   </th>
                   <td cdk-cell *cdkCellDef="let row">
-                    @if (columnTemplates[col.key]) {
+                    @if (columnTemplates()[col.key]) {
                       <ng-container
-                        *ngTemplateOutlet="columnTemplates[col.key]; context: { $implicit: row }"
+                        *ngTemplateOutlet="columnTemplates()[col.key]; context: { $implicit: row }"
                       ></ng-container>
                     } @else {
                       <span class="truncate-text" [appTooltip]="getTooltipText(row, col.key)">
@@ -192,11 +187,11 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
                 </ng-container>
               }
 
-              <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
-              <tr cdk-row *cdkRowDef="let row; columns: displayedColumns"></tr>
+              <tr cdk-header-row *cdkHeaderRowDef="displayedColumns()"></tr>
+              <tr cdk-row *cdkRowDef="let row; columns: displayedColumns()"></tr>
 
               <tr class="no-data-row" *cdkNoDataRow>
-                <td [attr.colspan]="displayedColumns.length">
+                <td [attr.colspan]="displayedColumns().length">
                   {{ 'COMMON.NO_DATA' | translate }}
                 </td>
               </tr>
@@ -206,7 +201,7 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
               [length]="displayedTotal()"
               [pageSize]="effectivePageSize"
               [pageIndex]="effectivePageIndex"
-              [pageSizeOptions]="pageSizeOptions"
+              [pageSizeOptions]="pageSizeOptions()"
               (page)="onPage($event)"
             ></app-paginator>
           </div>
@@ -338,78 +333,79 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
     `,
   ],
 })
-export class DataTableComponent<T> implements AfterContentInit, OnChanges {
-  @Input() title = '';
-  @Input() helpTextKey = '';
-  @Input() createButtonLabel = '';
-  @Input() columns: ColumnDef[] = [];
-  @Input() data: T[] = [];
+export class DataTableComponent<T> {
+  readonly title = input('');
+  readonly helpTextKey = input('');
+  readonly createButtonLabel = input('');
+  readonly columns = input<ColumnDef[]>([]);
+  readonly data = input<T[]>([]);
   /** Total number of records. If server-side, this comes from API response. */
-  @Input() totalRecords = 0;
-  @Input() pageSize = 10;
-  @Input() pageIndex = 0;
-  @Input() pageSizeOptions = [5, 10, 25, 100];
-  @Input() showSearch = true;
-  @Input() searchLabel = 'COMMON.SEARCH';
-  @Input() searchPlaceholder = 'COMMON.SEARCH_PLACEHOLDER';
+  readonly totalRecords = input(0);
+  readonly pageSize = input(10);
+  readonly pageIndex = input(0);
+  readonly pageSizeOptions = input([5, 10, 25, 100]);
+  readonly showSearch = input(true);
+  readonly searchLabel = input('COMMON.SEARCH');
+  readonly searchPlaceholder = input('COMMON.SEARCH_PLACEHOLDER');
   /** If true, the component will handle pagination/sorting locally. */
-  @Input() localLogic = false;
-  @Input() isLoading = false;
+  readonly localLogic = input(false);
+  readonly isLoading = input(false);
   /**
    * Whether the last load failed.
    *
    * Set this instead of swallowing the failure into an empty array. A table that renders
    * "No records found" after a request errored tells the user the data does not exist, when
    * in fact nobody knows — and leaves them no way to ask again short of reloading the page.
-   *
-   * A signal input rather than a decorator: the surrounding `@Input()`s are on the Wave 3
-   * conversion list, and adding to that list is the wrong direction.
    */
   readonly hasError = input(false);
 
-  @Output() create = new EventEmitter<void>();
-  @Output() searchChange = new EventEmitter<string>();
-  @Output() sortChange = new EventEmitter<SortEvent>();
-  @Output() pageChange = new EventEmitter<PageEvent>();
+  readonly create = output<void>();
+  readonly searchChange = output<string>();
+  readonly sortChange = output<SortEvent>();
+  readonly pageChange = output<PageEvent>();
   /** Emitted when the user asks to load again after a failure. */
   readonly retry = output<void>();
 
-  @ContentChildren(CellTemplateDirective) cellTemplates!: QueryList<CellTemplateDirective>;
-
   /**
-   * Rows currently rendered — the visible page when `localLogic`, otherwise `data` verbatim.
+   * Per-column templates projected by the parent.
    *
-   * Signals rather than plain fields so the view refreshes whenever the derived state changes,
-   * independently of how change detection was triggered.
+   * A signal query rather than `@ContentChildren` + `QueryList`: `QueryList.changes` does not
+   * mark an OnPush view dirty, so a template registered after the first pass — one inside an
+   * `@if`, say — would never appear.
    */
-  readonly rows = signal<T[]>([]);
-  /** Record count reported to the paginator; local filtering shrinks it. */
-  readonly displayedTotal = signal(0);
+  readonly cellTemplates = contentChildren(CellTemplateDirective);
+
   readonly sort = signal<SortEvent>({ active: '', direction: '' });
 
-  columnTemplates: Record<string, TemplateRef<unknown>> = {};
+  protected readonly columnTemplates = computed<Record<string, TemplateRef<unknown>>>(() => {
+    const map: Record<string, TemplateRef<unknown>> = {};
+    for (const directive of this.cellTemplates()) {
+      map[directive.columnName()] = directive.template;
+    }
+    return map;
+  });
 
-  private filterText = '';
-  private readonly localPageIndex = signal(0);
-  private readonly localPageSize = signal(10);
-
-  get displayedColumns(): string[] {
-    return this.columns.map((c) => c.key);
-  }
+  private readonly filterText = signal('');
 
   /*
    * Page state is tracked here in both modes.
    *
-   * These used to read the raw @Input in server-side mode, which left the
-   * paginator pinned to whatever the parent last bound. Since most parents fetch
-   * by offset and never bind `pageIndex` back, it stayed 0 forever: the range
-   * label was always "1 - 10", "previous" was always disabled, and because
-   * `goTo()` computes from `pageIndex()`, "next" resolved to page 1 every time —
-   * so page 2 was reachable and nothing beyond it.
+   * Reading the raw input in server-side mode left the paginator pinned to whatever the parent
+   * last bound. Since most parents fetch by offset and never bind `pageIndex` back, it stayed 0
+   * forever: the range label was always "1 - 10", "previous" was always disabled, and because
+   * `goTo()` computes from `pageIndex()`, "next" resolved to page 1 every time — so page 2 was
+   * reachable and nothing beyond it.
    *
-   * ngOnChanges still syncs from the @Input, so a parent that does drive
-   * `pageIndex` (to reset to the first page when a filter changes) keeps control.
+   * `linkedSignal` keeps both halves of that: writable here, and reset whenever the parent
+   * binds a new value, so a parent that drives `pageIndex` (to return to the first page when a
+   * filter changes) keeps control. This is what the old `ngOnChanges` did by hand, and it has
+   * to be expressed this way now — `ngOnChanges` does not run for signal inputs.
    */
+  private readonly localPageIndex = linkedSignal(() => this.pageIndex());
+  private readonly localPageSize = linkedSignal(() => this.pageSize());
+
+  readonly displayedColumns = computed(() => this.columns().map((c) => c.key));
+
   get effectivePageIndex(): number {
     return this.localPageIndex();
   }
@@ -418,21 +414,44 @@ export class DataTableComponent<T> implements AfterContentInit, OnChanges {
     return this.localPageSize();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['pageSize']) {
-      this.localPageSize.set(this.pageSize);
+  /**
+   * The full result set behind the table: `data` verbatim server-side, filtered and sorted
+   * locally otherwise. Derived rather than recomputed on notification, so it cannot fall out
+   * of step with the inputs it is built from.
+   */
+  private readonly resolved = computed<T[]>(() => {
+    const data = this.data() ?? [];
+    if (!this.localLogic()) {
+      return data;
     }
-    if (changes['pageIndex']) {
-      this.localPageIndex.set(this.pageIndex);
-    }
-    this.recompute();
-  }
 
-  ngAfterContentInit(): void {
-    this.cellTemplates.forEach((directive) => {
-      this.columnTemplates[directive.columnName] = directive.template;
-    });
-  }
+    let result = [...data];
+
+    const filter = this.filterText();
+    if (filter) {
+      result = result.filter((row) => this.matchesFilter(row, filter));
+    }
+    const { active, direction } = this.sort();
+    if (active && direction) {
+      result = this.sortRows(result, active, direction);
+    }
+    return result;
+  });
+
+  /** Rows currently rendered — the visible page when `localLogic`, otherwise `data` verbatim. */
+  readonly rows = computed<T[]>(() => {
+    if (!this.localLogic()) {
+      return this.resolved();
+    }
+    const pageSize = this.localPageSize();
+    const start = this.localPageIndex() * pageSize;
+    return this.resolved().slice(start, start + pageSize);
+  });
+
+  /** Record count reported to the paginator; local filtering shrinks it. */
+  readonly displayedTotal = computed(() =>
+    this.localLogic() ? this.resolved().length : this.totalRecords(),
+  );
 
   onCreate(): void {
     this.create.emit();
@@ -447,9 +466,8 @@ export class DataTableComponent<T> implements AfterContentInit, OnChanges {
     // parents also refetch from offset 0 on a new search, so the paginator has to
     // agree in both modes or the label drifts from the rows on screen.
     this.localPageIndex.set(0);
-    if (this.localLogic) {
-      this.filterText = value.trim().toLowerCase();
-      this.recompute();
+    if (this.localLogic()) {
+      this.filterText.set(value.trim().toLowerCase());
     }
     this.searchChange.emit(value);
   }
@@ -465,18 +483,12 @@ export class DataTableComponent<T> implements AfterContentInit, OnChanges {
     // Re-sorting reorders the whole set, so the current page no longer means
     // anything; server-side parents reset to offset 0 for the same reason.
     this.localPageIndex.set(0);
-    if (this.localLogic) {
-      this.recompute();
-    }
     this.sortChange.emit(this.sort());
   }
 
   onPage(event: PageEvent): void {
     this.localPageIndex.set(event.pageIndex);
     this.localPageSize.set(event.pageSize);
-    if (this.localLogic) {
-      this.recompute();
-    }
     this.pageChange.emit(event);
   }
 
@@ -505,37 +517,12 @@ export class DataTableComponent<T> implements AfterContentInit, OnChanges {
     return String(val);
   }
 
-  /** Recomputes the rendered rows. Server-side mode passes `data` straight through. */
-  private recompute(): void {
-    if (!this.localLogic) {
-      this.rows.set(this.data ?? []);
-      this.displayedTotal.set(this.totalRecords);
-      return;
-    }
-
-    let result = [...(this.data ?? [])];
-
-    if (this.filterText) {
-      result = result.filter((row) => this.matchesFilter(row));
-    }
-    const { active, direction } = this.sort();
-    if (active && direction) {
-      result = this.sortRows(result, active, direction);
-    }
-
-    this.displayedTotal.set(result.length);
-
-    const pageSize = this.localPageSize();
-    const start = this.localPageIndex() * pageSize;
-    this.rows.set(result.slice(start, start + pageSize));
-  }
-
   /** Matches the row against the search text across every displayed column. */
-  private matchesFilter(row: T): boolean {
-    return this.columns.some((col) => {
+  private matchesFilter(row: T, filter: string): boolean {
+    return this.columns().some((col) => {
       const value = this.getCellValue(row, col.key);
       return value !== null && value !== undefined
-        ? String(value).toLowerCase().includes(this.filterText)
+        ? String(value).toLowerCase().includes(filter)
         : false;
     });
   }

--- a/src/app/shared/directives/has-institution-feature.directive.ts
+++ b/src/app/shared/directives/has-institution-feature.directive.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Directive, Input, TemplateRef, ViewContainerRef, inject, effect } from '@angular/core';
+import { Directive, TemplateRef, ViewContainerRef, effect, inject, input } from '@angular/core';
 import {
   InstitutionConfigService,
   InstitutionFeature,
@@ -45,25 +45,15 @@ export class HasInstitutionFeatureDirective {
   private readonly institutionConfig = inject(InstitutionConfigService);
   private readonly config = inject(ConfigService);
 
-  private feature: InstitutionFeature | null = null;
+  /** Feature the element requires. */
+  readonly appInstitutionFeature = input<InstitutionFeature | null>(null);
+
   private hasView = false;
 
   constructor() {
-    // React to institution type changes automatically.
-    effect(() => {
-      // Access signals to register dependencies. `rbacEnabled` is read here as well as in
-      // updateView() so that a deployment toggling it re-runs this directive rather than
-      // leaving whatever was rendered at construction.
-      this.institutionConfig.institutionType();
-      this.config.rbacEnabled();
-      this.updateView();
-    });
-  }
-
-  @Input()
-  set appInstitutionFeature(val: InstitutionFeature) {
-    this.feature = val;
-    this.updateView();
+    // One effect over every input the decision depends on, rather than an updateView() call per
+    // setter plus one for the configuration. The signal input is tracked like any other signal.
+    effect(() => this.updateView());
   }
 
   private updateView(): void {
@@ -73,7 +63,12 @@ export class HasInstitutionFeatureDirective {
       return;
     }
 
-    if (this.feature && this.institutionConfig.isFeatureEnabled(this.feature)) {
+    // Read outside the guard below so the effect re-runs when the deployment's type changes,
+    // not only when the feature being asked about changes.
+    this.institutionConfig.institutionType();
+
+    const feature = this.appInstitutionFeature();
+    if (feature && this.institutionConfig.isFeatureEnabled(feature)) {
       this.showTemplate();
     } else {
       this.hideTemplate();

--- a/src/app/shared/directives/has-permission.directive.ts
+++ b/src/app/shared/directives/has-permission.directive.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Directive, Input, TemplateRef, ViewContainerRef, inject, effect } from '@angular/core';
+import { Directive, TemplateRef, ViewContainerRef, effect, inject, input } from '@angular/core';
 import { AuthService } from '../../core/services/auth.service';
 import { ConfigService } from '../../core/services/config.service';
 
@@ -39,32 +39,20 @@ export class HasPermissionDirective {
   private readonly authService = inject(AuthService);
   private readonly config = inject(ConfigService);
 
-  private permissions: string | string[] = [];
-  private matchAllValue = false;
+  /** Permission, or permissions, the element requires. */
+  readonly appHasPermission = input<string | string[]>([]);
+  /** AND semantics for an array. Default is OR — any one of them is enough. */
+  readonly appHasPermissionMatchAll = input(false);
+
   private hasView = false;
 
   constructor() {
-    // React to authentication changes or signal changes automatically
-    effect(() => {
-      // Access signals to register dependencies. `rbacEnabled` is read here as well as in
-      // updateView() so that a deployment toggling it re-runs this directive rather than
-      // leaving whatever was rendered at construction.
-      this.authService.currentUser();
-      this.config.rbacEnabled();
-      this.updateView();
-    });
-  }
-
-  @Input()
-  set appHasPermission(val: string | string[]) {
-    this.permissions = val;
-    this.updateView();
-  }
-
-  @Input()
-  set appHasPermissionMatchAll(val: boolean) {
-    this.matchAllValue = val;
-    this.updateView();
+    // One effect over every input the decision depends on, rather than an updateView() call
+    // per setter plus one for the session. Signal inputs are tracked like any other signal, so
+    // the directive re-evaluates when the permissions change, when the user changes, and when a
+    // deployment toggles RBAC — the last of which previously needed reading the signal here
+    // purely to register the dependency.
+    effect(() => this.updateView());
   }
 
   private updateView(): void {
@@ -74,14 +62,17 @@ export class HasPermissionDirective {
       return;
     }
 
-    if (!this.permissions || this.permissions.length === 0) {
+    // Reading `currentUser` registers the dependency; `hasPermission` reads it internally,
+    // but not through a signal this effect would see.
+    this.authService.currentUser();
+
+    const permissions = this.appHasPermission();
+    if (!permissions || permissions.length === 0) {
       this.showTemplate();
       return;
     }
 
-    const isAuthorized = this.authService.hasPermission(this.permissions, this.matchAllValue);
-
-    if (isAuthorized) {
+    if (this.authService.hasPermission(permissions, this.appHasPermissionMatchAll())) {
       this.showTemplate();
     } else {
       this.hideTemplate();


### PR DESCRIPTION
Closes #182.

## Why

Angular 22 makes `OnPush` the default, so a plain field assigned from an HTTP callback never marks its view dirty. `app-data-table` and the two structural permission directives sit underneath most of the application — every list screen renders through the table, and the directives decide what is on screen at all — so while they were built on decorator inputs, every new screen inherited the same failure mode.

This is a prerequisite for the Group (#180) and Center (#181) detail views, which add several screens on top of these primitives.

## A live bug, not just old style

`QueryList.changes` does not mark an OnPush view dirty, and `columnTemplates` was populated once in `ngAfterContentInit`. A cell template registered later — one inside an `@if` — was therefore never picked up, and its column silently kept rendering the plain value instead of the projected template.

It is now a `contentChildren()` signal query feeding a computed map.

The new spec covers exactly that case. It was verified to fail without the fix: reverting the map to snapshot-once semantics turns it red, and restoring `contentChildren()` turns it green. A test that passes either way would not be evidence of anything.

## `ngOnChanges` had to go

It does not run for signal inputs, so removing it is part of the conversion rather than an optional tidy-up. It was doing two jobs:

- **Syncing local page state from the input** is now `linkedSignal`, which is exactly the semantics it hand-rolled: writable locally, reset when the parent binds a new value. A parent that drives `pageIndex` back to `0` on a filter change keeps control.
- **Recomputing rows** is now `computed`. `rows` and `displayedTotal` derive from the inputs rather than being imperatively refreshed on notification, so they cannot fall out of step with the data they are built from.

## One spec changed meaning — worth a reviewer's eye

`still lets a parent drive the page index` set `pageIndex` to `0` after the table had moved to `3`, and expected a reset.

That passed only because `componentRef.setInput` treats a first write as a change, so the old `ngOnChanges` fired on `0 -> 0`. A real parent binding a constant `0` never triggered it either — the assertion was pinning a harness artifact, not the contract.

Parents mirror the index back from `(pageChange)` (see `onPage` in `clients-list` and `centers-list`), so the test now binds `3` first and asserts the genuine `3 -> 0` transition.

## Also

`CellTemplateDirective.columnName` becomes a signal input, so the computed map is reactive in the value as well as in the set of templates.

## Verification

- `tsc` (app + spec) clean
- production build clean — this is the real check, since it type-checks all 92 consumer templates
- `npm run lint` clean; the suppressions baseline **shrinks by 23 entries**
- `format:check`, `check-license.sh`, `i18n:check` clean
- **687** unit tests pass (up from 686 — one added)
- **192/192** mocked Playwright tests pass
- `scripts/audit-async-state.mjs` unchanged at 429, as expected: this converts shared primitives, not feature fields

## Scope

Out of scope: the remaining 429 fields across feature components, and `provideZonelessChangeDetection()` / dropping `zone.js`, which follow once those are converted.