### PR TITLE
feat(products): configure capitalised income and buy-down fees

### DIFF
--- a/e2e/full-demo.spec.ts
+++ b/e2e/full-demo.spec.ts
@@ -151,6 +151,16 @@ test.describe('Full feature demo recording', () => {
     await page.getByTestId('loan-product-max-tranche-count').locator('input').fill('3');
     await beat(page);
 
+    // Income recognition: spread fee or interest income across the term rather than booking it
+    // at once, and let a third party buy down the borrower's rate. Both are progressive-engine
+    // capabilities, and both are what the Buy-Down Fees and Capitalised Income tabs on the loan
+    // account read — until they were settable here, those tabs could never appear.
+    await page.getByTestId('loan-product-enable-income-capitalization').click();
+    await expect(page.getByTestId('loan-product-capitalized-income-type')).toBeVisible();
+    await page.getByTestId('loan-product-enable-buy-down-fee').click();
+    await expect(page.getByTestId('loan-product-buy-down-fee-income-type')).toBeVisible();
+    await beat(page);
+
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(page).toHaveURL(/\/products\/loan$/, { timeout: 15000 });
 
@@ -178,6 +188,8 @@ test.describe('Full feature demo recording', () => {
     // explanation of where the setting lives, rather than simply not being there.
     await expect(page.getByTestId('down-payment-unavailable-note')).toBeVisible();
     await expect(page.getByTestId('loan-product-enable-down-payment')).toHaveCount(0);
+    await expect(page.getByTestId('loan-product-enable-income-capitalization')).toHaveCount(0);
+    await expect(page.getByTestId('loan-product-enable-buy-down-fee')).toHaveCount(0);
     await beat(page);
 
     const cumSuffix = uniqueSuffix();

--- a/e2e/loan-product-down-payment.spec.ts
+++ b/e2e/loan-product-down-payment.spec.ts
@@ -18,7 +18,8 @@
  */
 
 /**
- * Down payment and multi-tranche disbursement on the loan product form. See issue #188.
+ * The progressive-only settings on the loan product form: down payment and multi-tranche
+ * disbursement (#188), capitalised income and buy-down fees (#190).
  *
  * Neither could be configured here before, so a product created in this application could never
  * use either, and `allowFullTermForTranche` on the loan application form was unreachable.
@@ -37,6 +38,8 @@ const PASSWORD = 'password';
 const SCHEDULE_TYPE_LABEL = 'Loan Schedule Type';
 const DOWN_PAYMENT_TESTID = 'loan-product-enable-down-payment';
 const TRANCHE_COUNT_TESTID = 'loan-product-max-tranche-count';
+const CAPITALIZATION_TESTID = 'loan-product-enable-income-capitalization';
+const BUY_DOWN_TESTID = 'loan-product-enable-buy-down-fee';
 
 /** The POST body the form submits, captured in Node so a navigation cannot discard it. */
 interface Captured {
@@ -224,5 +227,76 @@ test.describe('Loan product down payment and tranches', () => {
     expect(body['loanScheduleType']).toBe('CUMULATIVE');
     expect(body['enableDownPayment']).toBeUndefined();
     expect(body['disbursedAmountPercentageForDownPayment']).toBeUndefined();
+  });
+
+  test('income recognition is offered only for a progressive product', async ({ page }) => {
+    await login(page);
+    await page.goto('/products/loan/create');
+    await expect(page.getByTestId('loan-product-schedule-type')).toBeVisible();
+
+    await expect(page.getByTestId(CAPITALIZATION_TESTID)).toHaveCount(0);
+    await expect(page.getByTestId(BUY_DOWN_TESTID)).toHaveCount(0);
+
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+
+    await expect(page.getByTestId(CAPITALIZATION_TESTID)).toBeVisible();
+    await expect(page.getByTestId(BUY_DOWN_TESTID)).toBeVisible();
+  });
+
+  test('the capitalisation details appear only once it is on', async ({ page }) => {
+    await login(page);
+    await page.goto('/products/loan/create');
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+
+    await expect(page.getByTestId('loan-product-capitalized-income-type')).toHaveCount(0);
+
+    await page.getByTestId(CAPITALIZATION_TESTID).click();
+
+    await expect(page.getByTestId('loan-product-capitalized-income-type')).toBeVisible();
+    await expect(page.getByTestId('loan-product-capitalized-income-calculation')).toBeVisible();
+    await expect(page.getByTestId('loan-product-capitalized-income-strategy')).toBeVisible();
+  });
+
+  test('submits the income recognition settings it was given', async ({ page }) => {
+    const captured = await login(page);
+    await page.goto('/products/loan/create');
+    await fillRequiredFields(page, 'E2E Capitalised Income Product');
+
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+    await page.getByTestId(CAPITALIZATION_TESTID).click();
+    await page.getByTestId(BUY_DOWN_TESTID).click();
+
+    await page.getByTestId('loan-product-submit-btn').click();
+
+    await expect.poll(() => captured.body).not.toBeNull();
+    expect(captured.body).toMatchObject({
+      enableIncomeCapitalization: true,
+      capitalizedIncomeType: 'FEE',
+      capitalizedIncomeCalculationType: 'FLAT',
+      capitalizedIncomeStrategy: 'EQUAL_AMORTIZATION',
+      enableBuyDownFee: true,
+      buyDownFeeIncomeType: 'FEE',
+      buyDownFeeStrategy: 'EQUAL_AMORTIZATION',
+    });
+  });
+
+  test('does not send income recognition on a cumulative product', async ({ page }) => {
+    const captured = await login(page);
+    await page.goto('/products/loan/create');
+    await fillRequiredFields(page, 'E2E Cumulative No Capitalisation');
+
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Progressive');
+    await page.getByTestId(CAPITALIZATION_TESTID).click();
+    await page.getByTestId(BUY_DOWN_TESTID).click();
+    await selectOption(page, SCHEDULE_TYPE_LABEL, 'Cumulative');
+
+    await page.getByTestId('loan-product-submit-btn').click();
+
+    await expect.poll(() => captured.body).not.toBeNull();
+    const body = captured.body as Record<string, unknown>;
+    expect(body['enableIncomeCapitalization']).toBeUndefined();
+    expect(body['capitalizedIncomeType']).toBeUndefined();
+    expect(body['enableBuyDownFee']).toBeUndefined();
+    expect(body['buyDownFeeStrategy']).toBeUndefined();
   });
 });

--- a/src/app/features/products/loan-product-form.component.spec.ts
+++ b/src/app/features/products/loan-product-form.component.spec.ts
@@ -199,6 +199,93 @@ describe('LoanProductFormComponent', () => {
     });
   });
 
+  describe('income recognition', () => {
+    /**
+     * Capitalised income and buy-down fees are progressive-engine capabilities. #187 gated the
+     * matching account tabs on these flags, so until they were settable the tabs could only ever
+     * appear for products created outside this application.
+     */
+    it('is offered only on a progressive product', () => {
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="loan-product-enable-income-capitalization"]',
+        ),
+      ).toBeNull();
+
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="loan-product-enable-income-capitalization"]',
+        ),
+      ).not.toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-enable-buy-down-fee"]'),
+      ).not.toBeNull();
+    });
+
+    it('seeds the detail fields when capitalisation is switched on', () => {
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      component.onEnableIncomeCapitalizationChange(true);
+
+      const product = component.product();
+      expect(product.enableIncomeCapitalization).toBeTrue();
+      expect(product.capitalizedIncomeType).toBe('FEE');
+      expect(product.capitalizedIncomeCalculationType).toBe('FLAT');
+      expect(product.capitalizedIncomeStrategy).toBe('EQUAL_AMORTIZATION');
+    });
+
+    it('keeps a choice the user already made rather than resetting it', () => {
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      component.onEnableIncomeCapitalizationChange(true);
+      component.product().capitalizedIncomeType = 'INTEREST';
+
+      component.onEnableIncomeCapitalizationChange(false);
+      component.onEnableIncomeCapitalizationChange(true);
+
+      // Cleared on the way out, so re-enabling starts from the default again.
+      expect(component.product().capitalizedIncomeType).toBe('FEE');
+    });
+
+    it('clears both groups when the product returns to cumulative', () => {
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      component.onEnableIncomeCapitalizationChange(true);
+      component.onEnableBuyDownFeeChange(true);
+
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.CUMULATIVE);
+
+      const product = component.product();
+      expect(product.enableIncomeCapitalization).toBeUndefined();
+      expect(product.capitalizedIncomeType).toBeUndefined();
+      expect(product.capitalizedIncomeStrategy).toBeUndefined();
+      expect(product.enableBuyDownFee).toBeUndefined();
+      expect(product.buyDownFeeIncomeType).toBeUndefined();
+      expect(product.buyDownFeeStrategy).toBeUndefined();
+      expect(component.incomeCapitalizationEnabled()).toBeFalse();
+      expect(component.buyDownFeeEnabled()).toBeFalse();
+    });
+
+    it('reveals the buy-down detail fields only once it is on', () => {
+      component.onLoanScheduleTypeChange(LOAN_SCHEDULE_TYPE.PROGRESSIVE);
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="loan-product-buy-down-fee-income-type"]',
+        ),
+      ).toBeNull();
+
+      component.onEnableBuyDownFeeChange(true);
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="loan-product-buy-down-fee-income-type"]',
+        ),
+      ).not.toBeNull();
+    });
+  });
+
   describe('editing an existing product', () => {
     /**
      * The payload is rebuilt field by field, so anything the form does not name is dropped on
@@ -221,6 +308,14 @@ describe('LoanProductFormComponent', () => {
           enableDownPayment: true,
           disbursedAmountPercentageForDownPayment: 20,
           enableAutoRepaymentForDownPayment: true,
+          enableIncomeCapitalization: true,
+          capitalizedIncomeType: { code: 'INTEREST', value: 'Interest' },
+          capitalizedIncomeCalculationType: { code: 'FLAT', value: 'Flat' },
+          capitalizedIncomeStrategy: { code: 'EQUAL_AMORTIZATION', value: 'Equal amortization' },
+          enableBuyDownFee: true,
+          buyDownFeeIncomeType: { code: 'FEE', value: 'Fee' },
+          buyDownFeeCalculationType: { code: 'FLAT', value: 'Flat' },
+          buyDownFeeStrategy: { code: 'EQUAL_AMORTIZATION', value: 'Equal amortization' },
         }) as any,
       );
 
@@ -234,6 +329,14 @@ describe('LoanProductFormComponent', () => {
       expect(product.enableDownPayment).toBeTrue();
       expect(product.disbursedAmountPercentageForDownPayment).toBe(20);
       expect(product.enableAutoRepaymentForDownPayment).toBeTrue();
+      // The response wraps these as `{ code, value }`; the request takes the bare code.
+      expect(product.enableIncomeCapitalization).toBeTrue();
+      expect(product.capitalizedIncomeType).toBe('INTEREST');
+      expect(product.capitalizedIncomeStrategy).toBe('EQUAL_AMORTIZATION');
+      expect(product.enableBuyDownFee).toBeTrue();
+      expect(product.buyDownFeeIncomeType).toBe('FEE');
+      expect(component.incomeCapitalizationEnabled()).toBeTrue();
+      expect(component.buyDownFeeEnabled()).toBeTrue();
     });
   });
 });

--- a/src/app/features/products/loan-product-form.component.ts
+++ b/src/app/features/products/loan-product-form.component.ts
@@ -656,6 +656,211 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
               </ion-row>
             </ion-grid>
 
+            <!-- Income recognition. Both groups belong to the progressive engine. -->
+            @if (isProgressive()) {
+              <ion-grid class="ion-no-padding">
+                <ion-row>
+                  <ion-col size="12">
+                    <h3 class="section-heading">
+                      {{ 'PRODUCTS.INCOME_RECOGNITION' | translate }}
+                    </h3>
+                  </ion-col>
+
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      class="form-item"
+                      [appTooltip]="'HELP.ENABLE_INCOME_CAPITALIZATION_DESC' | translate"
+                    >
+                      <ion-checkbox
+                        name="enableIncomeCapitalization"
+                        data-testid="loan-product-enable-income-capitalization"
+                        [ngModel]="incomeCapitalizationEnabled()"
+                        (ngModelChange)="onEnableIncomeCapitalizationChange($event)"
+                      >
+                        {{ 'PRODUCTS.ENABLE_INCOME_CAPITALIZATION' | translate }}
+                      </ion-checkbox>
+                    </ion-item>
+                  </ion-col>
+
+                  @if (incomeCapitalizationEnabled()) {
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.CAPITALIZED_INCOME_TYPE_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.CAPITALIZED_INCOME_TYPE' | translate
+                        }}</ion-label>
+                        <ion-select
+                          [attr.aria-label]="'PRODUCTS.CAPITALIZED_INCOME_TYPE' | translate"
+                          interface="popover"
+                          data-testid="loan-product-capitalized-income-type"
+                          name="capitalizedIncomeType"
+                          [(ngModel)]="product().capitalizedIncomeType"
+                          required
+                        >
+                          @for (option of incomeTypeOptions; track option.code) {
+                            <ion-select-option [value]="option.code">{{
+                              option.labelKey | translate
+                            }}</ion-select-option>
+                          }
+                        </ion-select>
+                      </ion-item>
+                    </ion-col>
+
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.INCOME_CALCULATION_TYPE_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.INCOME_CALCULATION_TYPE' | translate
+                        }}</ion-label>
+                        <ion-select
+                          [attr.aria-label]="'PRODUCTS.INCOME_CALCULATION_TYPE' | translate"
+                          interface="popover"
+                          data-testid="loan-product-capitalized-income-calculation"
+                          name="capitalizedIncomeCalculationType"
+                          [(ngModel)]="product().capitalizedIncomeCalculationType"
+                          required
+                        >
+                          @for (option of incomeCalculationOptions; track option.code) {
+                            <ion-select-option [value]="option.code">{{
+                              option.labelKey | translate
+                            }}</ion-select-option>
+                          }
+                        </ion-select>
+                      </ion-item>
+                    </ion-col>
+
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.INCOME_STRATEGY_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.INCOME_STRATEGY' | translate
+                        }}</ion-label>
+                        <ion-select
+                          [attr.aria-label]="'PRODUCTS.INCOME_STRATEGY' | translate"
+                          interface="popover"
+                          data-testid="loan-product-capitalized-income-strategy"
+                          name="capitalizedIncomeStrategy"
+                          [(ngModel)]="product().capitalizedIncomeStrategy"
+                          required
+                        >
+                          @for (option of incomeStrategyOptions; track option.code) {
+                            <ion-select-option [value]="option.code">{{
+                              option.labelKey | translate
+                            }}</ion-select-option>
+                          }
+                        </ion-select>
+                      </ion-item>
+                    </ion-col>
+                  }
+
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      class="form-item"
+                      [appTooltip]="'HELP.ENABLE_BUY_DOWN_FEE_DESC' | translate"
+                    >
+                      <ion-checkbox
+                        name="enableBuyDownFee"
+                        data-testid="loan-product-enable-buy-down-fee"
+                        [ngModel]="buyDownFeeEnabled()"
+                        (ngModelChange)="onEnableBuyDownFeeChange($event)"
+                      >
+                        {{ 'PRODUCTS.ENABLE_BUY_DOWN_FEE' | translate }}
+                      </ion-checkbox>
+                    </ion-item>
+                  </ion-col>
+
+                  @if (buyDownFeeEnabled()) {
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.BUY_DOWN_FEE_INCOME_TYPE_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.BUY_DOWN_FEE_INCOME_TYPE' | translate
+                        }}</ion-label>
+                        <ion-select
+                          [attr.aria-label]="'PRODUCTS.BUY_DOWN_FEE_INCOME_TYPE' | translate"
+                          interface="popover"
+                          data-testid="loan-product-buy-down-fee-income-type"
+                          name="buyDownFeeIncomeType"
+                          [(ngModel)]="product().buyDownFeeIncomeType"
+                          required
+                        >
+                          @for (option of incomeTypeOptions; track option.code) {
+                            <ion-select-option [value]="option.code">{{
+                              option.labelKey | translate
+                            }}</ion-select-option>
+                          }
+                        </ion-select>
+                      </ion-item>
+                    </ion-col>
+
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.INCOME_CALCULATION_TYPE_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.INCOME_CALCULATION_TYPE' | translate
+                        }}</ion-label>
+                        <ion-select
+                          [attr.aria-label]="'PRODUCTS.INCOME_CALCULATION_TYPE' | translate"
+                          interface="popover"
+                          data-testid="loan-product-buy-down-fee-calculation"
+                          name="buyDownFeeCalculationType"
+                          [(ngModel)]="product().buyDownFeeCalculationType"
+                          required
+                        >
+                          @for (option of incomeCalculationOptions; track option.code) {
+                            <ion-select-option [value]="option.code">{{
+                              option.labelKey | translate
+                            }}</ion-select-option>
+                          }
+                        </ion-select>
+                      </ion-item>
+                    </ion-col>
+
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.INCOME_STRATEGY_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.INCOME_STRATEGY' | translate
+                        }}</ion-label>
+                        <ion-select
+                          [attr.aria-label]="'PRODUCTS.INCOME_STRATEGY' | translate"
+                          interface="popover"
+                          data-testid="loan-product-buy-down-fee-strategy"
+                          name="buyDownFeeStrategy"
+                          [(ngModel)]="product().buyDownFeeStrategy"
+                          required
+                        >
+                          @for (option of incomeStrategyOptions; track option.code) {
+                            <ion-select-option [value]="option.code">{{
+                              option.labelKey | translate
+                            }}</ion-select-option>
+                          }
+                        </ion-select>
+                      </ion-item>
+                    </ion-col>
+                  }
+                </ion-row>
+              </ion-grid>
+            }
+
             @if (isProgressive()) {
               <app-payment-credit-allocation-editor
                 [transactionTypeOptions]="advancedPaymentAllocationTransactionTypes()"
@@ -777,6 +982,27 @@ export class LoanProductFormComponent implements OnInit {
   // its own signal rather than being read off the product.
   readonly downPaymentEnabled = signal(false);
   readonly multiDisburseEnabled = signal(false);
+  readonly incomeCapitalizationEnabled = signal(false);
+  readonly buyDownFeeEnabled = signal(false);
+
+  /**
+   * Option lists for the income-recognition enums.
+   *
+   * Held here rather than taken from the product template, which does not return them. Two of the
+   * three currently admit a single value; they are still rendered as selects so the payload
+   * records what the product was created with, and so a value added upstream needs one line here
+   * rather than a new control.
+   */
+  readonly incomeTypeOptions = [
+    { code: 'FEE', labelKey: 'PRODUCTS.INCOME_TYPE_FEE' },
+    { code: 'INTEREST', labelKey: 'PRODUCTS.INCOME_TYPE_INTEREST' },
+  ];
+  readonly incomeCalculationOptions = [
+    { code: 'FLAT', labelKey: 'PRODUCTS.INCOME_CALCULATION_FLAT' },
+  ];
+  readonly incomeStrategyOptions = [
+    { code: 'EQUAL_AMORTIZATION', labelKey: 'PRODUCTS.INCOME_STRATEGY_EQUAL_AMORTIZATION' },
+  ];
 
   readonly product = signal<PostLoanProductsRequest>({
     currencyCode: 'USD',
@@ -840,9 +1066,11 @@ export class LoanProductFormComponent implements OnInit {
       this.product().loanScheduleProcessingType = undefined;
       this.product().paymentAllocation = undefined;
       this.product().creditAllocation = undefined;
-      // Down payment is a progressive capability. Hiding the controls is not enough — the values
-      // would still be in the payload, describing a product the cumulative engine cannot honour.
+      // These are progressive capabilities. Hiding the controls is not enough — the values would
+      // still be in the payload, describing a product the cumulative engine cannot honour.
       this.clearDownPayment();
+      this.clearIncomeCapitalization();
+      this.clearBuyDownFee();
     }
   }
 
@@ -865,6 +1093,52 @@ export class LoanProductFormComponent implements OnInit {
       return;
     }
     this.clearDownPayment();
+  }
+
+  onEnableIncomeCapitalizationChange(enabled: boolean): void {
+    if (!enabled) {
+      this.clearIncomeCapitalization();
+      return;
+    }
+    this.incomeCapitalizationEnabled.set(true);
+    const product = this.product();
+    product.enableIncomeCapitalization = true;
+    // Seeded explicitly so the product records what it was created with, rather than relying on
+    // whatever the server would default to.
+    product.capitalizedIncomeType ??= 'FEE';
+    product.capitalizedIncomeCalculationType ??= 'FLAT';
+    product.capitalizedIncomeStrategy ??= 'EQUAL_AMORTIZATION';
+  }
+
+  onEnableBuyDownFeeChange(enabled: boolean): void {
+    if (!enabled) {
+      this.clearBuyDownFee();
+      return;
+    }
+    this.buyDownFeeEnabled.set(true);
+    const product = this.product();
+    product.enableBuyDownFee = true;
+    product.buyDownFeeIncomeType ??= 'FEE';
+    product.buyDownFeeCalculationType ??= 'FLAT';
+    product.buyDownFeeStrategy ??= 'EQUAL_AMORTIZATION';
+  }
+
+  private clearIncomeCapitalization(): void {
+    this.incomeCapitalizationEnabled.set(false);
+    const product = this.product();
+    product.enableIncomeCapitalization = undefined;
+    product.capitalizedIncomeType = undefined;
+    product.capitalizedIncomeCalculationType = undefined;
+    product.capitalizedIncomeStrategy = undefined;
+  }
+
+  private clearBuyDownFee(): void {
+    this.buyDownFeeEnabled.set(false);
+    const product = this.product();
+    product.enableBuyDownFee = undefined;
+    product.buyDownFeeIncomeType = undefined;
+    product.buyDownFeeCalculationType = undefined;
+    product.buyDownFeeStrategy = undefined;
   }
 
   private clearDownPayment(): void {
@@ -953,10 +1227,20 @@ export class LoanProductFormComponent implements OnInit {
         enableDownPayment: data.enableDownPayment,
         disbursedAmountPercentageForDownPayment: data.disbursedAmountPercentageForDownPayment,
         enableAutoRepaymentForDownPayment: data.enableAutoRepaymentForDownPayment,
+        enableIncomeCapitalization: data.enableIncomeCapitalization,
+        capitalizedIncomeType: data.capitalizedIncomeType?.code as never,
+        capitalizedIncomeCalculationType: data.capitalizedIncomeCalculationType?.code as never,
+        capitalizedIncomeStrategy: data.capitalizedIncomeStrategy?.code as never,
+        enableBuyDownFee: data.enableBuyDownFee,
+        buyDownFeeIncomeType: data.buyDownFeeIncomeType?.code as never,
+        buyDownFeeCalculationType: data.buyDownFeeCalculationType?.code as never,
+        buyDownFeeStrategy: data.buyDownFeeStrategy?.code as never,
       });
       this.isProgressive.set(this.product().loanScheduleType === LOAN_SCHEDULE_TYPE.PROGRESSIVE);
       this.downPaymentEnabled.set(this.product().enableDownPayment === true);
       this.multiDisburseEnabled.set(this.product().multiDisburseLoan === true);
+      this.incomeCapitalizationEnabled.set(this.product().enableIncomeCapitalization === true);
+      this.buyDownFeeEnabled.set(this.product().enableBuyDownFee === true);
       this.applyTransactionProcessingStrategyFilter();
     });
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -360,7 +360,18 @@
     "ENABLE_DOWN_PAYMENT": "Collect a down payment at disbursement",
     "DOWN_PAYMENT_PERCENTAGE": "Down payment (% of the amount disbursed)",
     "ENABLE_AUTO_REPAYMENT_FOR_DOWN_PAYMENT": "Post the down payment automatically",
-    "DOWN_PAYMENT_PROGRESSIVE_ONLY_NOTE": "Down payments are available on Progressive products only. Change the loan schedule type above to configure one."
+    "DOWN_PAYMENT_PROGRESSIVE_ONLY_NOTE": "Down payments are available on Progressive products only. Change the loan schedule type above to configure one.",
+    "INCOME_RECOGNITION": "Income Recognition",
+    "ENABLE_INCOME_CAPITALIZATION": "Spread income over the life of the loan",
+    "CAPITALIZED_INCOME_TYPE": "Income being spread",
+    "ENABLE_BUY_DOWN_FEE": "Allow a third party to buy down the rate",
+    "BUY_DOWN_FEE_INCOME_TYPE": "Buy-down treated as",
+    "INCOME_CALCULATION_TYPE": "How the amount is worked out",
+    "INCOME_STRATEGY": "How it is spread",
+    "INCOME_TYPE_FEE": "Fee",
+    "INCOME_TYPE_INTEREST": "Interest",
+    "INCOME_CALCULATION_FLAT": "A flat amount",
+    "INCOME_STRATEGY_EQUAL_AMORTIZATION": "In equal parts across the term"
   },
   "CHARGES": {
     "CREATE": "Create Charge",
@@ -873,7 +884,13 @@
     "MAX_TRANCHE_COUNT_DESC": "The largest number of separate releases allowed on one loan. Officers cannot add more tranches than this.",
     "DISALLOW_EXPECTED_DISBURSEMENTS_DESC": "Leave unticked to require the full tranche plan — how much, and when — to be entered when the loan is created. Tick it to let tranches be added as they are actually needed.",
     "DOWN_PAYMENT_PERCENTAGE_DESC": "How much of the disbursed amount the borrower pays upfront, as a percentage. 20 on a 1,000 disbursement means a 200 down payment and 800 repaid over the schedule.",
-    "AUTO_REPAYMENT_FOR_DOWN_PAYMENT_DESC": "Record the down payment for the borrower as soon as the loan is disbursed. Leave unticked if it is collected separately and should be entered by hand."
+    "AUTO_REPAYMENT_FOR_DOWN_PAYMENT_DESC": "Record the down payment for the borrower as soon as the loan is disbursed. Leave unticked if it is collected separately and should be entered by hand.",
+    "ENABLE_INCOME_CAPITALIZATION_DESC": "Recognise income gradually over the loan's term instead of all at once when it is charged. The borrower pays the same either way — this changes when the institution books the income. Progressive products only.",
+    "CAPITALIZED_INCOME_TYPE_DESC": "Whether the amount being spread is treated as a fee or as interest. This decides which income account it lands in and how it appears on the loan.",
+    "ENABLE_BUY_DOWN_FEE_DESC": "Let someone other than the borrower — typically a dealer or supplier — pay an amount upfront to reduce the borrower's effective rate. The cost is spread over the term rather than taken in full at disbursement. Progressive products only.",
+    "BUY_DOWN_FEE_INCOME_TYPE_DESC": "Whether the amount the third party paid is booked as a fee or as interest.",
+    "INCOME_CALCULATION_TYPE_DESC": "How the amount to recognise in each period is worked out. Flat divides the total evenly rather than varying it with the outstanding balance.",
+    "INCOME_STRATEGY_DESC": "How the total is distributed across the loan's periods. Equal parts gives every period the same share."
   },
   "REPORTS": {
     "NAME": "Report Name",


### PR DESCRIPTION
Closes #190.

Adds an **Income Recognition** section covering `enableIncomeCapitalization` and
`enableBuyDownFee`, each with its income type, calculation type and amortisation strategy.

### This closes a loop the application opened itself

#187 gated the *Buy-Down Fees* and *Capitalised Income* tabs on the loan account screen on the
loan's own capability flags — correctly, since a tab that can never hold anything is worse than no
tab. But nothing in this application could set those flags, so the tabs could only ever appear for
products created elsewhere. The gating worked and the feature behind it was unreachable. It isn't
any more.

### Which engine these belong to, and how confident that is

Both are offered for progressive products only, and cleared when the schedule type moves back to
cumulative. The evidence differs between the two, and I'd rather record that than smooth it over:

- **Capitalised income** has a direct marker: `CAPITALIZED_INCOME_ADJUSTMENT` is one of the
  advanced payment allocation transaction types, which exist only on products using that strategy.
- **Buy-down fee** has no equivalent — there is no `BUY_DOWN` entry anywhere in the allocation
  types. It is grouped with capitalised income throughout the API (adjacent on the product
  request, product response and loan response), shares the same `EQUAL_AMORTIZATION` vocabulary,
  and is already treated as a progressive capability by the account screen. Consistent, but
  inferred rather than stated.

### Details worth noting

The detail fields are **seeded on enable** rather than left to a server default, so the product
records what it was created with. Two of the three enums currently admit a single value; they are
still rendered as selects driven by one option list each, so a value added upstream needs a line
rather than a new control.

All eight fields are also carried through `loadProductData`, which rebuilds the payload field by
field — the same silent data-loss bug fixed for tranches and down payments in #189, which these
fields still had. The response wraps them as `{ code, value }` while the request takes the bare
code, and the round-trip test covers that unwrapping.

### Comprehensibility

Each control explains the effect in business terms. For example:

> **Spread income over the life of the loan** — Recognise income gradually over the loan's term
> instead of all at once when it is charged. The borrower pays the same either way — this changes
> when the institution books the income.

Labels avoid jargon where plain words work: *Income being spread*, *How the amount is worked out*,
*How it is spread*, *Allow a third party to buy down the rate*.

### Verification

| Check | Result |
|---|---|
| Unit tests | **720 passing** (715 → 720) |
| Mocked Playwright | **204/204 passing** (200 → 204) |
| `tsc` (app + spec) | 0 errors |
| `npm run build` | passes |
| lint (empty suppressions baseline), format, i18n, icons, license | all clean |

I drove the form by hand against mocks before committing. One thing that looked wrong in the
screenshot — the buy-down checkbox appearing unchecked while its detail fields were showing —
turned out to be the checkbox caught mid-animation; I checked the actual `checked` property rather
than trusting the pixels, and both read `true`.

### Not in this PR

The demo steps run only in the `backend` project, which needs a live Fineract, so they are
unverified here; their assertions mirror the mocked spec that does run.

Interest recalculation is still a hardcoded `false` with no control, and `chargeOffBehaviour`,
`enableAccrualActivityPosting`, `fixedLength` and `repaymentStartDateType` remain unexposed — the
remaining step of this phase.

The run surfaced pre-existing `NG0100` reports on this form (`ng-untouched`, and an
`undefined → 10` on the interest rate field). These are the form-state class described earlier,
not introduced here — the reported value belongs to an existing field, and the check is advisory
rather than enforced.
