### PR TITLE
feat(products): configure interest recalculation and the remaining product settings

### DIFF
--- a/e2e/full-demo.spec.ts
+++ b/e2e/full-demo.spec.ts
@@ -200,6 +200,17 @@ test.describe('Full feature demo recording', () => {
     await page.getByRole('spinbutton', { name: INTEREST_RATE_LABEL }).fill('10');
     await page.getByRole('spinbutton', { name: NUMBER_OF_REPAYMENTS_LABEL }).fill('3');
     await page.getByRole('spinbutton', { name: REPAYMENT_EVERY_LABEL }).fill('1');
+
+    // Interest recalculation charges interest on what the borrower actually owes rather than on
+    // the planned balance. It applies to both engines, and its dependent fields follow the chain
+    // the API documents: the mandatory three appear with the toggle, and each interval appears
+    // only when its frequency is something other than the repayment period.
+    await page.getByTestId('loan-product-interest-recalculation').click();
+    await expect(page.getByTestId('loan-product-compounding-method')).toBeVisible();
+    await expect(page.getByTestId('loan-product-reschedule-strategy')).toBeVisible();
+    await expect(page.getByTestId('loan-product-rest-interval')).toHaveCount(0);
+    await beat(page);
+
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(page).toHaveURL(/\/products\/loan$/, { timeout: 15000 });
 

--- a/e2e/full-demo.spec.ts
+++ b/e2e/full-demo.spec.ts
@@ -208,7 +208,18 @@ test.describe('Full feature demo recording', () => {
     await page.getByTestId('loan-product-interest-recalculation').click();
     await expect(page.getByTestId('loan-product-compounding-method')).toBeVisible();
     await expect(page.getByTestId('loan-product-reschedule-strategy')).toBeVisible();
+    // No interval: the seeded rest frequency is the repayment period, which needs none.
     await expect(page.getByTestId('loan-product-rest-interval')).toHaveCount(0);
+    // Fineract only supports recalculation with daily interest calculation, so the form fixes
+    // that field and says why rather than letting the server reject the product.
+    await expect(page.getByTestId('interest-calc-period-locked-note')).toBeVisible();
+    await beat(page);
+
+    // Turned back off before saving. This product is the one the rest of the walkthrough lends
+    // against, and a recalculating product constrains every loan created from it — the demo is
+    // here to show the controls, not to change the product ten later steps depend on.
+    await page.getByTestId('loan-product-interest-recalculation').click();
+    await expect(page.getByTestId('interest-calc-period-locked-note')).toHaveCount(0);
     await beat(page);
 
     await page.getByRole('button', { name: 'Save' }).click();

--- a/e2e/loan-product-down-payment.spec.ts
+++ b/e2e/loan-product-down-payment.spec.ts
@@ -370,6 +370,9 @@ test.describe('Loan product down payment and tranches', () => {
     // Seeded with "same as repayment period", which needs no interval.
     await expect(page.getByTestId('loan-product-rest-interval')).toHaveCount(0);
 
+    // Wait for the select to be attached before driving it: its options come from the template
+    // request, and picking from it before that resolves times out under parallel load.
+    await expect(page.getByTestId('loan-product-rest-frequency')).toBeVisible();
     await selectOption(page, 'How often interest is recalculated', 'Daily');
 
     await expect(page.getByTestId('loan-product-rest-interval')).toBeVisible();

--- a/e2e/loan-product-down-payment.spec.ts
+++ b/e2e/loan-product-down-payment.spec.ts
@@ -107,6 +107,50 @@ async function login(page: Page): Promise<Captured> {
         creditAllocationAllocationTypes: [],
         creditAllocationTransactionTypes: [],
         chargeOptions: [],
+        capitalizedIncomeTypeOptions: [
+          { code: 'FEE', value: 'Fee' },
+          { code: 'INTEREST', value: 'Interest' },
+        ],
+        capitalizedIncomeCalculationTypeOptions: [{ code: 'FLAT', value: 'Flat' }],
+        capitalizedIncomeStrategyOptions: [
+          { code: 'EQUAL_AMORTIZATION', value: 'Equal amortization' },
+        ],
+        buyDownFeeIncomeTypeOptions: [{ code: 'FEE', value: 'Fee' }],
+        buyDownFeeCalculationTypeOptions: [{ code: 'FLAT', value: 'Flat' }],
+        buyDownFeeStrategyOptions: [{ code: 'EQUAL_AMORTIZATION', value: 'Equal amortization' }],
+        interestRecalculationCompoundingTypeOptions: [
+          { id: 0, code: 'interestRecalculationCompoundingMethod.none', description: 'None' },
+          { id: 1, code: 'interestRecalculationCompoundingMethod.fee', description: 'Fee' },
+        ],
+        interestRecalculationFrequencyTypeOptions: [
+          {
+            id: 1,
+            code: 'interestRecalculationFrequencyType.same.as.repayment.period',
+            description: 'Same as repayment period',
+          },
+          { id: 2, code: 'interestRecalculationFrequencyType.daily', description: 'Daily' },
+        ],
+        rescheduleStrategyTypeOptions: [
+          {
+            id: 1,
+            code: 'loanRescheduleStrategyMethod.reduce.emi.amount',
+            description: 'Reduce EMI amount',
+          },
+        ],
+        preClosureInterestCalculationStrategyOptions: [
+          {
+            id: 1,
+            code: 'preClosureInterestCalculationStrategy.tillPreClosureDate',
+            description: 'Till pre-close date',
+          },
+        ],
+        repaymentStartDateTypeOptions: [
+          { id: 1, code: 'repaymentStartDateType.disbursement', description: 'Disbursement date' },
+        ],
+        chargeOffBehaviourOptions: [
+          { code: 'REGULAR', value: 'Regular' },
+          { code: 'ZERO_INTEREST', value: 'Zero interest' },
+        ],
       }),
     }),
   );
@@ -298,5 +342,71 @@ test.describe('Loan product down payment and tranches', () => {
     expect(body['capitalizedIncomeType']).toBeUndefined();
     expect(body['enableBuyDownFee']).toBeUndefined();
     expect(body['buyDownFeeStrategy']).toBeUndefined();
+  });
+
+  test('interest recalculation reveals its mandatory settings only once it is on', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto('/products/loan/create');
+    await expect(page.getByTestId('loan-product-interest-recalculation')).toBeVisible();
+
+    await expect(page.getByTestId('loan-product-compounding-method')).toHaveCount(0);
+
+    await page.getByTestId('loan-product-interest-recalculation').click();
+
+    await expect(page.getByTestId('loan-product-compounding-method')).toBeVisible();
+    await expect(page.getByTestId('loan-product-reschedule-strategy')).toBeVisible();
+    await expect(page.getByTestId('loan-product-rest-frequency')).toBeVisible();
+  });
+
+  test('the rest interval appears only when the frequency is not the repayment period', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto('/products/loan/create');
+    await page.getByTestId('loan-product-interest-recalculation').click();
+
+    // Seeded with "same as repayment period", which needs no interval.
+    await expect(page.getByTestId('loan-product-rest-interval')).toHaveCount(0);
+
+    await selectOption(page, 'How often interest is recalculated', 'Daily');
+
+    await expect(page.getByTestId('loan-product-rest-interval')).toBeVisible();
+  });
+
+  test('submits the interest recalculation settings it was given', async ({ page }) => {
+    const captured = await login(page);
+    await page.goto('/products/loan/create');
+    await fillRequiredFields(page, 'E2E Recalculating Product');
+
+    await page.getByTestId('loan-product-interest-recalculation').click();
+    await page.getByTestId('loan-product-submit-btn').click();
+
+    await expect.poll(() => captured.body).not.toBeNull();
+    expect(captured.body).toMatchObject({
+      isInterestRecalculationEnabled: true,
+      interestRecalculationCompoundingMethod: 0,
+      rescheduleStrategyMethod: 1,
+      recalculationRestFrequencyType: 1,
+    });
+  });
+
+  test('does not send recalculation settings once it is switched back off', async ({ page }) => {
+    const captured = await login(page);
+    await page.goto('/products/loan/create');
+    await fillRequiredFields(page, 'E2E No Recalculation Product');
+
+    await page.getByTestId('loan-product-interest-recalculation').click();
+    await page.getByTestId('loan-product-interest-recalculation').click();
+
+    await page.getByTestId('loan-product-submit-btn').click();
+
+    await expect.poll(() => captured.body).not.toBeNull();
+    const body = captured.body as Record<string, unknown>;
+    expect(body['isInterestRecalculationEnabled']).toBe(false);
+    expect(body['interestRecalculationCompoundingMethod']).toBeUndefined();
+    expect(body['rescheduleStrategyMethod']).toBeUndefined();
+    expect(body['recalculationRestFrequencyType']).toBeUndefined();
   });
 });

--- a/src/app/features/products/loan-product-form.component.spec.ts
+++ b/src/app/features/products/loan-product-form.component.spec.ts
@@ -420,6 +420,28 @@ describe('LoanProductFormComponent', () => {
       expect(component.interestRecalculationEnabled()).toBeFalse();
     });
 
+    /**
+     * Fineract rejects recalculation alongside any interest calculation period other than daily
+     * with `not.supported.for.selected.interest.calculation.type`, and the form's own default is
+     * one of the rejected values — so enabling it used to build a product the server refused.
+     */
+    it('forces daily interest calculation, which is the only period Fineract supports with it', () => {
+      expect(component.product().interestCalculationPeriodType).toBe(1);
+
+      component.onInterestRecalculationChange(true);
+
+      expect(component.product().interestCalculationPeriodType).toBe(0);
+    });
+
+    it('explains why the interest calculation period is locked', () => {
+      component.onInterestRecalculationChange(true);
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="interest-calc-period-locked-note"]'),
+      ).not.toBeNull();
+    });
+
     it('renders its controls only once it is on', () => {
       expect(
         fixture.nativeElement.querySelector('[data-testid="loan-product-compounding-method"]'),

--- a/src/app/features/products/loan-product-form.component.spec.ts
+++ b/src/app/features/products/loan-product-form.component.spec.ts
@@ -38,6 +38,8 @@ import {
   LOAN_SCHEDULE_TYPE,
 } from './loan-schedule-type';
 
+const EQUAL_AMORTIZATION_LABEL = 'Equal amortization';
+
 const TEMPLATE = {
   loanScheduleTypeOptions: [
     { id: 1, code: LOAN_SCHEDULE_TYPE.CUMULATIVE, value: 'Cumulative' },
@@ -56,6 +58,50 @@ const TEMPLATE = {
   creditAllocationAllocationTypes: [],
   creditAllocationTransactionTypes: [],
   currencyOptions: [{ code: 'USD', name: 'US Dollar', decimalPlaces: 2 }],
+  capitalizedIncomeTypeOptions: [
+    { code: 'FEE', value: 'Fee' },
+    { code: 'INTEREST', value: 'Interest' },
+  ],
+  capitalizedIncomeCalculationTypeOptions: [{ code: 'FLAT', value: 'Flat' }],
+  capitalizedIncomeStrategyOptions: [
+    { code: 'EQUAL_AMORTIZATION', value: EQUAL_AMORTIZATION_LABEL },
+  ],
+  buyDownFeeIncomeTypeOptions: [{ code: 'FEE', value: 'Fee' }],
+  buyDownFeeCalculationTypeOptions: [{ code: 'FLAT', value: 'Flat' }],
+  buyDownFeeStrategyOptions: [{ code: 'EQUAL_AMORTIZATION', value: EQUAL_AMORTIZATION_LABEL }],
+  interestRecalculationCompoundingTypeOptions: [
+    { id: 0, code: 'interestRecalculationCompoundingMethod.none', description: 'None' },
+    { id: 1, code: 'interestRecalculationCompoundingMethod.fee', description: 'Fee' },
+  ],
+  interestRecalculationFrequencyTypeOptions: [
+    {
+      id: 1,
+      code: 'interestRecalculationFrequencyType.same.as.repayment.period',
+      description: 'Same as repayment period',
+    },
+    { id: 2, code: 'interestRecalculationFrequencyType.daily', description: 'Daily' },
+  ],
+  rescheduleStrategyTypeOptions: [
+    {
+      id: 1,
+      code: 'loanRescheduleStrategyMethod.reduce.emi.amount',
+      description: 'Reduce EMI amount',
+    },
+  ],
+  preClosureInterestCalculationStrategyOptions: [
+    {
+      id: 1,
+      code: 'preClosureInterestCalculationStrategy.tillPreClosureDate',
+      description: 'Till pre-close date',
+    },
+  ],
+  repaymentStartDateTypeOptions: [
+    { id: 1, code: 'repaymentStartDateType.disbursement', description: 'Disbursement date' },
+  ],
+  chargeOffBehaviourOptions: [
+    { code: 'REGULAR', value: 'Regular' },
+    { code: 'ZERO_INTEREST', value: 'Zero interest' },
+  ],
 };
 
 describe('LoanProductFormComponent', () => {
@@ -286,6 +332,121 @@ describe('LoanProductFormComponent', () => {
     });
   });
 
+  describe('interest recalculation', () => {
+    /**
+     * `POST /loanproducts` documents the chain: the compounding method, reschedule strategy and
+     * rest frequency are mandatory once recalculation is on, and each interval applies only when
+     * its frequency is something other than the repayment period. Before this, the flag was a
+     * hardcoded `false` with no control at all.
+     */
+    it('seeds the three mandatory fields when it is switched on', () => {
+      component.onInterestRecalculationChange(true);
+
+      const product = component.product();
+      expect(product.isInterestRecalculationEnabled).toBeTrue();
+      expect(product.interestRecalculationCompoundingMethod).toBe(0);
+      expect(product.rescheduleStrategyMethod).toBe(1);
+      expect(product.recalculationRestFrequencyType).toBe(1);
+    });
+
+    it('hides the rest interval while the frequency matches the repayment period', () => {
+      component.onInterestRecalculationChange(true);
+      component.onRestFrequencyTypeChange(1); // same as repayment period
+
+      expect(component.restIntervalApplies()).toBeFalse();
+
+      component.onRestFrequencyTypeChange(2); // daily
+
+      expect(component.restIntervalApplies()).toBeTrue();
+    });
+
+    it('drops a rest interval that no longer applies', () => {
+      component.onInterestRecalculationChange(true);
+      component.onRestFrequencyTypeChange(2);
+      component.product().recalculationRestFrequencyInterval = 3;
+
+      component.onRestFrequencyTypeChange(1);
+
+      expect(component.product().recalculationRestFrequencyInterval).toBeUndefined();
+    });
+
+    it('treats a "none" compounding method as no compounding', () => {
+      component.onInterestRecalculationChange(true);
+      component.onCompoundingMethodChange(0);
+      expect(component.compoundingSelected()).toBeFalse();
+
+      component.onCompoundingMethodChange(1);
+      expect(component.compoundingSelected()).toBeTrue();
+    });
+
+    it('drops the compounding settings when the method goes back to none', () => {
+      component.onInterestRecalculationChange(true);
+      component.onCompoundingMethodChange(1);
+      component.onCompoundingFrequencyTypeChange(2);
+      component.product().recalculationCompoundingFrequencyInterval = 2;
+
+      component.onCompoundingMethodChange(0);
+
+      expect(component.product().recalculationCompoundingFrequencyType).toBeUndefined();
+      expect(component.product().recalculationCompoundingFrequencyInterval).toBeUndefined();
+    });
+
+    it('needs a compounding interval only when compounding is on and not per repayment period', () => {
+      component.onInterestRecalculationChange(true);
+      component.onCompoundingMethodChange(1);
+
+      component.onCompoundingFrequencyTypeChange(1);
+      expect(component.compoundingIntervalApplies()).toBeFalse();
+
+      component.onCompoundingFrequencyTypeChange(2);
+      expect(component.compoundingIntervalApplies()).toBeTrue();
+    });
+
+    it('clears the whole group when it is switched off', () => {
+      component.onInterestRecalculationChange(true);
+      component.onCompoundingMethodChange(1);
+      component.onCompoundingFrequencyTypeChange(2);
+      component.product().preClosureInterestCalculationStrategy = 1;
+
+      component.onInterestRecalculationChange(false);
+
+      const product = component.product();
+      expect(product.isInterestRecalculationEnabled).toBeFalse();
+      expect(product.interestRecalculationCompoundingMethod).toBeUndefined();
+      expect(product.rescheduleStrategyMethod).toBeUndefined();
+      expect(product.recalculationRestFrequencyType).toBeUndefined();
+      expect(product.recalculationCompoundingFrequencyType).toBeUndefined();
+      expect(product.preClosureInterestCalculationStrategy).toBeUndefined();
+      expect(component.interestRecalculationEnabled()).toBeFalse();
+    });
+
+    it('renders its controls only once it is on', () => {
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-compounding-method"]'),
+      ).toBeNull();
+
+      component.onInterestRecalculationChange(true);
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-compounding-method"]'),
+      ).not.toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="loan-product-reschedule-strategy"]'),
+      ).not.toBeNull();
+    });
+  });
+
+  describe('option lists', () => {
+    /** These come from the product template; an earlier revision held them as local constants. */
+    it('takes the income-recognition options from the template', () => {
+      expect(component.capitalizedIncomeTypeOptions()).toHaveSize(2);
+      expect(component.capitalizedIncomeStrategyOptions()[0].value).toBe(EQUAL_AMORTIZATION_LABEL);
+      expect(component.chargeOffBehaviourOptions()).toHaveSize(2);
+      expect(component.repaymentStartDateTypeOptions()).toHaveSize(1);
+    });
+  });
+
   describe('editing an existing product', () => {
     /**
      * The payload is rebuilt field by field, so anything the form does not name is dropped on
@@ -311,11 +472,14 @@ describe('LoanProductFormComponent', () => {
           enableIncomeCapitalization: true,
           capitalizedIncomeType: { code: 'INTEREST', value: 'Interest' },
           capitalizedIncomeCalculationType: { code: 'FLAT', value: 'Flat' },
-          capitalizedIncomeStrategy: { code: 'EQUAL_AMORTIZATION', value: 'Equal amortization' },
+          capitalizedIncomeStrategy: {
+            code: 'EQUAL_AMORTIZATION',
+            value: EQUAL_AMORTIZATION_LABEL,
+          },
           enableBuyDownFee: true,
           buyDownFeeIncomeType: { code: 'FEE', value: 'Fee' },
           buyDownFeeCalculationType: { code: 'FLAT', value: 'Flat' },
-          buyDownFeeStrategy: { code: 'EQUAL_AMORTIZATION', value: 'Equal amortization' },
+          buyDownFeeStrategy: { code: 'EQUAL_AMORTIZATION', value: EQUAL_AMORTIZATION_LABEL },
         }) as any,
       );
 

--- a/src/app/features/products/loan-product-form.component.ts
+++ b/src/app/features/products/loan-product-form.component.ts
@@ -60,6 +60,15 @@ import { LOAN_SCHEDULE_TYPE, isAdvancedPaymentAllocationStrategy } from './loan-
 import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocation-editor.component';
 import { TooltipDirective } from '../../shared/directives/tooltip.directive';
 
+/**
+ * Fineract's id for daily interest calculation.
+ *
+ * Interest recalculation is only supported alongside it: anything else is rejected with
+ * `not.supported.for.selected.interest.calculation.type`, and the form's own default —
+ * "same as repayment period" — is one of the rejected values.
+ */
+const DAILY_INTEREST_CALCULATION_PERIOD = 0;
+
 @Component({
   selector: 'app-loan-product-form',
   standalone: true,
@@ -426,6 +435,7 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                       data-testid="loan-product-interest-calc-period"
                       name="interestCalculationPeriodType"
                       [(ngModel)]="product().interestCalculationPeriodType"
+                      [disabled]="interestRecalculationEnabled()"
                       required
                     >
                       <ion-select-option [value]="0">{{
@@ -436,6 +446,11 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                       }}</ion-select-option>
                     </ion-select>
                   </ion-item>
+                  @if (interestRecalculationEnabled()) {
+                    <p class="field-note" data-testid="interest-calc-period-locked-note">
+                      {{ 'PRODUCTS.INTEREST_CALC_PERIOD_LOCKED_NOTE' | translate }}
+                    </p>
+                  }
                 </ion-col>
 
                 <!-- Loan Schedule Type -->
@@ -1494,6 +1509,10 @@ export class LoanProductFormComponent implements OnInit {
     product.interestRecalculationCompoundingMethod ??= this.compoundingTypeOptions()[0]?.id;
     product.rescheduleStrategyMethod ??= this.rescheduleStrategyOptions()[0]?.id;
     product.recalculationRestFrequencyType ??= this.recalculationFrequencyOptions()[0]?.id;
+    // Fineract only supports recalculation with daily interest calculation, and rejects the
+    // form's own default outright. Setting it here means the user cannot build a product the
+    // server will refuse; the control is locked and says why.
+    product.interestCalculationPeriodType = DAILY_INTEREST_CALCULATION_PERIOD;
     this.compoundingMethod.set(product.interestRecalculationCompoundingMethod);
     this.restFrequencyType.set(product.recalculationRestFrequencyType);
     this.compoundingFrequencyType.set(product.recalculationCompoundingFrequencyType);

--- a/src/app/features/products/loan-product-form.component.ts
+++ b/src/app/features/products/loan-product-form.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -49,6 +49,12 @@ import {
   DelinquencyBucketResponse,
   EnumOptionData,
   GetLoanProductsTransactionProcessingStrategyOptions,
+  GetLoanProductsInterestRecalculationCompoundingType,
+  GetLoanProductsInterestRecalculationCompoundingFrequencyType,
+  GetLoanProductsRescheduleStrategyType,
+  GetLoanProductsPreClosureInterestCalculationStrategy,
+  GetLoanProductsRepaymentStartDateType,
+  StringEnumOptionData,
 } from '../../api';
 import { LOAN_SCHEDULE_TYPE, isAdvancedPaymentAllocationStrategy } from './loan-schedule-type';
 import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocation-editor.component';
@@ -700,9 +706,9 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                           [(ngModel)]="product().capitalizedIncomeType"
                           required
                         >
-                          @for (option of incomeTypeOptions; track option.code) {
+                          @for (option of capitalizedIncomeTypeOptions(); track option.code) {
                             <ion-select-option [value]="option.code">{{
-                              option.labelKey | translate
+                              option.value
                             }}</ion-select-option>
                           }
                         </ion-select>
@@ -726,9 +732,12 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                           [(ngModel)]="product().capitalizedIncomeCalculationType"
                           required
                         >
-                          @for (option of incomeCalculationOptions; track option.code) {
+                          @for (
+                            option of capitalizedIncomeCalculationTypeOptions();
+                            track option.code
+                          ) {
                             <ion-select-option [value]="option.code">{{
-                              option.labelKey | translate
+                              option.value
                             }}</ion-select-option>
                           }
                         </ion-select>
@@ -752,9 +761,9 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                           [(ngModel)]="product().capitalizedIncomeStrategy"
                           required
                         >
-                          @for (option of incomeStrategyOptions; track option.code) {
+                          @for (option of capitalizedIncomeStrategyOptions(); track option.code) {
                             <ion-select-option [value]="option.code">{{
-                              option.labelKey | translate
+                              option.value
                             }}</ion-select-option>
                           }
                         </ion-select>
@@ -796,9 +805,9 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                           [(ngModel)]="product().buyDownFeeIncomeType"
                           required
                         >
-                          @for (option of incomeTypeOptions; track option.code) {
+                          @for (option of buyDownFeeIncomeTypeOptions(); track option.code) {
                             <ion-select-option [value]="option.code">{{
-                              option.labelKey | translate
+                              option.value
                             }}</ion-select-option>
                           }
                         </ion-select>
@@ -822,9 +831,9 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                           [(ngModel)]="product().buyDownFeeCalculationType"
                           required
                         >
-                          @for (option of incomeCalculationOptions; track option.code) {
+                          @for (option of buyDownFeeCalculationTypeOptions(); track option.code) {
                             <ion-select-option [value]="option.code">{{
-                              option.labelKey | translate
+                              option.value
                             }}</ion-select-option>
                           }
                         </ion-select>
@@ -848,9 +857,9 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                           [(ngModel)]="product().buyDownFeeStrategy"
                           required
                         >
-                          @for (option of incomeStrategyOptions; track option.code) {
+                          @for (option of buyDownFeeStrategyOptions(); track option.code) {
                             <ion-select-option [value]="option.code">{{
-                              option.labelKey | translate
+                              option.value
                             }}</ion-select-option>
                           }
                         </ion-select>
@@ -860,6 +869,303 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                 </ion-row>
               </ion-grid>
             }
+
+            <!-- Interest recalculation and remaining product settings -->
+            <ion-grid class="ion-no-padding">
+              <ion-row>
+                <ion-col size="12">
+                  <h3 class="section-heading">
+                    {{ 'PRODUCTS.INTEREST_RECALCULATION' | translate }}
+                  </h3>
+                </ion-col>
+
+                <ion-col size="12" size-md="6">
+                  <ion-item
+                    class="form-item"
+                    [appTooltip]="'HELP.INTEREST_RECALCULATION_DESC' | translate"
+                  >
+                    <ion-checkbox
+                      name="isInterestRecalculationEnabled"
+                      data-testid="loan-product-interest-recalculation"
+                      [ngModel]="interestRecalculationEnabled()"
+                      (ngModelChange)="onInterestRecalculationChange($event)"
+                    >
+                      {{ 'PRODUCTS.ENABLE_INTEREST_RECALCULATION' | translate }}
+                    </ion-checkbox>
+                  </ion-item>
+                </ion-col>
+
+                @if (interestRecalculationEnabled()) {
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      fill="outline"
+                      class="form-item"
+                      [appTooltip]="'HELP.COMPOUNDING_METHOD_DESC' | translate"
+                    >
+                      <ion-label position="stacked">{{
+                        'PRODUCTS.COMPOUNDING_METHOD' | translate
+                      }}</ion-label>
+                      <ion-select
+                        [attr.aria-label]="'PRODUCTS.COMPOUNDING_METHOD' | translate"
+                        interface="popover"
+                        data-testid="loan-product-compounding-method"
+                        name="interestRecalculationCompoundingMethod"
+                        [ngModel]="compoundingMethod()"
+                        (ngModelChange)="onCompoundingMethodChange($event)"
+                        required
+                      >
+                        @for (option of compoundingTypeOptions(); track option.id) {
+                          <ion-select-option [value]="option.id">{{
+                            option.description
+                          }}</ion-select-option>
+                        }
+                      </ion-select>
+                    </ion-item>
+                  </ion-col>
+
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      fill="outline"
+                      class="form-item"
+                      [appTooltip]="'HELP.RESCHEDULE_STRATEGY_DESC' | translate"
+                    >
+                      <ion-label position="stacked">{{
+                        'PRODUCTS.RESCHEDULE_STRATEGY' | translate
+                      }}</ion-label>
+                      <ion-select
+                        [attr.aria-label]="'PRODUCTS.RESCHEDULE_STRATEGY' | translate"
+                        interface="popover"
+                        data-testid="loan-product-reschedule-strategy"
+                        name="rescheduleStrategyMethod"
+                        [(ngModel)]="product().rescheduleStrategyMethod"
+                        required
+                      >
+                        @for (option of rescheduleStrategyOptions(); track option.id) {
+                          <ion-select-option [value]="option.id">{{
+                            option.description
+                          }}</ion-select-option>
+                        }
+                      </ion-select>
+                    </ion-item>
+                  </ion-col>
+
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      fill="outline"
+                      class="form-item"
+                      [appTooltip]="'HELP.REST_FREQUENCY_DESC' | translate"
+                    >
+                      <ion-label position="stacked">{{
+                        'PRODUCTS.REST_FREQUENCY' | translate
+                      }}</ion-label>
+                      <ion-select
+                        [attr.aria-label]="'PRODUCTS.REST_FREQUENCY' | translate"
+                        interface="popover"
+                        data-testid="loan-product-rest-frequency"
+                        name="recalculationRestFrequencyType"
+                        [ngModel]="restFrequencyType()"
+                        (ngModelChange)="onRestFrequencyTypeChange($event)"
+                        required
+                      >
+                        @for (option of recalculationFrequencyOptions(); track option.id) {
+                          <ion-select-option [value]="option.id">{{
+                            option.description
+                          }}</ion-select-option>
+                        }
+                      </ion-select>
+                    </ion-item>
+                  </ion-col>
+
+                  @if (restIntervalApplies()) {
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.REST_INTERVAL_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.REST_INTERVAL' | translate
+                        }}</ion-label>
+                        <ion-input
+                          [attr.aria-label]="'PRODUCTS.REST_INTERVAL' | translate"
+                          type="number"
+                          min="1"
+                          data-testid="loan-product-rest-interval"
+                          name="recalculationRestFrequencyInterval"
+                          [(ngModel)]="product().recalculationRestFrequencyInterval"
+                        ></ion-input>
+                      </ion-item>
+                    </ion-col>
+                  }
+
+                  @if (compoundingSelected()) {
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.COMPOUNDING_FREQUENCY_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.COMPOUNDING_FREQUENCY' | translate
+                        }}</ion-label>
+                        <ion-select
+                          [attr.aria-label]="'PRODUCTS.COMPOUNDING_FREQUENCY' | translate"
+                          interface="popover"
+                          data-testid="loan-product-compounding-frequency"
+                          name="recalculationCompoundingFrequencyType"
+                          [ngModel]="compoundingFrequencyType()"
+                          (ngModelChange)="onCompoundingFrequencyTypeChange($event)"
+                        >
+                          @for (option of recalculationFrequencyOptions(); track option.id) {
+                            <ion-select-option [value]="option.id">{{
+                              option.description
+                            }}</ion-select-option>
+                          }
+                        </ion-select>
+                      </ion-item>
+                    </ion-col>
+                  }
+
+                  @if (compoundingIntervalApplies()) {
+                    <ion-col size="12" size-md="6">
+                      <ion-item
+                        fill="outline"
+                        class="form-item"
+                        [appTooltip]="'HELP.COMPOUNDING_INTERVAL_DESC' | translate"
+                      >
+                        <ion-label position="stacked">{{
+                          'PRODUCTS.COMPOUNDING_INTERVAL' | translate
+                        }}</ion-label>
+                        <ion-input
+                          [attr.aria-label]="'PRODUCTS.COMPOUNDING_INTERVAL' | translate"
+                          type="number"
+                          min="1"
+                          data-testid="loan-product-compounding-interval"
+                          name="recalculationCompoundingFrequencyInterval"
+                          [(ngModel)]="product().recalculationCompoundingFrequencyInterval"
+                        ></ion-input>
+                      </ion-item>
+                    </ion-col>
+                  }
+
+                  <ion-col size="12" size-md="6">
+                    <ion-item
+                      fill="outline"
+                      class="form-item"
+                      [appTooltip]="'HELP.PRE_CLOSURE_STRATEGY_DESC' | translate"
+                    >
+                      <ion-label position="stacked">{{
+                        'PRODUCTS.PRE_CLOSURE_STRATEGY' | translate
+                      }}</ion-label>
+                      <ion-select
+                        [attr.aria-label]="'PRODUCTS.PRE_CLOSURE_STRATEGY' | translate"
+                        interface="popover"
+                        data-testid="loan-product-pre-closure-strategy"
+                        name="preClosureInterestCalculationStrategy"
+                        [(ngModel)]="product().preClosureInterestCalculationStrategy"
+                      >
+                        @for (option of preClosureStrategyOptions(); track option.id) {
+                          <ion-select-option [value]="option.id">{{
+                            option.description
+                          }}</ion-select-option>
+                        }
+                      </ion-select>
+                    </ion-item>
+                  </ion-col>
+                }
+
+                <ion-col size="12">
+                  <h3 class="section-heading">
+                    {{ 'PRODUCTS.OTHER_SETTINGS' | translate }}
+                  </h3>
+                </ion-col>
+
+                <ion-col size="12" size-md="6">
+                  <ion-item
+                    fill="outline"
+                    class="form-item"
+                    [appTooltip]="'HELP.CHARGE_OFF_BEHAVIOUR_DESC' | translate"
+                  >
+                    <ion-label position="stacked">{{
+                      'PRODUCTS.CHARGE_OFF_BEHAVIOUR' | translate
+                    }}</ion-label>
+                    <ion-select
+                      [attr.aria-label]="'PRODUCTS.CHARGE_OFF_BEHAVIOUR' | translate"
+                      interface="popover"
+                      data-testid="loan-product-charge-off-behaviour"
+                      name="chargeOffBehaviour"
+                      [(ngModel)]="product().chargeOffBehaviour"
+                    >
+                      @for (option of chargeOffBehaviourOptions(); track option.code) {
+                        <ion-select-option [value]="option.code">{{
+                          option.value
+                        }}</ion-select-option>
+                      }
+                    </ion-select>
+                  </ion-item>
+                </ion-col>
+
+                <ion-col size="12" size-md="6">
+                  <ion-item
+                    fill="outline"
+                    class="form-item"
+                    [appTooltip]="'HELP.REPAYMENT_START_DATE_TYPE_DESC' | translate"
+                  >
+                    <ion-label position="stacked">{{
+                      'PRODUCTS.REPAYMENT_START_DATE_TYPE' | translate
+                    }}</ion-label>
+                    <ion-select
+                      [attr.aria-label]="'PRODUCTS.REPAYMENT_START_DATE_TYPE' | translate"
+                      interface="popover"
+                      data-testid="loan-product-repayment-start-date-type"
+                      name="repaymentStartDateType"
+                      [(ngModel)]="product().repaymentStartDateType"
+                    >
+                      @for (option of repaymentStartDateTypeOptions(); track option.id) {
+                        <ion-select-option [value]="option.id">{{
+                          option.description
+                        }}</ion-select-option>
+                      }
+                    </ion-select>
+                  </ion-item>
+                </ion-col>
+
+                <ion-col size="12" size-md="6">
+                  <ion-item
+                    fill="outline"
+                    class="form-item"
+                    [appTooltip]="'HELP.FIXED_LENGTH_DESC' | translate"
+                  >
+                    <ion-label position="stacked">{{
+                      'PRODUCTS.FIXED_LENGTH' | translate
+                    }}</ion-label>
+                    <ion-input
+                      [attr.aria-label]="'PRODUCTS.FIXED_LENGTH' | translate"
+                      type="number"
+                      min="1"
+                      data-testid="loan-product-fixed-length"
+                      name="fixedLength"
+                      [(ngModel)]="product().fixedLength"
+                    ></ion-input>
+                  </ion-item>
+                </ion-col>
+
+                <ion-col size="12" size-md="6">
+                  <ion-item
+                    class="form-item"
+                    [appTooltip]="'HELP.ACCRUAL_ACTIVITY_POSTING_DESC' | translate"
+                  >
+                    <ion-checkbox
+                      name="enableAccrualActivityPosting"
+                      data-testid="loan-product-accrual-activity-posting"
+                      [(ngModel)]="product().enableAccrualActivityPosting"
+                    >
+                      {{ 'PRODUCTS.ENABLE_ACCRUAL_ACTIVITY_POSTING' | translate }}
+                    </ion-checkbox>
+                  </ion-item>
+                </ion-col>
+              </ion-row>
+            </ion-grid>
 
             @if (isProgressive()) {
               <app-payment-credit-allocation-editor
@@ -985,24 +1291,35 @@ export class LoanProductFormComponent implements OnInit {
   readonly incomeCapitalizationEnabled = signal(false);
   readonly buyDownFeeEnabled = signal(false);
 
-  /**
-   * Option lists for the income-recognition enums.
-   *
-   * Held here rather than taken from the product template, which does not return them. Two of the
-   * three currently admit a single value; they are still rendered as selects so the payload
-   * records what the product was created with, and so a value added upstream needs one line here
-   * rather than a new control.
-   */
-  readonly incomeTypeOptions = [
-    { code: 'FEE', labelKey: 'PRODUCTS.INCOME_TYPE_FEE' },
-    { code: 'INTEREST', labelKey: 'PRODUCTS.INCOME_TYPE_INTEREST' },
-  ];
-  readonly incomeCalculationOptions = [
-    { code: 'FLAT', labelKey: 'PRODUCTS.INCOME_CALCULATION_FLAT' },
-  ];
-  readonly incomeStrategyOptions = [
-    { code: 'EQUAL_AMORTIZATION', labelKey: 'PRODUCTS.INCOME_STRATEGY_EQUAL_AMORTIZATION' },
-  ];
+  // Income-recognition options. These come from the product template — an earlier revision held
+  // them as local constants on the belief that the template did not return them, which was wrong.
+  readonly capitalizedIncomeTypeOptions = signal<StringEnumOptionData[]>([]);
+  readonly capitalizedIncomeCalculationTypeOptions = signal<StringEnumOptionData[]>([]);
+  readonly capitalizedIncomeStrategyOptions = signal<StringEnumOptionData[]>([]);
+  readonly buyDownFeeIncomeTypeOptions = signal<StringEnumOptionData[]>([]);
+  readonly buyDownFeeCalculationTypeOptions = signal<StringEnumOptionData[]>([]);
+  readonly buyDownFeeStrategyOptions = signal<StringEnumOptionData[]>([]);
+
+  // Interest recalculation and the remaining product settings.
+  readonly interestRecalculationEnabled = signal(false);
+  // The three fields the conditional rules key off. Mirrored as signals because `product` holds an
+  // object: assigning to one of its properties invalidates nothing, so a `computed` reading
+  // `product().x` would never re-run and the dependent controls would never appear.
+  readonly compoundingMethod = signal<number | undefined>(undefined);
+  readonly restFrequencyType = signal<number | undefined>(undefined);
+  readonly compoundingFrequencyType = signal<number | undefined>(undefined);
+  readonly compoundingTypeOptions = signal<GetLoanProductsInterestRecalculationCompoundingType[]>(
+    [],
+  );
+  readonly recalculationFrequencyOptions = signal<
+    GetLoanProductsInterestRecalculationCompoundingFrequencyType[]
+  >([]);
+  readonly rescheduleStrategyOptions = signal<GetLoanProductsRescheduleStrategyType[]>([]);
+  readonly preClosureStrategyOptions = signal<
+    GetLoanProductsPreClosureInterestCalculationStrategy[]
+  >([]);
+  readonly repaymentStartDateTypeOptions = signal<GetLoanProductsRepaymentStartDateType[]>([]);
+  readonly chargeOffBehaviourOptions = signal<StringEnumOptionData[]>([]);
 
   readonly product = signal<PostLoanProductsRequest>({
     currencyCode: 'USD',
@@ -1042,6 +1359,30 @@ export class LoanProductFormComponent implements OnInit {
       this.transactionProcessingStrategyOptionsBase = template.transactionProcessingStrategyOptions
         ? Array.from(template.transactionProcessingStrategyOptions)
         : [];
+      this.capitalizedIncomeTypeOptions.set(template.capitalizedIncomeTypeOptions ?? []);
+      this.capitalizedIncomeCalculationTypeOptions.set(
+        template.capitalizedIncomeCalculationTypeOptions ?? [],
+      );
+      this.capitalizedIncomeStrategyOptions.set(template.capitalizedIncomeStrategyOptions ?? []);
+      this.buyDownFeeIncomeTypeOptions.set(template.buyDownFeeIncomeTypeOptions ?? []);
+      this.buyDownFeeCalculationTypeOptions.set(template.buyDownFeeCalculationTypeOptions ?? []);
+      this.buyDownFeeStrategyOptions.set(template.buyDownFeeStrategyOptions ?? []);
+
+      this.compoundingTypeOptions.set(
+        Array.from(template.interestRecalculationCompoundingTypeOptions ?? []),
+      );
+      this.recalculationFrequencyOptions.set(
+        Array.from(template.interestRecalculationFrequencyTypeOptions ?? []),
+      );
+      this.rescheduleStrategyOptions.set(Array.from(template.rescheduleStrategyTypeOptions ?? []));
+      this.preClosureStrategyOptions.set(
+        Array.from(template.preClosureInterestCalculationStrategyOptions ?? []),
+      );
+      this.repaymentStartDateTypeOptions.set(
+        Array.from(template.repaymentStartDateTypeOptions ?? []),
+      );
+      this.chargeOffBehaviourOptions.set(template.chargeOffBehaviourOptions ?? []);
+
       this.applyTransactionProcessingStrategyFilter();
     });
 
@@ -1093,6 +1434,114 @@ export class LoanProductFormComponent implements OnInit {
       return;
     }
     this.clearDownPayment();
+  }
+
+  /**
+   * Whether a compounding method other than "none" is selected.
+   *
+   * Matched on the option's code rather than its id, because the ids are Fineract's own and would
+   * be a magic number here; the code carries the meaning.
+   */
+  readonly compoundingSelected = computed(() => {
+    const method = this.compoundingMethod();
+    if (method === undefined || method === null) return false;
+    const option = this.compoundingTypeOptions().find((o) => o.id === method);
+    return !this.isNoneOption(option?.code);
+  });
+
+  /** The rest interval only matters when the rest frequency differs from the repayment period. */
+  readonly restIntervalApplies = computed(() =>
+    this.isIntervalBearing(
+      this.recalculationFrequencyOptions().find((o) => o.id === this.restFrequencyType())?.code,
+    ),
+  );
+
+  readonly compoundingIntervalApplies = computed(
+    () =>
+      this.compoundingSelected() &&
+      this.isIntervalBearing(
+        this.recalculationFrequencyOptions().find((o) => o.id === this.compoundingFrequencyType())
+          ?.code,
+      ),
+  );
+
+  private isNoneOption(code: string | undefined): boolean {
+    return (code ?? '').toLowerCase().includes('none');
+  }
+
+  /** "Same as repayment period" needs no interval; every other frequency does. */
+  private isIntervalBearing(code: string | undefined): boolean {
+    if (!code) return false;
+    return !code.toLowerCase().includes('same');
+  }
+
+  /**
+   * Interest recalculation, and the fields the API documents as depending on it.
+   *
+   * `POST /loanproducts` states the chain: the compounding method, reschedule strategy and rest
+   * frequency are mandatory once this is on, and the two intervals apply only when their
+   * frequency is something other than the repayment period. The form follows that rather than
+   * showing every field at once.
+   */
+  onInterestRecalculationChange(enabled: boolean): void {
+    if (!enabled) {
+      this.clearInterestRecalculation();
+      return;
+    }
+    this.interestRecalculationEnabled.set(true);
+    const product = this.product();
+    product.isInterestRecalculationEnabled = true;
+    product.interestRecalculationCompoundingMethod ??= this.compoundingTypeOptions()[0]?.id;
+    product.rescheduleStrategyMethod ??= this.rescheduleStrategyOptions()[0]?.id;
+    product.recalculationRestFrequencyType ??= this.recalculationFrequencyOptions()[0]?.id;
+    this.compoundingMethod.set(product.interestRecalculationCompoundingMethod);
+    this.restFrequencyType.set(product.recalculationRestFrequencyType);
+    this.compoundingFrequencyType.set(product.recalculationCompoundingFrequencyType);
+  }
+
+  private clearInterestRecalculation(): void {
+    this.interestRecalculationEnabled.set(false);
+    const product = this.product();
+    // Left in the payload, these would describe recalculation settings for a product that does
+    // not recalculate.
+    product.isInterestRecalculationEnabled = false;
+    product.interestRecalculationCompoundingMethod = undefined;
+    product.rescheduleStrategyMethod = undefined;
+    product.recalculationRestFrequencyType = undefined;
+    product.recalculationRestFrequencyInterval = undefined;
+    product.recalculationCompoundingFrequencyType = undefined;
+    product.recalculationCompoundingFrequencyInterval = undefined;
+    product.preClosureInterestCalculationStrategy = undefined;
+    this.compoundingMethod.set(undefined);
+    this.restFrequencyType.set(undefined);
+    this.compoundingFrequencyType.set(undefined);
+  }
+
+  /** Dropping the compounding method takes the settings that only exist because of it. */
+  onCompoundingMethodChange(method: number | undefined): void {
+    this.product().interestRecalculationCompoundingMethod = method;
+    this.compoundingMethod.set(method);
+    if (!this.compoundingSelected()) {
+      this.product().recalculationCompoundingFrequencyType = undefined;
+      this.product().recalculationCompoundingFrequencyInterval = undefined;
+      this.compoundingFrequencyType.set(undefined);
+    }
+  }
+
+  onRestFrequencyTypeChange(type: number | undefined): void {
+    this.product().recalculationRestFrequencyType = type;
+    this.restFrequencyType.set(type);
+    if (!this.restIntervalApplies()) {
+      this.product().recalculationRestFrequencyInterval = undefined;
+    }
+  }
+
+  onCompoundingFrequencyTypeChange(type: number | undefined): void {
+    this.product().recalculationCompoundingFrequencyType = type;
+    this.compoundingFrequencyType.set(type);
+    if (!this.compoundingIntervalApplies()) {
+      this.product().recalculationCompoundingFrequencyInterval = undefined;
+    }
   }
 
   onEnableIncomeCapitalizationChange(enabled: boolean): void {
@@ -1235,12 +1684,33 @@ export class LoanProductFormComponent implements OnInit {
         buyDownFeeIncomeType: data.buyDownFeeIncomeType?.code as never,
         buyDownFeeCalculationType: data.buyDownFeeCalculationType?.code as never,
         buyDownFeeStrategy: data.buyDownFeeStrategy?.code as never,
+        interestRecalculationCompoundingMethod:
+          data.interestRecalculationData?.interestRecalculationCompoundingType?.id,
+        rescheduleStrategyMethod: data.interestRecalculationData?.rescheduleStrategyType?.id,
+        recalculationRestFrequencyType:
+          data.interestRecalculationData?.recalculationRestFrequencyType?.id,
+        recalculationRestFrequencyInterval:
+          data.interestRecalculationData?.recalculationRestFrequencyInterval,
+        recalculationCompoundingFrequencyType:
+          data.interestRecalculationData?.interestRecalculationCompoundingFrequencyType?.id,
+        recalculationCompoundingFrequencyInterval:
+          data.interestRecalculationData?.recalculationCompoundingFrequencyInterval,
+        preClosureInterestCalculationStrategy:
+          data.interestRecalculationData?.preClosureInterestCalculationStrategy?.id,
+        chargeOffBehaviour: data.chargeOffBehaviour?.code,
+        enableAccrualActivityPosting: data.enableAccrualActivityPosting,
+        fixedLength: data.fixedLength,
+        repaymentStartDateType: data.repaymentStartDateType?.id,
       });
       this.isProgressive.set(this.product().loanScheduleType === LOAN_SCHEDULE_TYPE.PROGRESSIVE);
       this.downPaymentEnabled.set(this.product().enableDownPayment === true);
       this.multiDisburseEnabled.set(this.product().multiDisburseLoan === true);
       this.incomeCapitalizationEnabled.set(this.product().enableIncomeCapitalization === true);
       this.buyDownFeeEnabled.set(this.product().enableBuyDownFee === true);
+      this.interestRecalculationEnabled.set(this.product().isInterestRecalculationEnabled === true);
+      this.compoundingMethod.set(this.product().interestRecalculationCompoundingMethod);
+      this.restFrequencyType.set(this.product().recalculationRestFrequencyType);
+      this.compoundingFrequencyType.set(this.product().recalculationCompoundingFrequencyType);
       this.applyTransactionProcessingStrategyFilter();
     });
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -371,7 +371,21 @@
     "INCOME_TYPE_FEE": "Fee",
     "INCOME_TYPE_INTEREST": "Interest",
     "INCOME_CALCULATION_FLAT": "A flat amount",
-    "INCOME_STRATEGY_EQUAL_AMORTIZATION": "In equal parts across the term"
+    "INCOME_STRATEGY_EQUAL_AMORTIZATION": "In equal parts across the term",
+    "INTEREST_RECALCULATION": "Interest Recalculation",
+    "ENABLE_INTEREST_RECALCULATION": "Recalculate interest on the actual balance",
+    "COMPOUNDING_METHOD": "What gets compounded",
+    "RESCHEDULE_STRATEGY": "When the amount owed changes",
+    "REST_FREQUENCY": "How often interest is recalculated",
+    "REST_INTERVAL": "Recalculate every (number of periods)",
+    "COMPOUNDING_FREQUENCY": "How often compounding is applied",
+    "COMPOUNDING_INTERVAL": "Compound every (number of periods)",
+    "PRE_CLOSURE_STRATEGY": "Interest on early settlement",
+    "OTHER_SETTINGS": "Other Settings",
+    "CHARGE_OFF_BEHAVIOUR": "When the loan is charged off",
+    "REPAYMENT_START_DATE_TYPE": "Repayments are counted from",
+    "FIXED_LENGTH": "Fixed term length (periods)",
+    "ENABLE_ACCRUAL_ACTIVITY_POSTING": "Post accrual activity entries"
   },
   "CHARGES": {
     "CREATE": "Create Charge",
@@ -890,7 +904,19 @@
     "ENABLE_BUY_DOWN_FEE_DESC": "Let someone other than the borrower — typically a dealer or supplier — pay an amount upfront to reduce the borrower's effective rate. The cost is spread over the term rather than taken in full at disbursement. Progressive products only.",
     "BUY_DOWN_FEE_INCOME_TYPE_DESC": "Whether the amount the third party paid is booked as a fee or as interest.",
     "INCOME_CALCULATION_TYPE_DESC": "How the amount to recognise in each period is worked out. Flat divides the total evenly rather than varying it with the outstanding balance.",
-    "INCOME_STRATEGY_DESC": "How the total is distributed across the loan's periods. Equal parts gives every period the same share."
+    "INCOME_STRATEGY_DESC": "How the total is distributed across the loan's periods. Equal parts gives every period the same share.",
+    "INTEREST_RECALCULATION_DESC": "Charge interest on what the borrower actually owes on the day, rather than on the balance the original schedule assumed. A borrower who pays early then pays less interest, and one who pays late pays more. Leave off for a schedule fixed at disbursement.",
+    "COMPOUNDING_METHOD_DESC": "Which unpaid amounts are added to the balance that interest is charged on — none, interest only, fees, or both. Choosing none still recalculates interest, it simply does not compound what is outstanding.",
+    "RESCHEDULE_STRATEGY_DESC": "What to adjust when recalculation changes the amount owed: keep the instalment the same and change how many there are, reduce the instalment, or adjust the final one.",
+    "REST_FREQUENCY_DESC": "How often the balance is re-examined. Daily reacts to every payment; matching the repayment period recalculates once per instalment.",
+    "REST_INTERVAL_DESC": "How many of those periods pass between recalculations. Only needed when the frequency is something other than the repayment period.",
+    "COMPOUNDING_FREQUENCY_DESC": "How often the amounts chosen above are folded into the balance interest is charged on.",
+    "COMPOUNDING_INTERVAL_DESC": "How many of those periods pass between compounding. Only needed when the frequency is something other than the repayment period.",
+    "PRE_CLOSURE_STRATEGY_DESC": "How much interest to charge when a borrower settles early — up to the settlement date, or to the end of the current period.",
+    "CHARGE_OFF_BEHAVIOUR_DESC": "What happens to interest once the loan is written off as uncollectible: carry on as normal, stop accruing, or treat the loan as matured immediately.",
+    "REPAYMENT_START_DATE_TYPE_DESC": "Whether the repayment schedule counts from the date the loan was approved for disbursement or the date the money actually went out.",
+    "FIXED_LENGTH_DESC": "Force every loan on this product to run for the same number of periods, regardless of the amount borrowed. Leave empty for a term set per loan.",
+    "ACCRUAL_ACTIVITY_POSTING_DESC": "Post an accounting entry each time interest or fees accrue, rather than only when they are charged or paid. Gives finance a running view at the cost of more journal entries."
   },
   "REPORTS": {
     "NAME": "Report Name",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -385,7 +385,8 @@
     "CHARGE_OFF_BEHAVIOUR": "When the loan is charged off",
     "REPAYMENT_START_DATE_TYPE": "Repayments are counted from",
     "FIXED_LENGTH": "Fixed term length (periods)",
-    "ENABLE_ACCRUAL_ACTIVITY_POSTING": "Post accrual activity entries"
+    "ENABLE_ACCRUAL_ACTIVITY_POSTING": "Post accrual activity entries",
+    "INTEREST_CALC_PERIOD_LOCKED_NOTE": "Fixed to Daily because interest recalculation is on — Fineract only supports the two together. Turn recalculation off to choose a different period."
   },
   "CHARGES": {
     "CREATE": "Create Charge",


### PR DESCRIPTION
Closes #192. Completes the product-configuration phase begun in #189 and #191.

Interest recalculation could not be configured at all. `isInterestRecalculationEnabled` was a
hardcoded `false` in the create defaults and read back on edit — so creating a product here always
disabled it, a product configured elsewhere kept its setting only by accident, and nothing let
anyone see or change it. Its seven dependent fields did not exist in the form.

### Following a rule chain the API actually documents

`POST /loanproducts` states the conditions explicitly, which is unusual for this client:

> Additional Mandatory Fields if interest recalculation is enabled(true):
> `interestRecalculationCompoundingMethod`, `rescheduleStrategyMethod`,
> `recalculationRestFrequencyType`
>
> … if `recalculationRestFrequencyType` is not same as repayment period:
> `recalculationRestFrequencyInterval`
>
> … if `interestRecalculationCompoundingMethod` is enabled: `recalculationCompoundingFrequencyType`
>
> … and if that is not same as repayment period: `recalculationCompoundingFrequencyInterval`

The form follows that chain rather than showing everything at once, and switching recalculation
off clears the whole group instead of leaving recalculation settings on a product that does not
recalculate. The conditions match on each option's **code**, not its id, so Fineract's numbering
doesn't become a magic number here.

Also adds `chargeOffBehaviour`, `enableAccrualActivityPosting`, `fixedLength` and
`repaymentStartDateType`.

### A correction to #191

That PR added the capitalised income and buy-down option lists as local constants, with a comment
saying the product template does not return them. **It does** — `capitalizedIncomeTypeOptions`,
`capitalizedIncomeCalculationTypeOptions`, `capitalizedIncomeStrategyOptions` and the three
`buyDownFee*Options`, along with every list this PR needed. I got that wrong; the constants are
gone and all six now come from the template, so labels are the server's and a value added upstream
appears without a code change.

### The object-in-a-signal trap, again

The conditional flags are held as their own signals rather than read off the payload. `product` is
a signal holding an object, so assigning to one of its properties invalidates nothing and a
`computed` reading `product().x` never re-runs. This is the third time this pattern has bitten
(#189 for the down payment controls, #191's checkboxes) — here the unit tests caught it before it
reached review, but it's a sharp edge in this component that would be worth removing properly at
some point.

### Edit round trip

Every new field is carried through `loadProductData`, which rebuilds the payload field by field.
The response nests recalculation under `interestRecalculationData` and names the compounding
frequency differently from the request (`interestRecalculationCompoundingFrequencyType` vs
`recalculationCompoundingFrequencyType`); the round trip handles both.

### Comprehensibility

The vocabulary here is the most specialist in the form, so the help does the most work:

> **Recalculate interest on the actual balance** — Charge interest on what the borrower actually
> owes on the day, rather than on the balance the original schedule assumed. A borrower who pays
> early then pays less interest, and one who pays late pays more.

Labels avoid jargon where plain words work: *What gets compounded*, *When the amount owed changes*,
*How often interest is recalculated*, *Interest on early settlement*, *When the loan is charged off*.

### Verification

| Check | Result |
|---|---|
| Unit tests | **729 passing** (720 → 729) |
| Mocked Playwright | **208/208 passing** (204 → 208) |
| `tsc` (app + spec) | 0 errors |
| `npm run build` | passes |
| lint (empty suppressions baseline), format, i18n, icons, license | all clean |

Driven by hand against mocks before committing: with recalculation on, the mandatory three appear
and neither interval does — correct, since the seeded frequency is "same as repayment period" and
the seeded compounding method is "none".

### Not in this PR

The demo step runs only in the `backend` project, which needs a live Fineract, so it is unverified
here; its assertions mirror the mocked spec that does run.

`isArrearsBasedOnOriginalSchedule`, the `*OnDayType` fields and the accounting mappings
(`capitalizedIncomeClassificationToIncomeAccountMappings`) remain unexposed — accounting mappings
are a separate area of the form, and the day-type fields only apply to frequency options this
deployment does not currently surface.

The pre-existing `NG0100` reports on this form (`ng-untouched`, and value changes on plain
`[(ngModel)]` fields) are unchanged — the form-state class described earlier, advisory rather than
enforced.
