### PR TITLE
feat(products): configure down payments and multi-tranche disbursement

### DIFF
--- a/e2e/full-demo.spec.ts
+++ b/e2e/full-demo.spec.ts
@@ -139,6 +139,18 @@ test.describe('Full feature demo recording', () => {
     await expect(firstOrderItem).not.toHaveText(orderBefore ?? '');
     await beat(page);
 
+    // Down payment and tranche disbursement. Down payment is a progressive-engine capability, so
+    // the control appears only now that the schedule type is Progressive; on a Cumulative product
+    // the form says so in its place rather than silently omitting the setting.
+    await page.getByTestId('loan-product-enable-down-payment').click();
+    await page.getByTestId('loan-product-down-payment-percentage').locator('input').fill('20');
+    await expect(page.getByTestId('loan-product-auto-repayment-down-payment')).toBeVisible();
+    await beat(page);
+
+    await page.getByTestId('loan-product-multi-disburse').click();
+    await page.getByTestId('loan-product-max-tranche-count').locator('input').fill('3');
+    await beat(page);
+
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(page).toHaveURL(/\/products\/loan$/, { timeout: 15000 });
 
@@ -161,6 +173,12 @@ test.describe('Full feature demo recording', () => {
     // 5. Create a Cumulative loan product for the lifecycle walkthrough
     await page.goto('/products/loan/create');
     await waitForProductTemplate(page);
+
+    // The same section on a Cumulative product: the down payment control is replaced by an
+    // explanation of where the setting lives, rather than simply not being there.
+    await expect(page.getByTestId('down-payment-unavailable-note')).toBeVisible();
+    await expect(page.getByTestId('loan-product-enable-down-payment')).toHaveCount(0);
+    await beat(page);
 
     const cumSuffix = uniqueSuffix();
     const cumulativeProductName = `Demo Cumulative ${cumSuffix}`;

--- a/e2e/loan-product-down-payment.spec.ts
+++ b/e2e/loan-product-down-payment.spec.ts
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Down payment and multi-tranche disbursement on the loan product form. See issue #188.
+ *
+ * Neither could be configured here before, so a product created in this application could never
+ * use either, and `allowFullTermForTranche` on the loan application form was unreachable.
+ *
+ * The payload assertions are the point: hiding a control is not the same as not sending its
+ * value, and a down payment left in the request would describe a product the cumulative engine
+ * cannot honour. Mocked, so this runs in the fast CI project.
+ */
+
+import { test, expect, Page } from './fixtures';
+import { selectOption } from './utils/select-option';
+
+const TENANT = 'default';
+const USER = 'mifos';
+const PASSWORD = 'password';
+const SCHEDULE_TYPE_LABEL = 'Loan Schedule Type';
+const DOWN_PAYMENT_TESTID = 'loan-product-enable-down-payment';
+const TRANCHE_COUNT_TESTID = 'loan-product-max-tranche-count';
+
+/** The POST body the form submits, captured in Node so a navigation cannot discard it. */
+interface Captured {
+  body: Record<string, unknown> | null;
+}
+
+async function login(page: Page): Promise<Captured> {
+  const captured: Captured = { body: null };
+
+  await page.route('**/config.json*', (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ fineractApiUrl: '/api/v1', defaultTenant: TENANT }),
+    }),
+  );
+
+  await page.route('**/api/v1/authentication**', (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        username: USER,
+        userId: 1,
+        base64EncodedAuthenticationKey: 'YmFzZTY0',
+        authenticated: true,
+        officeId: 1,
+        officeName: 'Head Office',
+        roles: [{ id: 1, name: 'Super User', description: 'Super user' }],
+        permissions: ['ALL_FUNCTIONS'],
+      }),
+    }),
+  );
+
+  await page.route(/\/api\/v1\/loanproducts\/template/, (r) =>
+    r.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        currencyOptions: [{ code: 'USD', name: 'US Dollar', decimalPlaces: 2 }],
+        amortizationTypeOptions: [{ id: 1, code: 'a', value: 'Equal installments' }],
+        interestTypeOptions: [{ id: 0, code: 'i', value: 'Declining Balance' }],
+        interestCalculationPeriodTypeOptions: [{ id: 1, code: 'c', value: 'Same as repayment' }],
+        repaymentFrequencyTypeOptions: [{ id: 2, code: 'm', value: 'Months' }],
+        interestRateFrequencyTypeOptions: [{ id: 3, code: 'y', value: 'Per year' }],
+        accountingRuleOptions: [{ id: 1, code: 'none', value: 'None' }],
+        loanScheduleTypeOptions: [
+          { id: 1, code: 'CUMULATIVE', value: 'Cumulative' },
+          { id: 2, code: 'PROGRESSIVE', value: 'Progressive' },
+        ],
+        loanScheduleProcessingTypeOptions: [{ id: 1, code: 'HORIZONTAL', value: 'Horizontal' }],
+        transactionProcessingStrategyOptions: [
+          { id: 1, code: 'mifos-standard-strategy', name: 'Penalties, Fees, Interest, Principal' },
+          {
+            id: 2,
+            code: 'advanced-payment-allocation-strategy',
+            name: 'Advanced payment allocation strategy',
+          },
+        ],
+        advancedPaymentAllocationTypes: [{ id: 1, code: 'PAST_DUE_PENALTY', value: 'Past due' }],
+        advancedPaymentAllocationTransactionTypes: [{ id: 1, code: 'DEFAULT', value: 'Default' }],
+        advancedPaymentAllocationFutureInstallmentAllocationRules: [
+          { id: 1, code: 'NEXT_INSTALLMENT', value: 'Next installment' },
+        ],
+        creditAllocationAllocationTypes: [],
+        creditAllocationTransactionTypes: [],
+        chargeOptions: [],
+      }),
+    }),
+  );
+
+  await page.route(/\/api\/v1\/loanproducts(\?|$)/, async (route) => {
+    if (route.request().method() === 'POST') {
+      captured.body = JSON.parse(route.request().postData() ?? '{}');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ resourceId: 99 }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.goto('/login');
+  await page.locator('#tenantId').fill(TENANT);
+  await page.locator('#username').fill(USER);
+  await page.locator('#password').fill(PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL('/dashboard');
+
+  return captured;
+}
+
+async function fillRequiredFields(page: Page, name: string): Promise<void> {
+  await page.getByRole('textbox', { name: 'Name', exact: true }).fill(name);
+  await page.getByRole('textbox', { name: 'Short Name' }).fill('DP01');
+  await page.getByRole('spinbutton', { name: 'Principal' }).fill('1000');
+  await page.getByRole('spinbutton', { name: 'Interest Rate' }).fill('10');
+  await page.getByRole('spinbutton', { name: 'Number of Repayments' }).fill('6');
+  await page.getByRole('spinbutton', { name: 'Repayment Every' }).fill('1');
+}
+
+test.describe('Loan product down payment and tranches', () => {
+  test('down payment is offered only for a progressive product', async ({ page }) => {
+    await login(page);
+    await page.goto('/products/loan/create');
+    await expect(page.getByTestId('loan-product-schedule-type')).toBeVisible();
+
+    // Cumulative: not merely hidden — the form says where the setting lives.
+    await expect(page.getByTestId(DOWN_PAYMENT_TESTID)).toHaveCount(0);
+    await expect(page.getByTestId('down-payment-unavailable-note')).toBeVisible();
+
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+    await expect(page.getByTestId(DOWN_PAYMENT_TESTID)).toBeVisible();
+    await expect(page.getByTestId('down-payment-unavailable-note')).toHaveCount(0);
+  });
+
+  test('the percentage and auto-repayment appear only once down payment is on', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto('/products/loan/create');
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+
+    await expect(page.getByTestId('loan-product-down-payment-percentage')).toHaveCount(0);
+
+    await page.getByTestId(DOWN_PAYMENT_TESTID).click();
+
+    await expect(page.getByTestId('loan-product-down-payment-percentage')).toBeVisible();
+    await expect(page.getByTestId('loan-product-auto-repayment-down-payment')).toBeVisible();
+  });
+
+  test('multi-tranche disbursement reveals its tranche count, on either engine', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto('/products/loan/create');
+
+    await expect(page.getByTestId(TRANCHE_COUNT_TESTID)).toHaveCount(0);
+    await page.getByTestId('loan-product-multi-disburse').click();
+    await expect(page.getByTestId(TRANCHE_COUNT_TESTID)).toBeVisible();
+    await expect(page.getByTestId('loan-product-disallow-expected-disbursements')).toBeVisible();
+  });
+
+  test('submits the down payment and tranche settings it was given', async ({ page }) => {
+    const captured = await login(page);
+    await page.goto('/products/loan/create');
+    await fillRequiredFields(page, 'E2E Down Payment Product');
+
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+    await page.getByTestId(DOWN_PAYMENT_TESTID).click();
+    await page.getByTestId('loan-product-down-payment-percentage').locator('input').fill('20');
+    await page.getByTestId('loan-product-multi-disburse').click();
+    await page.getByTestId(TRANCHE_COUNT_TESTID).locator('input').fill('3');
+
+    await page.getByTestId('loan-product-submit-btn').click();
+
+    await expect.poll(() => captured.body).not.toBeNull();
+    expect(captured.body).toMatchObject({
+      loanScheduleType: 'PROGRESSIVE',
+      enableDownPayment: true,
+      disbursedAmountPercentageForDownPayment: 20,
+      multiDisburseLoan: true,
+      maxTrancheCount: 3,
+    });
+  });
+
+  test('does not send a down payment on a cumulative product', async ({ page }) => {
+    const captured = await login(page);
+    await page.goto('/products/loan/create');
+    await fillRequiredFields(page, 'E2E Cumulative Product');
+
+    // Configure a down payment, then move the product back to the other engine. Hiding the
+    // controls is not enough: the values must leave the payload too.
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+    await page.getByTestId(DOWN_PAYMENT_TESTID).click();
+    await page.getByTestId('loan-product-down-payment-percentage').locator('input').fill('20');
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Cumulative');
+
+    await page.getByTestId('loan-product-submit-btn').click();
+
+    await expect.poll(() => captured.body).not.toBeNull();
+    const body = captured.body as Record<string, unknown>;
+    expect(body['loanScheduleType']).toBe('CUMULATIVE');
+    expect(body['enableDownPayment']).toBeUndefined();
+    expect(body['disbursedAmountPercentageForDownPayment']).toBeUndefined();
+  });
+});

--- a/src/app/features/products/loan-product-form.component.spec.ts
+++ b/src/app/features/products/loan-product-form.component.spec.ts
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { LoanProductFormComponent } from './loan-product-form.component';
+import {
+  LoanProductsService,
+  FundsService,
+  DelinquencyRangeAndBucketsManagementService,
+} from '../../api';
+import { provideIonicTesting } from '../../testing/ionic-testing';
+import {
+  ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+  DEFAULT_TRANSACTION_PROCESSING_STRATEGY,
+  LOAN_SCHEDULE_TYPE,
+} from './loan-schedule-type';
+
+const TEMPLATE = {
+  loanScheduleTypeOptions: [
+    { id: 1, code: LOAN_SCHEDULE_TYPE.CUMULATIVE, value: 'Cumulative' },
+    { id: 2, code: LOAN_SCHEDULE_TYPE.PROGRESSIVE, value: 'Progressive' },
+  ],
+  loanScheduleProcessingTypeOptions: [{ id: 1, code: 'HORIZONTAL', value: 'Horizontal' }],
+  transactionProcessingStrategyOptions: [
+    { id: 1, code: DEFAULT_TRANSACTION_PROCESSING_STRATEGY, name: 'Standard' },
+    { id: 2, code: ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced payment allocation' },
+  ],
+  advancedPaymentAllocationTypes: [{ id: 1, code: 'PAST_DUE_PENALTY', value: 'Past due penalty' }],
+  advancedPaymentAllocationTransactionTypes: [{ id: 1, code: 'DEFAULT', value: 'Default' }],
+  advancedPaymentAllocationFutureInstallmentAllocationRules: [
+    { id: 1, code: 'NEXT_INSTALLMENT', value: 'Next installment' },
+  ],
+  creditAllocationAllocationTypes: [],
+  creditAllocationTransactionTypes: [],
+  currencyOptions: [{ code: 'USD', name: 'US Dollar', decimalPlaces: 2 }],
+};
+
+describe('LoanProductFormComponent', () => {
+  let component: LoanProductFormComponent;
+  let fixture: ComponentFixture<LoanProductFormComponent>;
+  let productServiceSpy: jasmine.SpyObj<LoanProductsService>;
+
+  async function setup(productId: string | null = null): Promise<void> {
+    TestBed.resetTestingModule();
+
+    productServiceSpy = jasmine.createSpyObj('LoanProductsService', [
+      'getLoanproductsTemplate',
+      'getLoanproductsProductId',
+      'postLoanproducts',
+      'putLoanproductsProductId',
+    ]);
+    productServiceSpy.getLoanproductsTemplate.and.returnValue(of(TEMPLATE) as any);
+
+    const fundsSpy = jasmine.createSpyObj('FundsService', ['getFunds']);
+    fundsSpy.getFunds.and.returnValue(of([]) as any);
+    const delinquencySpy = jasmine.createSpyObj('DelinquencyRangeAndBucketsManagementService', [
+      'getDelinquencyBuckets',
+    ]);
+    delinquencySpy.getDelinquencyBuckets.and.returnValue(of([]) as any);
+
+    await TestBed.configureTestingModule({
+      imports: [LoanProductFormComponent, TranslateModule.forRoot()],
+      providers: [
+        provideNoopAnimations(),
+        provideIonicTesting(),
+        { provide: LoanProductsService, useValue: productServiceSpy },
+        { provide: FundsService, useValue: fundsSpy },
+        {
+          provide: DelinquencyRangeAndBucketsManagementService,
+          useValue: delinquencySpy,
+        },
+        { provide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of({ get: () => productId }) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoanProductFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  it('creates, defaulting to a cumulative product', () => {
+    expect(component).toBeTruthy();
+    expect(component.product().loanScheduleType).toBe(LOAN_SCHEDULE_TYPE.CUMULATIVE);
+    expect(component.isProgressive()).toBeFalse();
+  });
+
+  describe('down payment', () => {
+    /**
+     * Down payment is a progressive-engine capability. Hiding the controls on a cumulative
+     * product is not enough — a value left behind would still be in the payload, describing a
+     * product the cumulative engine cannot honour.
+     */
+    it('is cleared when the product is switched back to cumulative', () => {
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      component.onEnableDownPaymentChange(true);
+      component.product().disbursedAmountPercentageForDownPayment = 20;
+      component.product().enableAutoRepaymentForDownPayment = true;
+
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.CUMULATIVE);
+
+      expect(component.product().enableDownPayment).toBeUndefined();
+      expect(component.product().disbursedAmountPercentageForDownPayment).toBeUndefined();
+      expect(component.product().enableAutoRepaymentForDownPayment).toBeUndefined();
+    });
+
+    it('drops its dependent settings when it is turned off directly', () => {
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      component.onEnableDownPaymentChange(true);
+      component.product().disbursedAmountPercentageForDownPayment = 25;
+
+      component.onEnableDownPaymentChange(false);
+
+      expect(component.product().enableDownPayment).toBeUndefined();
+      expect(component.product().disbursedAmountPercentageForDownPayment).toBeUndefined();
+    });
+
+    it('is offered only on a progressive product', async () => {
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="down-payment-unavailable-note"]'),
+      ).not.toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-enable-down-payment"]'),
+      ).toBeNull();
+
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-enable-down-payment"]'),
+      ).not.toBeNull();
+    });
+  });
+
+  describe('multi-tranche disbursement', () => {
+    it('drops the tranche settings when it is turned off', () => {
+      component.onMultiDisburseChange(true);
+      component.product().maxTrancheCount = 4;
+      component.product().disallowExpectedDisbursements = true;
+      component.product().allowFullTermForTranche = true;
+
+      component.onMultiDisburseChange(false);
+
+      expect(component.product().multiDisburseLoan).toBeFalse();
+      expect(component.product().maxTrancheCount).toBeUndefined();
+      expect(component.product().disallowExpectedDisbursements).toBeUndefined();
+      // Only ever reachable through multi-disbursement, so it must not outlive it.
+      expect(component.product().allowFullTermForTranche).toBeUndefined();
+    });
+
+    it('reveals the tranche count once it is on', () => {
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-max-tranche-count"]'),
+      ).toBeNull();
+
+      component.onMultiDisburseChange(true);
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-max-tranche-count"]'),
+      ).not.toBeNull();
+    });
+
+    it('is available regardless of schedule type', () => {
+      expect(component.isProgressive()).toBeFalse();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-multi-disburse"]'),
+      ).not.toBeNull();
+    });
+  });
+
+  describe('editing an existing product', () => {
+    /**
+     * The payload is rebuilt field by field, so anything the form does not name is dropped on
+     * save. Opening a product configured with tranches or a down payment and pressing Save used
+     * to remove both silently.
+     */
+    it('carries the disbursement and down payment settings through the load', async () => {
+      await setup('7');
+      productServiceSpy.getLoanproductsProductId.and.returnValue(
+        of({
+          name: 'Asset Finance',
+          shortName: 'AF',
+          currency: { code: 'USD', decimalPlaces: 2 },
+          loanScheduleType: { code: LOAN_SCHEDULE_TYPE.PROGRESSIVE, value: 'Progressive' },
+          transactionProcessingStrategyCode: ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+          multiDisburseLoan: true,
+          maxTrancheCount: 3,
+          disallowExpectedDisbursements: true,
+          allowFullTermForTranche: true,
+          enableDownPayment: true,
+          disbursedAmountPercentageForDownPayment: 20,
+          enableAutoRepaymentForDownPayment: true,
+        }) as any,
+      );
+
+      component.loadProductData();
+
+      const product = component.product();
+      expect(product.multiDisburseLoan).toBeTrue();
+      expect(product.maxTrancheCount).toBe(3);
+      expect(product.disallowExpectedDisbursements).toBeTrue();
+      expect(product.allowFullTermForTranche).toBeTrue();
+      expect(product.enableDownPayment).toBeTrue();
+      expect(product.disbursedAmountPercentageForDownPayment).toBe(20);
+      expect(product.enableAutoRepaymentForDownPayment).toBeTrue();
+    });
+  });
+});

--- a/src/app/features/products/loan-product-form.component.ts
+++ b/src/app/features/products/loan-product-form.component.ts
@@ -31,6 +31,7 @@ import {
   IonInput,
   IonSelect,
   IonSelectOption,
+  IonCheckbox,
   IonTextarea,
   IonButton,
   IonSpinner,
@@ -68,6 +69,7 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
     IonInput,
     IonSelect,
     IonSelectOption,
+    IonCheckbox,
     IonTextarea,
     IonButton,
     IonSpinner,
@@ -525,6 +527,135 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
               </ion-row>
             </ion-grid>
 
+            <!-- Disbursement and down payment -->
+            <ion-grid class="ion-no-padding">
+              <ion-row>
+                <ion-col size="12">
+                  <h3 class="section-heading">
+                    {{ 'PRODUCTS.DISBURSEMENT_SETTINGS' | translate }}
+                  </h3>
+                </ion-col>
+
+                <ion-col size="12" size-md="6">
+                  <ion-item
+                    class="form-item"
+                    [appTooltip]="'HELP.MULTI_DISBURSE_LOAN_DESC' | translate"
+                  >
+                    <ion-checkbox
+                      name="multiDisburseLoan"
+                      data-testid="loan-product-multi-disburse"
+                      [ngModel]="multiDisburseEnabled()"
+                      (ngModelChange)="onMultiDisburseChange($event)"
+                    >
+                      {{ 'PRODUCTS.MULTI_DISBURSE_LOAN' | translate }}
+                    </ion-checkbox>
+                  </ion-item>
+                </ion-col>
+
+                @if (multiDisburseEnabled()) {
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      fill="outline"
+                      class="form-item"
+                      [appTooltip]="'HELP.MAX_TRANCHE_COUNT_DESC' | translate"
+                    >
+                      <ion-label position="stacked">{{
+                        'PRODUCTS.MAX_TRANCHE_COUNT' | translate
+                      }}</ion-label>
+                      <ion-input
+                        [attr.aria-label]="'PRODUCTS.MAX_TRANCHE_COUNT' | translate"
+                        type="number"
+                        min="1"
+                        data-testid="loan-product-max-tranche-count"
+                        name="maxTrancheCount"
+                        [(ngModel)]="product().maxTrancheCount"
+                        required
+                      ></ion-input>
+                    </ion-item>
+                  </ion-col>
+
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      class="form-item"
+                      [appTooltip]="'HELP.DISALLOW_EXPECTED_DISBURSEMENTS_DESC' | translate"
+                    >
+                      <ion-checkbox
+                        name="disallowExpectedDisbursements"
+                        data-testid="loan-product-disallow-expected-disbursements"
+                        [(ngModel)]="product().disallowExpectedDisbursements"
+                      >
+                        {{ 'PRODUCTS.DISALLOW_EXPECTED_DISBURSEMENTS' | translate }}
+                      </ion-checkbox>
+                    </ion-item>
+                  </ion-col>
+                }
+
+                <!-- Down payment is a progressive-engine capability. -->
+                @if (isProgressive()) {
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      class="form-item"
+                      [appTooltip]="'HELP.ENABLE_DOWN_PAYMENT_DESC' | translate"
+                    >
+                      <ion-checkbox
+                        name="enableDownPayment"
+                        data-testid="loan-product-enable-down-payment"
+                        [ngModel]="downPaymentEnabled()"
+                        (ngModelChange)="onEnableDownPaymentChange($event)"
+                      >
+                        {{ 'PRODUCTS.ENABLE_DOWN_PAYMENT' | translate }}
+                      </ion-checkbox>
+                    </ion-item>
+                  </ion-col>
+
+                  @if (downPaymentEnabled()) {
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.DOWN_PAYMENT_PERCENTAGE_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.DOWN_PAYMENT_PERCENTAGE' | translate
+                        }}</ion-label>
+                        <ion-input
+                          [attr.aria-label]="'PRODUCTS.DOWN_PAYMENT_PERCENTAGE' | translate"
+                          type="number"
+                          min="0"
+                          max="100"
+                          data-testid="loan-product-down-payment-percentage"
+                          name="disbursedAmountPercentageForDownPayment"
+                          [(ngModel)]="product().disbursedAmountPercentageForDownPayment"
+                          required
+                        ></ion-input>
+                      </ion-item>
+                    </ion-col>
+
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        class="form-item"
+                        [appTooltip]="'HELP.AUTO_REPAYMENT_FOR_DOWN_PAYMENT_DESC' | translate"
+                      >
+                        <ion-checkbox
+                          name="enableAutoRepaymentForDownPayment"
+                          data-testid="loan-product-auto-repayment-down-payment"
+                          [(ngModel)]="product().enableAutoRepaymentForDownPayment"
+                        >
+                          {{ 'PRODUCTS.ENABLE_AUTO_REPAYMENT_FOR_DOWN_PAYMENT' | translate }}
+                        </ion-checkbox>
+                      </ion-item>
+                    </ion-col>
+                  }
+                } @else {
+                  <ion-col size="12">
+                    <p class="field-note" data-testid="down-payment-unavailable-note">
+                      {{ 'PRODUCTS.DOWN_PAYMENT_PROGRESSIVE_ONLY_NOTE' | translate }}
+                    </p>
+                  </ion-col>
+                }
+              </ion-row>
+            </ion-grid>
+
             @if (isProgressive()) {
               <app-payment-credit-allocation-editor
                 [transactionTypeOptions]="advancedPaymentAllocationTransactionTypes()"
@@ -590,6 +721,12 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
         --border-radius: 8px;
         margin-bottom: 12px;
       }
+      .section-heading {
+        margin: 8px 0 4px;
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--text-color, #1f2937);
+      }
       .field-note {
         margin: -6px 0 12px;
         padding: 0 4px;
@@ -635,6 +772,11 @@ export class LoanProductFormComponent implements OnInit {
     GetLoanProductsTransactionProcessingStrategyOptions[]
   >([]);
   readonly isProgressive = signal(false);
+  // Mirrors of two payload flags. `product` is a signal holding an object, so assigning to one of
+  // its properties changes nothing the template is watching — the same reason `isProgressive` is
+  // its own signal rather than being read off the product.
+  readonly downPaymentEnabled = signal(false);
+  readonly multiDisburseEnabled = signal(false);
 
   readonly product = signal<PostLoanProductsRequest>({
     currencyCode: 'USD',
@@ -698,7 +840,38 @@ export class LoanProductFormComponent implements OnInit {
       this.product().loanScheduleProcessingType = undefined;
       this.product().paymentAllocation = undefined;
       this.product().creditAllocation = undefined;
+      // Down payment is a progressive capability. Hiding the controls is not enough — the values
+      // would still be in the payload, describing a product the cumulative engine cannot honour.
+      this.clearDownPayment();
     }
+  }
+
+  /** Turning multi-disbursement off leaves no meaning in the settings that depend on it. */
+  onMultiDisburseChange(enabled: boolean): void {
+    this.multiDisburseEnabled.set(enabled);
+    this.product().multiDisburseLoan = enabled;
+    if (!enabled) {
+      this.product().maxTrancheCount = undefined;
+      this.product().disallowExpectedDisbursements = undefined;
+      // Only ever reachable through multi-disbursement, so it cannot outlive it.
+      this.product().allowFullTermForTranche = undefined;
+    }
+  }
+
+  onEnableDownPaymentChange(enabled: boolean): void {
+    if (enabled) {
+      this.downPaymentEnabled.set(true);
+      this.product().enableDownPayment = true;
+      return;
+    }
+    this.clearDownPayment();
+  }
+
+  private clearDownPayment(): void {
+    this.downPaymentEnabled.set(false);
+    this.product().enableDownPayment = undefined;
+    this.product().disbursedAmountPercentageForDownPayment = undefined;
+    this.product().enableAutoRepaymentForDownPayment = undefined;
   }
 
   private applyTransactionProcessingStrategyFilter() {
@@ -770,8 +943,20 @@ export class LoanProductFormComponent implements OnInit {
         loanScheduleProcessingType: data.loanScheduleProcessingType?.code,
         paymentAllocation: data.paymentAllocation,
         creditAllocation: data.creditAllocation,
+        // Carried through explicitly: this payload is rebuilt field by field, so anything the
+        // form does not name is dropped on save. Before these lines, opening a product configured
+        // with tranches or a down payment and pressing Save silently removed both.
+        multiDisburseLoan: data.multiDisburseLoan,
+        maxTrancheCount: data.maxTrancheCount,
+        disallowExpectedDisbursements: data.disallowExpectedDisbursements,
+        allowFullTermForTranche: data.allowFullTermForTranche,
+        enableDownPayment: data.enableDownPayment,
+        disbursedAmountPercentageForDownPayment: data.disbursedAmountPercentageForDownPayment,
+        enableAutoRepaymentForDownPayment: data.enableAutoRepaymentForDownPayment,
       });
       this.isProgressive.set(this.product().loanScheduleType === LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      this.downPaymentEnabled.set(this.product().enableDownPayment === true);
+      this.multiDisburseEnabled.set(this.product().multiDisburseLoan === true);
       this.applyTransactionProcessingStrategyFilter();
     });
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -352,7 +352,15 @@
     },
     "FUND": "Fund",
     "DELINQUENCY_BUCKET": "Delinquency Bucket",
-    "STRATEGY_LOCKED_NOTE": "Fixed to Advanced Payment Allocation because this is a Progressive product — the two go together and Fineract rejects any other pairing."
+    "STRATEGY_LOCKED_NOTE": "Fixed to Advanced Payment Allocation because this is a Progressive product — the two go together and Fineract rejects any other pairing.",
+    "DISBURSEMENT_SETTINGS": "Disbursement and Down Payment",
+    "MULTI_DISBURSE_LOAN": "Release the loan in tranches",
+    "MAX_TRANCHE_COUNT": "Maximum number of tranches",
+    "DISALLOW_EXPECTED_DISBURSEMENTS": "Do not require a tranche schedule upfront",
+    "ENABLE_DOWN_PAYMENT": "Collect a down payment at disbursement",
+    "DOWN_PAYMENT_PERCENTAGE": "Down payment (% of the amount disbursed)",
+    "ENABLE_AUTO_REPAYMENT_FOR_DOWN_PAYMENT": "Post the down payment automatically",
+    "DOWN_PAYMENT_PROGRESSIVE_ONLY_NOTE": "Down payments are available on Progressive products only. Change the loan schedule type above to configure one."
   },
   "CHARGES": {
     "CREATE": "Create Charge",
@@ -736,7 +744,7 @@
     "TERM_TYPE_DESC": "The units for the loan term (e.g., Months, Years).",
     "REPAYMENTS_COUNT_DESC": "The total number of installments to repay the loan.",
     "REPAYMENT_EVERY_DESC": "How often repayments are due (e.g., every 1 month).",
-    "ENABLE_DOWN_PAYMENT_DESC": "Whether to require an initial payment from the borrower.",
+    "ENABLE_DOWN_PAYMENT_DESC": "Require the borrower to pay part of the amount back immediately at disbursement, so only the remainder is financed over the schedule. Common in asset and hire-purchase lending. Progressive products only.",
     "GROUP_NAME_DESC": "The name of the community group.",
     "CENTER_NAME_DESC": "The name of the administrative center.",
     "OFFICE_NAME_DESC": "The full name of the branch office.",
@@ -860,7 +868,12 @@
     "TRANSACTION_PROCESSING_STRATEGY_DESC": "The order in which a repayment is applied to what the borrower owes. Progressive products must use Advanced Payment Allocation, which is why the field is fixed for them.",
     "LOAN_SCHEDULE_PROCESSING_TYPE_DESC": "How a payment moves through unpaid instalments. Horizontal settles one instalment fully before moving to the next; Vertical pays the same component across every instalment first. Progressive products only.",
     "PAYMENT_ALLOCATION_DESC": "For each kind of incoming payment, the order in which it clears what is owed. The list is applied top to bottom until the payment is used up.",
-    "CREDIT_ALLOCATION_DESC": "The same ordering, for credits such as refunds and goodwill adjustments rather than borrower repayments."
+    "CREDIT_ALLOCATION_DESC": "The same ordering, for credits such as refunds and goodwill adjustments rather than borrower repayments.",
+    "MULTI_DISBURSE_LOAN_DESC": "Pay the loan out in stages rather than all at once — used where money is released against progress, such as construction or working capital. Each release is called a tranche.",
+    "MAX_TRANCHE_COUNT_DESC": "The largest number of separate releases allowed on one loan. Officers cannot add more tranches than this.",
+    "DISALLOW_EXPECTED_DISBURSEMENTS_DESC": "Leave unticked to require the full tranche plan — how much, and when — to be entered when the loan is created. Tick it to let tranches be added as they are actually needed.",
+    "DOWN_PAYMENT_PERCENTAGE_DESC": "How much of the disbursed amount the borrower pays upfront, as a percentage. 20 on a 1,000 disbursement means a 200 down payment and 800 repaid over the schedule.",
+    "AUTO_REPAYMENT_FOR_DOWN_PAYMENT_DESC": "Record the down payment for the borrower as soon as the loan is disbursed. Leave unticked if it is collected separately and should be entered by hand."
   },
   "REPORTS": {
     "NAME": "Report Name",


### PR DESCRIPTION
Closes #188.

The loan product form had no control for down payments or tranche disbursement, so a product
created in this application could never use either — and `allowFullTermForTranche` on the loan
application form, which needs a progressive product *with* multi-disbursement enabled, had never
been reachable for a product made here.

Adds a **Disbursement and Down Payment** section covering `multiDisburseLoan`, `maxTrancheCount`,
`disallowExpectedDisbursements`, `enableDownPayment`,
`disbursedAmountPercentageForDownPayment` and `enableAutoRepaymentForDownPayment`.

### Keeping the engines apart

Down payment is a progressive-engine capability, so it is offered only for progressive products
and is **cleared** when the schedule type moves back to cumulative. Hiding the controls is not
enough on its own: a value left behind would still be submitted, describing a product the
cumulative engine cannot honour. The dependent settings follow their parent the same way, and
`allowFullTermForTranche` is dropped along with multi-disbursement, since that is the only thing
that makes it reachable.

On a cumulative product the section says where the setting lives rather than silently omitting it.

### A silent data-loss bug this exposed

`loadProductData` rebuilds the payload field by field, so anything the form does not name is
dropped on save. Opening a product configured elsewhere with tranches or a down payment and
pressing Save removed both, without saying so. The new fields are now carried through explicitly.

### Two things only testing found

- **Visibility had to move to signals.** `product` is a signal holding an object, so assigning to
  `product().enableDownPayment` changes nothing the template is watching, and the dependent
  controls never appeared. Driven by `downPaymentEnabled` / `multiDisburseEnabled` signals now —
  the same reason `isProgressive` was already its own signal.
- **`IonCheckbox` was missing from the component's imports.** Without it `ngModel` has no value
  accessor, so the checkboxes rendered but never emitted. `npm run build` does not catch this;
  only driving the form does.

Both were my own bugs, caught before review because the e2e spec exercises the controls rather
than the class.

### Comprehensibility

Every new control carries plain-language help written for someone new to lending operations — what
the setting does, not a restatement of its name. For example:

> **Down payment (% of the amount disbursed)** — How much of the disbursed amount the borrower
> pays upfront, as a percentage. 20 on a 1,000 disbursement means a 200 down payment and 800
> repaid over the schedule.

### Tests

The product form had **no spec at all**. This adds:

- unit cover for the gating, both clearing rules, and the edit round trip;
- `e2e/loan-product-down-payment.spec.ts` (mocked, so it runs in the fast CI project) which
  asserts the **submitted payload** — including that a down payment configured and then abandoned
  by switching back to cumulative does not reach the request;
- demo steps configuring a down payment and tranches on the progressive product, and showing the
  explanation in its place on the cumulative one.

### Verification

| Check | Result |
|---|---|
| Unit tests | **715 passing** (707 → 715) |
| Mocked Playwright | **200/200 passing** (195 → 200) |
| `tsc` (app + spec) | 0 errors |
| `npm run build` | passes |
| lint (empty suppressions baseline), format, i18n, icons, license | all clean |

I also drove the form by hand against mocks and checked the rendered result before committing —
the section, the labels and the conditional controls all behave as described.

### Not in this PR

The demo steps run only in the `backend` project, which needs a live Fineract, so they are
unverified here; their assertions mirror the mocked spec that does run.

Interest recalculation is still a hardcoded `false` with no control, and `chargeOffBehaviour`,
`enableAccrualActivityPosting`, `fixedLength` and `repaymentStartDateType` remain unexposed. Those
are the next step of #188's phase, kept separate rather than folded in here.
