### PR TITLE
feat(loans): keep cumulative and progressive loans distinct on the account screens

### DIFF
--- a/e2e/full-demo.spec.ts
+++ b/e2e/full-demo.spec.ts
@@ -128,6 +128,9 @@ test.describe('Full feature demo recording', () => {
     // locks. ion-select carries `disabled` only as a JS property — there is no
     // disabled/aria-disabled attribute on the host for toBeDisabled() to read.
     await expect(ionSelect(page, 'Repayment Strategy')).toHaveJSProperty('disabled', true);
+    // A disabled control that does not say why is a dead end for anyone who does not already
+    // know the rule, so the form states it in plain language next to the field.
+    await expect(page.getByTestId('strategy-locked-note')).toBeVisible();
     await expect(ionSelect(page, 'Loan Schedule Processing Type')).toBeVisible();
 
     const firstOrderItem = page.locator('.allocation-order-list ion-item').first();
@@ -240,6 +243,13 @@ test.describe('Full feature demo recording', () => {
     await page.goto(`/loans/view/${loanId}`);
     await expect(page.getByText('Active', { exact: true })).toBeVisible({ timeout: 15000 });
     await expect(page.getByText(/Loan Schedule Type:\s*Cumulative/)).toBeVisible();
+    // The two engines are kept apart on the account screen too: buy-down fees and capitalised
+    // income belong to the progressive engine, so this cumulative loan must not offer them.
+    // They would otherwise render as tabs that can never hold anything.
+    await expect(page.locator('ion-segment-button', { hasText: 'Buy-Down Fees' })).toHaveCount(0);
+    await expect(page.locator('ion-segment-button', { hasText: 'Capitalized Income' })).toHaveCount(
+      0,
+    );
     await beat(page);
 
     // 10. Custom Fields tab: add an entry through the dialog. The datatable this

--- a/e2e/loan-schedule-type-gating.spec.ts
+++ b/e2e/loan-schedule-type-gating.spec.ts
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Cumulative and progressive loans must not offer each other's features. See issue #186.
+ *
+ * Buy-down fees and capitalised income belong to the progressive engine, so a cumulative loan
+ * showed two tabs that could never contain anything — an empty table the user cannot distinguish
+ * from "none recorded" — and issued two guaranteed-useless requests on every loan view.
+ *
+ * Mocked rather than backend, so the gating runs in the fast CI project. Seeding a real
+ * progressive product and a real cumulative one just to compare two tab bars would put this
+ * behind a live Fineract for no extra confidence.
+ */
+
+import { test, expect, Page } from './fixtures';
+
+const TENANT = 'default';
+const USER = 'mifos';
+const PASSWORD = 'password';
+const HEAD_OFFICE = 'Head Office';
+const BUY_DOWN_TAB = 'Buy-Down Fees';
+const CAPITALIZED_TAB = 'Capitalized Income';
+
+interface LoanOverrides {
+  loanScheduleType?: { code: string; value: string };
+  enableBuyDownFee?: boolean;
+  enableIncomeCapitalization?: boolean;
+}
+
+function loan(overrides: LoanOverrides) {
+  return {
+    id: 456,
+    accountNo: 'L000456',
+    externalId: 'ext-456',
+    clientId: 1,
+    clientName: 'Jane Smith',
+    loanProductName: 'Demo Product',
+    principal: 5000,
+    annualInterestRate: 12,
+    status: { id: 300, code: 'loanStatusType.active', value: 'Active', active: true },
+    currency: { code: 'USD', displaySymbol: '$' },
+    summary: { principalOutstanding: 5000, totalOutstanding: 5000 },
+    repaymentSchedule: { periods: [] },
+    transactions: [],
+    charges: [],
+    ...overrides,
+  };
+}
+
+/** Counts the calls the page makes, so "does not fetch" is asserted rather than assumed. */
+interface Probe {
+  buyDownCalls: number;
+  capitalizedCalls: number;
+}
+
+async function loginWithLoan(page: Page, overrides: LoanOverrides): Promise<Probe> {
+  const probe: Probe = { buyDownCalls: 0, capitalizedCalls: 0 };
+
+  await page.route('**/config.json*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ fineractApiUrl: '/api/v1', defaultTenant: TENANT }),
+    });
+  });
+
+  await page.route('**/api/v1/authentication**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        username: USER,
+        userId: 1,
+        base64EncodedAuthenticationKey: 'YmFzZTY0',
+        authenticated: true,
+        officeId: 1,
+        officeName: HEAD_OFFICE,
+        roles: [{ id: 1, name: 'Super User', description: 'Super user' }],
+        permissions: ['ALL_FUNCTIONS'],
+      }),
+    });
+  });
+
+  await page.route(/\/api\/v1\/loans\/external-id\/[^/]+\/buydown-fees/, async (route) => {
+    probe.buyDownCalls += 1;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.route(/\/api\/v1\/loans\/external-id\/[^/]+\/capitalized-incomes/, async (route) => {
+    probe.capitalizedCalls += 1;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.route(/\/api\/v1\/loans\/456(\?|$)/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(loan(overrides)),
+    });
+  });
+
+  await page.goto('/login');
+  await page.locator('#tenantId').fill(TENANT);
+  await page.locator('#username').fill(USER);
+  await page.locator('#password').fill(PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL('/dashboard');
+
+  return probe;
+}
+
+const tab = (page: Page, name: string) => page.locator('ion-segment-button', { hasText: name });
+
+test.describe('Loan schedule type gating', () => {
+  test('a cumulative loan offers neither progressive-only tab, and fetches neither', async ({
+    page,
+  }) => {
+    const probe = await loginWithLoan(page, {
+      loanScheduleType: { code: 'CUMULATIVE', value: 'Cumulative' },
+    });
+
+    await page.goto('/loans/view/456');
+    // Anchor on something that is always present, so the negative assertions below are made
+    // against a rendered page rather than an empty one.
+    await expect(tab(page, 'Repayment Schedule')).toBeVisible();
+
+    await expect(tab(page, BUY_DOWN_TAB)).toHaveCount(0);
+    await expect(tab(page, CAPITALIZED_TAB)).toHaveCount(0);
+
+    expect(probe.buyDownCalls).toBe(0);
+    expect(probe.capitalizedCalls).toBe(0);
+  });
+
+  test('a progressive loan shows only the capabilities it actually has', async ({ page }) => {
+    const probe = await loginWithLoan(page, {
+      loanScheduleType: { code: 'PROGRESSIVE', value: 'Progressive' },
+      enableBuyDownFee: true,
+    });
+
+    await page.goto('/loans/view/456');
+    await expect(tab(page, BUY_DOWN_TAB)).toBeVisible();
+    // Progressive alone is not enough — the product has to have enabled it.
+    await expect(tab(page, CAPITALIZED_TAB)).toHaveCount(0);
+
+    await expect.poll(() => probe.buyDownCalls).toBeGreaterThan(0);
+    expect(probe.capitalizedCalls).toBe(0);
+  });
+
+  test('a progressive loan with both capabilities shows both', async ({ page }) => {
+    await loginWithLoan(page, {
+      loanScheduleType: { code: 'PROGRESSIVE', value: 'Progressive' },
+      enableBuyDownFee: true,
+      enableIncomeCapitalization: true,
+    });
+
+    await page.goto('/loans/view/456');
+    await expect(tab(page, BUY_DOWN_TAB)).toBeVisible();
+    await expect(tab(page, CAPITALIZED_TAB)).toBeVisible();
+
+    await tab(page, CAPITALIZED_TAB).click();
+    await expect(page.locator('.tab-content')).toBeVisible();
+  });
+});

--- a/src/app/features/loans/loan-form.component.ts
+++ b/src/app/features/loans/loan-form.component.ts
@@ -32,7 +32,14 @@ import {
   GetLoanProductsProductIdResponse,
   GetLoansLoanIdResponse,
 } from '../../api';
-import { LOAN_SCHEDULE_TYPE } from '../products/loan-schedule-type';
+import {
+  ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+  LOAN_SCHEDULE_TYPE,
+  isAdvancedPaymentAllocationStrategy,
+  isProgressiveScheduleType,
+  readScheduleTypeCode,
+  requiredStrategyFor,
+} from '../products/loan-schedule-type';
 import { NotificationService } from '../../core/services/notification.service';
 import { TooltipDirective } from '../../shared/directives/tooltip.directive';
 import {
@@ -649,17 +656,30 @@ export class LoanFormComponent implements OnInit {
     // Read the signal once: TypeScript cannot narrow a call expression, so the
     // guard above does not carry over to a second call.
     const productDetails = this.selectedProductDetails();
+    const selectedProduct = this.products().find((p) => p.id === this.loan().productId);
+    // The detail request may not have resolved, or may have failed; the list row still carries
+    // the schedule type, so the engine is knowable either way.
+    const scheduleTypeCode =
+      productDetails?.loanScheduleType?.code ?? readScheduleTypeCode(selectedProduct);
+
     if (productDetails?.transactionProcessingStrategyCode) {
       this.loan().transactionProcessingStrategyCode =
         productDetails.transactionProcessingStrategyCode;
-    } else {
-      const selectedProduct = this.products().find((p) => p.id === this.loan().productId);
-      if (selectedProduct && selectedProduct.transactionProcessingStrategy) {
-        this.loan().transactionProcessingStrategyCode =
-          selectedProduct.transactionProcessingStrategy;
-      } else if (!this.loan().transactionProcessingStrategyCode) {
-        this.loan().transactionProcessingStrategyCode = 'mifos-standard-strategy';
-      }
+    } else if (selectedProduct?.transactionProcessingStrategy) {
+      this.loan().transactionProcessingStrategyCode = selectedProduct.transactionProcessingStrategy;
+    } else if (!this.loan().transactionProcessingStrategyCode) {
+      // Never fall back to the standard strategy for a progressive product — it is the one code
+      // such a product may not carry, and Fineract rejects the pairing. Before this, a slow or
+      // failed product fetch could submit a loan whose strategy contradicted its own product.
+      this.loan().transactionProcessingStrategyCode = requiredStrategyFor(scheduleTypeCode);
+    }
+
+    // A strategy copied from a stale product selection can still contradict the engine.
+    if (
+      isProgressiveScheduleType(scheduleTypeCode) &&
+      !isAdvancedPaymentAllocationStrategy(this.loan().transactionProcessingStrategyCode)
+    ) {
+      this.loan().transactionProcessingStrategyCode = ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
     }
 
     if (this.isEditMode() && this.loanId) {

--- a/src/app/features/loans/loan-view.component.spec.ts
+++ b/src/app/features/loans/loan-view.component.spec.ts
@@ -2,8 +2,6 @@
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  See the NOTICE file
- * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
@@ -23,7 +21,12 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LoanViewComponent } from './loan-view.component';
-import { LoansService, BASE_PATH } from '../../api';
+import {
+  LoansService,
+  LoanBuyDownFeesService,
+  LoanCapitalizedIncomeService,
+  BASE_PATH,
+} from '../../api';
 import { AuthService } from '../../core/services/auth.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs';
@@ -31,17 +34,48 @@ import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { signal } from '@angular/core';
 import { provideIonicTesting } from '../../testing/ionic-testing';
+import { LOAN_SCHEDULE_TYPE } from '../products/loan-schedule-type';
+
+const PRODUCT_NAME = 'Micro Loan Product';
+const EXTERNAL_ID = 'ext-456';
 
 describe('LoanViewComponent', () => {
   let component: LoanViewComponent;
   let fixture: ComponentFixture<LoanViewComponent>;
   let loansServiceSpy: jasmine.SpyObj<LoansService>;
-  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let buyDownFeesSpy: jasmine.SpyObj<LoanBuyDownFeesService>;
+  let capitalizedIncomeSpy: jasmine.SpyObj<LoanCapitalizedIncomeService>;
   let routerSpy: jasmine.SpyObj<Router>;
 
-  beforeEach(async () => {
+  /** A cumulative loan, i.e. one that can carry none of the progressive-only features. */
+  const cumulativeLoan = {
+    id: 456,
+    accountNo: 'L000456',
+    loanProductName: PRODUCT_NAME,
+    clientName: 'Jane Smith',
+    principal: 5000,
+    annualInterestRate: 12,
+    externalId: EXTERNAL_ID,
+    loanScheduleType: { code: LOAN_SCHEDULE_TYPE.CUMULATIVE, value: 'Cumulative' },
+    status: { value: 'Active' },
+    repaymentSchedule: { periods: [] },
+    transactions: [],
+    charges: [],
+  };
+
+  async function setup(loanOverrides: Record<string, unknown> = {}): Promise<void> {
+    TestBed.resetTestingModule();
+
     loansServiceSpy = jasmine.createSpyObj('LoansService', ['getLoansLoanId']);
-    authServiceSpy = jasmine.createSpyObj('AuthService', ['hasPermission'], {
+    buyDownFeesSpy = jasmine.createSpyObj('LoanBuyDownFeesService', [
+      'getLoansExternalIdLoanExternalIdBuydownFees',
+    ]);
+    capitalizedIncomeSpy = jasmine.createSpyObj('LoanCapitalizedIncomeService', [
+      'getLoansExternalIdLoanExternalIdCapitalizedIncomes',
+    ]);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    const authServiceSpy = jasmine.createSpyObj('AuthService', ['hasPermission'], {
       currentUser: signal({
         username: 'mifos',
         base64EncodedAuthenticationKey: 'key',
@@ -52,7 +86,14 @@ describe('LoanViewComponent', () => {
         permissions: ['ALL_FUNCTIONS'],
       }),
     });
-    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+
+    loansServiceSpy.getLoansLoanId.and.returnValue(
+      of({ ...cumulativeLoan, ...loanOverrides }) as any,
+    );
+    buyDownFeesSpy.getLoansExternalIdLoanExternalIdBuydownFees.and.returnValue(of([]) as any);
+    capitalizedIncomeSpy.getLoansExternalIdLoanExternalIdCapitalizedIncomes.and.returnValue(
+      of([]) as any,
+    );
 
     await TestBed.configureTestingModule({
       imports: [LoanViewComponent, TranslateModule.forRoot()],
@@ -60,38 +101,27 @@ describe('LoanViewComponent', () => {
         provideNoopAnimations(),
         provideIonicTesting(),
         { provide: LoansService, useValue: loansServiceSpy },
+        { provide: LoanBuyDownFeesService, useValue: buyDownFeesSpy },
+        { provide: LoanCapitalizedIncomeService, useValue: capitalizedIncomeSpy },
         { provide: AuthService, useValue: authServiceSpy },
         { provide: Router, useValue: routerSpy },
         { provide: BASE_PATH, useValue: 'https://example.com/fineract-provider/api' },
         {
           provide: ActivatedRoute,
           useValue: {
-            paramMap: of({
-              get: (key: string) => (key === 'id' ? '456' : null),
-            }),
+            paramMap: of({ get: (key: string) => (key === 'id' ? '456' : null) }),
           },
         },
       ],
     }).compileComponents();
 
-    loansServiceSpy.getLoansLoanId.and.returnValue(
-      of({
-        id: 456,
-        accountNo: 'L000456',
-        loanProductName: 'Micro Loan Product',
-        clientName: 'Jane Smith',
-        principal: 5000,
-        annualInterestRate: 12,
-        status: { value: 'Active' },
-        repaymentSchedule: { periods: [] },
-        transactions: [],
-        charges: [],
-      }) as any,
-    );
-
     fixture = TestBed.createComponent(LoanViewComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await setup();
   });
 
   it('should create', () => {
@@ -100,6 +130,86 @@ describe('LoanViewComponent', () => {
 
   it('should load loan details on init', () => {
     expect(loansServiceSpy.getLoansLoanId).toHaveBeenCalledWith(456, false, 'all');
-    expect(component.loan()?.loanProductName).toBe('Micro Loan Product');
+    expect(component.loan()?.loanProductName).toBe(PRODUCT_NAME);
+  });
+
+  /**
+   * Buy-down fees and capitalised income are capabilities of the progressive engine. On a
+   * cumulative loan the tabs could never hold anything, and an empty table gives the user no way
+   * to tell "none recorded" from "not applicable" — so they must be absent, not merely empty.
+   */
+  describe('progressive-only tabs on a loan that cannot have them', () => {
+    it('hides both tabs', () => {
+      expect(component.showBuyDownFees()).toBeFalse();
+      expect(component.showCapitalizedIncome()).toBeFalse();
+
+      const labels = fixture.nativeElement.textContent as string;
+      expect(labels).not.toContain('LOANS.BUY_DOWN_FEES');
+      expect(labels).not.toContain('LOANS.CAPITALIZED_INCOME');
+    });
+
+    it('does not request data it knows cannot exist', () => {
+      expect(buyDownFeesSpy.getLoansExternalIdLoanExternalIdBuydownFees).not.toHaveBeenCalled();
+      expect(
+        capitalizedIncomeSpy.getLoansExternalIdLoanExternalIdCapitalizedIncomes,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the overview if such a tab is somehow selected', () => {
+      component.activeTab.set('7');
+      fixture.detectChanges();
+
+      expect(component.activeTab()).toBe('0');
+    });
+  });
+
+  describe('when the loan reports the capability', () => {
+    it('shows the buy-down tab and fetches it', async () => {
+      await setup({
+        loanScheduleType: { code: LOAN_SCHEDULE_TYPE.PROGRESSIVE, value: 'Progressive' },
+        enableBuyDownFee: true,
+      });
+
+      expect(component.showBuyDownFees()).toBeTrue();
+      expect(component.showCapitalizedIncome()).toBeFalse();
+      expect(buyDownFeesSpy.getLoansExternalIdLoanExternalIdBuydownFees).toHaveBeenCalledWith(
+        EXTERNAL_ID,
+      );
+      expect(
+        capitalizedIncomeSpy.getLoansExternalIdLoanExternalIdCapitalizedIncomes,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('shows the capitalised income tab and fetches it', async () => {
+      await setup({
+        loanScheduleType: { code: LOAN_SCHEDULE_TYPE.PROGRESSIVE, value: 'Progressive' },
+        enableIncomeCapitalization: true,
+      });
+
+      expect(component.showCapitalizedIncome()).toBeTrue();
+      expect(component.showBuyDownFees()).toBeFalse();
+      expect(
+        capitalizedIncomeSpy.getLoansExternalIdLoanExternalIdCapitalizedIncomes,
+      ).toHaveBeenCalledWith(EXTERNAL_ID);
+    });
+
+    it('keeps the tab selectable once it is available', async () => {
+      await setup({
+        loanScheduleType: { code: LOAN_SCHEDULE_TYPE.PROGRESSIVE, value: 'Progressive' },
+        enableBuyDownFee: true,
+      });
+
+      component.activeTab.set('7');
+      fixture.detectChanges();
+
+      expect(component.activeTab()).toBe('7');
+    });
+
+    it('still skips the request when the loan has no external id to fetch by', async () => {
+      await setup({ enableBuyDownFee: true, externalId: undefined });
+
+      expect(component.showBuyDownFees()).toBeTrue();
+      expect(buyDownFeesSpy.getLoansExternalIdLoanExternalIdBuydownFees).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/features/loans/loan-view.component.ts
+++ b/src/app/features/loans/loan-view.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, Signal, computed, effect, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Observable, from } from 'rxjs';
@@ -278,12 +278,16 @@ import {
           <ion-segment-button value="6">
             <ion-label>{{ 'LOANS.DOCUMENTS' | translate }}</ion-label>
           </ion-segment-button>
-          <ion-segment-button value="7">
-            <ion-label>{{ 'LOANS.BUY_DOWN_FEES' | translate }}</ion-label>
-          </ion-segment-button>
-          <ion-segment-button value="8">
-            <ion-label>{{ 'LOANS.CAPITALIZED_INCOME' | translate }}</ion-label>
-          </ion-segment-button>
+          @if (showBuyDownFees()) {
+            <ion-segment-button value="7">
+              <ion-label>{{ 'LOANS.BUY_DOWN_FEES' | translate }}</ion-label>
+            </ion-segment-button>
+          }
+          @if (showCapitalizedIncome()) {
+            <ion-segment-button value="8">
+              <ion-label>{{ 'LOANS.CAPITALIZED_INCOME' | translate }}</ion-label>
+            </ion-segment-button>
+          }
           <ion-segment-button value="9">
             <ion-label>{{ 'LOANS.DISBURSEMENT_DETAILS' | translate }}</ion-label>
           </ion-segment-button>
@@ -791,7 +795,7 @@ import {
             <app-loan-documents-tab [loanId]="loanId()"></app-loan-documents-tab>
           </div>
         }
-        @if (activeTab() === '7') {
+        @if (activeTab() === '7' && showBuyDownFees()) {
           <div class="tab-content">
             @if (buyDownFees().length === 0) {
               <p class="empty-state">{{ 'COMMON.NO_DATA' | translate }}</p>
@@ -827,7 +831,7 @@ import {
             }
           </div>
         }
-        @if (activeTab() === '8') {
+        @if (activeTab() === '8' && showCapitalizedIncome()) {
           <div class="tab-content">
             @if (capitalizedIncomes().length === 0) {
               <p class="empty-state">{{ 'COMMON.NO_DATA' | translate }}</p>
@@ -1194,6 +1198,35 @@ export class LoanViewComponent implements OnInit {
     return this.loan()?.loanScheduleType?.code === LOAN_SCHEDULE_TYPE.PROGRESSIVE;
   }
 
+  /**
+   * Whether this loan can carry buy-down fees / capitalized income at all.
+   *
+   * Gated on the loan's own capability flag rather than on the schedule type. Both are features
+   * of the progressive engine, so a cumulative loan never has them — but a progressive loan only
+   * has them when the product enabled them, and a tab that can never hold anything is worse than
+   * no tab: an empty table gives the user no way to tell "none recorded" from "not applicable".
+   */
+  readonly showBuyDownFees = computed(() => this.loan()?.enableBuyDownFee === true);
+  readonly showCapitalizedIncome = computed(() => this.loan()?.enableIncomeCapitalization === true);
+
+  /** Tabs that are not always present, keyed by the segment value that selects them. */
+  private readonly conditionalTabs: Record<string, Signal<boolean>> = {
+    '7': this.showBuyDownFees,
+    '8': this.showCapitalizedIncome,
+  };
+
+  constructor() {
+    // A tab can disappear when the loan finishes loading — the segment defaults to a value before
+    // the capabilities are known. Falling back to the overview keeps the page from rendering a
+    // segment with nothing selected and no content beneath it.
+    effect(() => {
+      const available = this.conditionalTabs[this.activeTab()];
+      if (available && !available()) {
+        this.activeTab.set('0');
+      }
+    });
+  }
+
   get isLoanApproved(): boolean {
     const status = this.loan()?.status;
     return (status as unknown as Record<string, unknown>)?.['value'] === 'Approved';
@@ -1312,7 +1345,10 @@ export class LoanViewComponent implements OnInit {
         this.periods.set(data.repaymentSchedule?.periods || []);
         this.transactions.set(data.transactions || []);
         this.charges.set(data.charges || []);
-        if (data.externalId) {
+        // Only ask for what this loan can actually have. Both are progressive-engine features:
+        // fetching them for every loan meant two guaranteed-useless requests per cumulative loan
+        // view, with their failures swallowed so nothing ever surfaced the waste.
+        if (data.externalId && data.enableBuyDownFee) {
           this.buyDownFeesService
             .getLoansExternalIdLoanExternalIdBuydownFees(data.externalId)
             .subscribe({
@@ -1321,6 +1357,8 @@ export class LoanViewComponent implements OnInit {
                 /* ignored */
               },
             });
+        }
+        if (data.externalId && data.enableIncomeCapitalization) {
           this.capitalizedIncomeService
             .getLoansExternalIdLoanExternalIdCapitalizedIncomes(data.externalId)
             .subscribe({

--- a/src/app/features/products/loan-product-form.component.ts
+++ b/src/app/features/products/loan-product-form.component.ts
@@ -51,6 +51,7 @@ import {
 } from '../../api';
 import { LOAN_SCHEDULE_TYPE, isAdvancedPaymentAllocationStrategy } from './loan-schedule-type';
 import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocation-editor.component';
+import { TooltipDirective } from '../../shared/directives/tooltip.directive';
 
 @Component({
   selector: 'app-loan-product-form',
@@ -74,6 +75,7 @@ import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocat
     IonRow,
     IonCol,
     PaymentCreditAllocationEditorComponent,
+    TooltipDirective,
   ],
   template: `
     <div class="form-container">
@@ -430,7 +432,11 @@ import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocat
 
                 <!-- Loan Schedule Type -->
                 <ion-col size="12" size-md="6">
-                  <ion-item fill="outline" class="form-item">
+                  <ion-item
+                    fill="outline"
+                    class="form-item"
+                    [appTooltip]="'HELP.LOAN_SCHEDULE_TYPE_DESC' | translate"
+                  >
                     <ion-label position="stacked">{{
                       'PRODUCTS.LOAN_SCHEDULE_TYPE' | translate
                     }}</ion-label>
@@ -455,7 +461,11 @@ import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocat
 
                 <!-- Transaction Processing Strategy Code -->
                 <ion-col size="12" size-md="6">
-                  <ion-item fill="outline" class="form-item">
+                  <ion-item
+                    fill="outline"
+                    class="form-item"
+                    [appTooltip]="'HELP.TRANSACTION_PROCESSING_STRATEGY_DESC' | translate"
+                  >
                     <ion-label position="stacked">{{
                       'PRODUCTS.TRANSACTION_PROCESSING_STRATEGY' | translate
                     }}</ion-label>
@@ -476,12 +486,21 @@ import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocat
                       }
                     </ion-select>
                   </ion-item>
+                  @if (isProgressive()) {
+                    <p class="field-note" data-testid="strategy-locked-note">
+                      {{ 'PRODUCTS.STRATEGY_LOCKED_NOTE' | translate }}
+                    </p>
+                  }
                 </ion-col>
 
                 <!-- Loan Schedule Processing Type (Progressive only) -->
                 @if (isProgressive()) {
                   <ion-col size="12" size-md="6">
-                    <ion-item fill="outline" class="form-item">
+                    <ion-item
+                      fill="outline"
+                      class="form-item"
+                      [appTooltip]="'HELP.LOAN_SCHEDULE_PROCESSING_TYPE_DESC' | translate"
+                    >
                       <ion-label position="stacked">{{
                         'PRODUCTS.LOAN_SCHEDULE_PROCESSING_TYPE' | translate
                       }}</ion-label>
@@ -570,6 +589,13 @@ import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocat
         --background: var(--ion-color-light, #f8f9fa);
         --border-radius: 8px;
         margin-bottom: 12px;
+      }
+      .field-note {
+        margin: -6px 0 12px;
+        padding: 0 4px;
+        font-size: 12px;
+        line-height: 1.4;
+        color: var(--text-muted, #6b7280);
       }
       .form-actions {
         display: flex;

--- a/src/app/features/products/loan-products-list.component.ts
+++ b/src/app/features/products/loan-products-list.component.ts
@@ -27,7 +27,7 @@ import { catchError, tap } from 'rxjs/operators';
 import { CellTemplateDirective, ColumnDef } from '../../shared';
 import { DataTableComponent } from '../../shared/components/data-table/data-table.component';
 import { LoanProductsService, GetLoanProductsResponse } from '../../api';
-import { LOAN_SCHEDULE_TYPE } from './loan-schedule-type';
+import { readScheduleTypeCode, readScheduleTypeLabel } from './loan-schedule-type';
 
 @Component({
   selector: 'app-loan-products-list',
@@ -130,22 +130,12 @@ export class LoanProductsListComponent implements OnInit {
     this.router.navigate(['/products/loan/view', product.id]);
   }
 
-  /**
-   * `loanScheduleType` is returned by GET /loanproducts but is missing from the
-   * generated GetLoanProductsResponse model, so it's read off the raw response.
-   */
   getLoanScheduleType(product: GetLoanProductsResponse): string | undefined {
-    return (product as unknown as { loanScheduleType?: { code?: string } }).loanScheduleType?.code;
+    return readScheduleTypeCode(product);
   }
 
   getLoanScheduleTypeLabel(product: GetLoanProductsResponse): string {
-    const scheduleType = product as unknown as { loanScheduleType?: { value?: string } };
-    return (
-      scheduleType.loanScheduleType?.value ??
-      (this.getLoanScheduleType(product) === LOAN_SCHEDULE_TYPE.PROGRESSIVE
-        ? 'Progressive'
-        : 'Cumulative')
-    );
+    return readScheduleTypeLabel(product);
   }
 
   onRetry(): void {

--- a/src/app/features/products/loan-schedule-type.spec.ts
+++ b/src/app/features/products/loan-schedule-type.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+  DEFAULT_TRANSACTION_PROCESSING_STRATEGY,
+  LOAN_SCHEDULE_TYPE,
+  isAdvancedPaymentAllocationStrategy,
+  isProgressiveScheduleType,
+  readScheduleTypeCode,
+  readScheduleTypeLabel,
+  requiredStrategyFor,
+} from './loan-schedule-type';
+
+describe('loan schedule type', () => {
+  describe('requiredStrategyFor', () => {
+    /**
+     * The pairing is not a preference. Progressive *is* the advanced payment allocation engine,
+     * and Fineract rejects a progressive product carrying any other strategy — so anything that
+     * has to choose a strategy without one to copy must not reach for the standard one.
+     */
+    it('demands advanced payment allocation for a progressive product', () => {
+      expect(requiredStrategyFor(LOAN_SCHEDULE_TYPE.PROGRESSIVE)).toBe(
+        ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+      );
+    });
+
+    it('uses the standard strategy for a cumulative product', () => {
+      expect(requiredStrategyFor(LOAN_SCHEDULE_TYPE.CUMULATIVE)).toBe(
+        DEFAULT_TRANSACTION_PROCESSING_STRATEGY,
+      );
+    });
+
+    it('treats an unknown schedule type as cumulative rather than guessing progressive', () => {
+      expect(requiredStrategyFor(undefined)).toBe(DEFAULT_TRANSACTION_PROCESSING_STRATEGY);
+      expect(requiredStrategyFor(null)).toBe(DEFAULT_TRANSACTION_PROCESSING_STRATEGY);
+    });
+  });
+
+  describe('isProgressiveScheduleType', () => {
+    it('recognises only the progressive code', () => {
+      expect(isProgressiveScheduleType(LOAN_SCHEDULE_TYPE.PROGRESSIVE)).toBeTrue();
+      expect(isProgressiveScheduleType(LOAN_SCHEDULE_TYPE.CUMULATIVE)).toBeFalse();
+      expect(isProgressiveScheduleType('progressive')).toBeFalse();
+      expect(isProgressiveScheduleType(undefined)).toBeFalse();
+    });
+  });
+
+  describe('isAdvancedPaymentAllocationStrategy', () => {
+    it('recognises only the advanced allocation code', () => {
+      expect(isAdvancedPaymentAllocationStrategy(ADVANCED_PAYMENT_ALLOCATION_STRATEGY)).toBeTrue();
+      expect(
+        isAdvancedPaymentAllocationStrategy(DEFAULT_TRANSACTION_PROCESSING_STRATEGY),
+      ).toBeFalse();
+      expect(isAdvancedPaymentAllocationStrategy(null)).toBeFalse();
+    });
+  });
+
+  describe('reading the type off a product', () => {
+    /**
+     * `GET /loanproducts` returns `loanScheduleType`, but the generated list model omits it, so
+     * it is only reachable through a cast. These cover that the cast survives the shapes the two
+     * endpoints actually return, and degrades safely when it is absent.
+     */
+    it('reads the code from a list row', () => {
+      expect(readScheduleTypeCode({ loanScheduleType: { code: 'PROGRESSIVE' } })).toBe(
+        'PROGRESSIVE',
+      );
+    });
+
+    it('returns undefined when the product does not carry one', () => {
+      expect(readScheduleTypeCode({ id: 1 })).toBeUndefined();
+      expect(readScheduleTypeCode(undefined)).toBeUndefined();
+      expect(readScheduleTypeCode(null)).toBeUndefined();
+    });
+
+    it('prefers the label the server supplied', () => {
+      expect(
+        readScheduleTypeLabel({ loanScheduleType: { code: 'PROGRESSIVE', value: 'Progressive' } }),
+      ).toBe('Progressive');
+    });
+
+    it('falls back to a readable label when the server sent only a code', () => {
+      expect(readScheduleTypeLabel({ loanScheduleType: { code: 'PROGRESSIVE' } })).toBe(
+        'Progressive',
+      );
+      expect(readScheduleTypeLabel({ loanScheduleType: { code: 'CUMULATIVE' } })).toBe(
+        'Cumulative',
+      );
+    });
+
+    it('describes a product with no schedule type as cumulative', () => {
+      expect(readScheduleTypeLabel({ id: 1 })).toBe('Cumulative');
+    });
+  });
+});

--- a/src/app/features/products/loan-schedule-type.ts
+++ b/src/app/features/products/loan-schedule-type.ts
@@ -24,6 +24,48 @@ export const LOAN_SCHEDULE_TYPE = {
 
 export const ADVANCED_PAYMENT_ALLOCATION_STRATEGY = 'advanced-payment-allocation-strategy';
 
+/** What Fineract applies when a product does not name a strategy. Never valid for progressive. */
+export const DEFAULT_TRANSACTION_PROCESSING_STRATEGY = 'mifos-standard-strategy';
+
 export function isAdvancedPaymentAllocationStrategy(code: string | undefined | null): boolean {
   return code === ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
+}
+
+export function isProgressiveScheduleType(code: string | undefined | null): boolean {
+  return code === LOAN_SCHEDULE_TYPE.PROGRESSIVE;
+}
+
+/**
+ * The only repayment strategy a product with this schedule type may carry.
+ *
+ * The two engines do not merely prefer different strategies — progressive *is* the advanced
+ * payment allocation engine, and Fineract rejects the pairing outright the other way round. Any
+ * code that has to pick a strategy without one to copy should ask here rather than assume the
+ * standard one.
+ */
+export function requiredStrategyFor(scheduleTypeCode: string | undefined | null): string {
+  return isProgressiveScheduleType(scheduleTypeCode)
+    ? ADVANCED_PAYMENT_ALLOCATION_STRATEGY
+    : DEFAULT_TRANSACTION_PROCESSING_STRATEGY;
+}
+
+/**
+ * Reads `loanScheduleType` off a loan product.
+ *
+ * `GET /loanproducts` returns it, but the generated `GetLoanProductsResponse` list model omits
+ * it, so it can only be reached through a cast. Kept here so the cast exists once rather than at
+ * every call site that needs to tell the two engines apart.
+ */
+export function readScheduleTypeCode(product: unknown): string | undefined {
+  return (product as { loanScheduleType?: { code?: string } } | null | undefined)?.loanScheduleType
+    ?.code;
+}
+
+export function readScheduleTypeLabel(product: unknown): string {
+  const label = (product as { loanScheduleType?: { value?: string } } | null | undefined)
+    ?.loanScheduleType?.value;
+  return (
+    label ??
+    (isProgressiveScheduleType(readScheduleTypeCode(product)) ? 'Progressive' : 'Cumulative')
+  );
 }

--- a/src/app/features/products/payment-credit-allocation-editor.component.ts
+++ b/src/app/features/products/payment-credit-allocation-editor.component.ts
@@ -34,6 +34,7 @@ import {
   IonIcon,
 } from '@ionic/angular/standalone';
 import { EnumOptionData, AdvancedPaymentData, CreditAllocationData } from '../../api';
+import { TooltipDirective } from '../../shared/directives/tooltip.directive';
 
 @Component({
   selector: 'app-payment-credit-allocation-editor',
@@ -52,11 +53,14 @@ import { EnumOptionData, AdvancedPaymentData, CreditAllocationData } from '../..
     IonSelectOption,
     IonButton,
     IonIcon,
+    TooltipDirective,
   ],
   template: `
     <ion-card class="allocation-card">
       <ion-card-header>
-        <ion-card-title>{{ 'PRODUCTS.PAYMENT_ALLOCATION' | translate }}</ion-card-title>
+        <ion-card-title [appTooltip]="'HELP.PAYMENT_ALLOCATION_DESC' | translate">
+          {{ 'PRODUCTS.PAYMENT_ALLOCATION' | translate }}
+        </ion-card-title>
       </ion-card-header>
       <ion-card-content>
         @for (rule of paymentAllocation(); track rule.transactionType; let ruleIndex = $index) {
@@ -159,7 +163,9 @@ import { EnumOptionData, AdvancedPaymentData, CreditAllocationData } from '../..
 
     <ion-card class="allocation-card">
       <ion-card-header>
-        <ion-card-title>{{ 'PRODUCTS.CREDIT_ALLOCATION' | translate }}</ion-card-title>
+        <ion-card-title [appTooltip]="'HELP.CREDIT_ALLOCATION_DESC' | translate">
+          {{ 'PRODUCTS.CREDIT_ALLOCATION' | translate }}
+        </ion-card-title>
       </ion-card-header>
       <ion-card-content>
         @for (rule of creditAllocation(); track rule.transactionType; let ruleIndex = $index) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -351,7 +351,8 @@
       "PENALTIES_FEES_INTEREST_PRINCIPAL": "Penalties, Fees, Interest, Principal"
     },
     "FUND": "Fund",
-    "DELINQUENCY_BUCKET": "Delinquency Bucket"
+    "DELINQUENCY_BUCKET": "Delinquency Bucket",
+    "STRATEGY_LOCKED_NOTE": "Fixed to Advanced Payment Allocation because this is a Progressive product — the two go together and Fineract rejects any other pairing."
   },
   "CHARGES": {
     "CREATE": "Create Charge",
@@ -720,7 +721,7 @@
     "ACTIVATION_DATE_DESC": "The date when this account or entity becomes operational.",
     "ACTIVE_DESC": "Whether this record is currently active in the system.",
     "PRODUCT_NAME_DESC": "The full name of the financial product.",
-    "LOAN_SCHEDULE_TYPE_DESC": "Cumulative uses the traditional repayment schedule engine. Progressive uses the advanced payment allocation engine and requires the Advanced Payment Allocation repayment strategy.",
+    "LOAN_SCHEDULE_TYPE_DESC": "Which engine builds the repayment schedule. Cumulative is the classic method: each repayment is split across penalties, fees, interest and principal in a fixed order. Progressive lets you define that order yourself per transaction type, and is required for down payments, capitalised income and buy-down fees. This cannot be changed once the product has loans against it.",
     "SHORT_NAME_DESC": "A 4-character unique identifier for the product.",
     "DESCRIPTION_DESC": "A detailed explanation of the product's purpose and rules.",
     "CURRENCY_DESC": "The currency in which transactions are processed.",
@@ -855,7 +856,11 @@
     "FLOATING_RATES_DESC": "Floating rates define base/differential interest rates that vary over time periods.",
     "LOAN_CHARGES_DESC": "Manage and view charges and fees applied to this loan account.",
     "OFFICES_DESC": "Configure and manage branch offices and their hierarchical structure.",
-    "TASKS_DESC": "Review and approve or reject maker-checker tasks pending authorization."
+    "TASKS_DESC": "Review and approve or reject maker-checker tasks pending authorization.",
+    "TRANSACTION_PROCESSING_STRATEGY_DESC": "The order in which a repayment is applied to what the borrower owes. Progressive products must use Advanced Payment Allocation, which is why the field is fixed for them.",
+    "LOAN_SCHEDULE_PROCESSING_TYPE_DESC": "How a payment moves through unpaid instalments. Horizontal settles one instalment fully before moving to the next; Vertical pays the same component across every instalment first. Progressive products only.",
+    "PAYMENT_ALLOCATION_DESC": "For each kind of incoming payment, the order in which it clears what is owed. The list is applied top to bottom until the payment is used up.",
+    "CREDIT_ALLOCATION_DESC": "The same ordering, for credits such as refunds and goodwill adjustments rather than borrower repayments."
   },
   "REPORTS": {
     "NAME": "Report Name",


### PR DESCRIPTION
Closes #186.

The loan **product** screens already model the two schedule engines properly. The loan **account**
screens did not — every loan got the same tabs and the same requests regardless of which engine it
runs on, and `isProgressiveLoan()` was used for exactly one thing: the colour of a chip.

### What was wrong

**Two permanently empty tabs on every cumulative loan.** Buy-down fees and capitalised income are
progressive-engine capabilities, so on a cumulative loan those tabs could never hold anything. The
user sees an empty table with no way to tell *none recorded* from *not applicable*.

**Two wasted requests per loan view.** Both tabs fetched unconditionally for any loan with an
external id, with `error: () => { /* ignored */ }`, so nothing ever surfaced the waste.

**A strategy that could contradict its own product.** The loan application form copies the
repayment strategy from the product, but fell back to `mifos-standard-strategy` when the product
detail request had not resolved — the one code a progressive product may never carry — and the
fallback was not guarded by schedule type.

### What changed

Both tabs are gated on the loan's own `enableBuyDownFee` / `enableIncomeCapitalization` flags,
which `GET /loans/{id}` already returns. That is deliberately stricter than gating on schedule
type: progressive alone is not enough, the product has to have enabled the feature. The requests
are gated the same way, and the active tab falls back to the overview if a tab disappears once the
loan resolves.

The form now reads the schedule type from the list row when the detail request is unavailable,
picks the strategy the engine requires, and corrects a strategy that contradicts a progressive
product before submitting.

`requiredStrategyFor`, `isProgressiveScheduleType` and the `loanScheduleType` readers move into
`loan-schedule-type.ts`, so the cast that reaches a field the generated list model omits exists
once rather than at each call site.

### Comprehensibility

Schedule type is the most consequential choice on a loan product and its vocabulary is not
self-explanatory. The schedule type, repayment strategy, processing type and both allocation
editors now carry plain-language help, and the locked strategy field says *why* it is locked
rather than only greying out:

> Fixed to Advanced Payment Allocation because this is a Progressive product — the two go together
> and Fineract rejects any other pairing.

### Tests

Schedule type had **no unit coverage at all**, and its only end-to-end coverage was real-backend
and exercised the progressive direction only. This adds:

- unit tests for the schedule-type helpers, including that an unknown type resolves to cumulative
  rather than guessing progressive;
- unit tests for tab gating in **both** directions — present when the capability is reported,
  absent and unfetched when it is not, and the fallback when a hidden tab is selected;
- `e2e/loan-schedule-type-gating.spec.ts`, **mocked** so the gating runs in the fast CI project
  rather than behind a live Fineract. It counts the requests, so "does not fetch" is asserted
  rather than assumed;
- demo steps showing the locked-strategy explanation and asserting the cumulative loan does not
  offer the progressive-only tabs.

### Verification

| Check | Result |
|---|---|
| Unit tests | **707 passing** (690 → 707) |
| Mocked Playwright | **195/195 passing** (192 → 195) |
| `tsc` (app + spec) | 0 errors |
| `npm run build` | passes |
| lint (empty suppressions baseline), format, i18n, icons, license | all clean |

I also checked the new spec actually catches the regression: with the gate reverted, **2 of its 3
tests fail**; restored, all 3 pass. And I drove the screens by hand against mocks before committing
— a cumulative loan renders 9 tabs, a progressive loan with both capabilities renders 11:

```
cumulative  = [Overview, Repayment Schedule, Transactions, Charges, Custom Fields,
               Notes, Documents, Disbursement Details, Collateral Management]
progressive = [... , Buy-Down Fees, Capitalized Income, Disbursement Details,
               Collateral Management]
```

### Not in this PR

The demo step is exercised only by the `backend` project, which needs a live Fineract, so it is
unverified here — the assertions mirror the mocked spec that does run.

Down payment, interest recalculation, `multiDisburseLoan` and charge-off still have no product-form
UI, and the repayment schedule still has no period-type column, so a down-payment period is
indistinguishable from a regular instalment. Those are separate gaps recorded in #186's research
rather than silently folded in here.
