### PR TITLE
fix(security): close the four blocking GA readiness gates

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -22,6 +22,26 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Security headers.
+    #
+    # `always` matters: without it nginx omits these on error responses, which is exactly where
+    # a reflected payload would land.
+    #
+    # The CSP has no 'unsafe-eval'. Angular's AOT build does not need it, and admitting it would
+    # give any injected string a route to execution. 'unsafe-inline' remains for styles only:
+    # Angular emits component styles inline, and there is no nonce plumbed through this static
+    # server. Scripts do not get it.
+    #
+    # connect-src allows the same origin only. A deployment whose Fineract lives on another host
+    # must add that origin here as well as to `allowedApiOrigins` in config.json — the two are
+    # deliberately separate, so a browser-side setting alone cannot open a new destination.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    # Only honoured over HTTPS; harmless on the plain-HTTP listener and correct once terminated.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     # Gzip Compression
     gzip on;
     gzip_http_version 1.1;

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -24,11 +24,6 @@
       "count": 4
     }
   },
-  "src/app/core/services/config.service.spec.ts": {
-    "no-restricted-globals": {
-      "count": 4
-    }
-  },
   "src/app/core/services/institution-config.service.spec.ts": {
     "no-restricted-globals": {
       "count": 5

--- a/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -23,11 +23,14 @@ import { authInterceptor } from './auth.interceptor';
 import { AuthService } from '../services/auth.service';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
+import { provideTestConfig } from '../../testing/config';
 
 describe('authInterceptor', () => {
   let authServiceSpy: jasmine.SpyObj<AuthService>;
   const testUrl = '/test';
   const testTenant = 'test-tenant';
+  const foreignUrl = 'https://vendor.example.com/collect';
+  const TENANT_HEADER = 'Fineract-Platform-TenantId';
 
   beforeEach(() => {
     authServiceSpy = jasmine.createSpyObj('AuthService', ['getAuthToken'], {
@@ -35,7 +38,7 @@ describe('authInterceptor', () => {
     });
 
     TestBed.configureTestingModule({
-      providers: [{ provide: AuthService, useValue: authServiceSpy }],
+      providers: [{ provide: AuthService, useValue: authServiceSpy }, provideTestConfig()],
     });
   });
 
@@ -43,7 +46,7 @@ describe('authInterceptor', () => {
     authServiceSpy.getAuthToken.and.returnValue(null);
     const request = new HttpRequest('GET', testUrl);
     const next: HttpHandlerFn = (req) => {
-      expect(req.headers.get('Fineract-Platform-TenantId')).toBe(testTenant);
+      expect(req.headers.get(TENANT_HEADER)).toBe(testTenant);
       expect(req.headers.get('X-Mifos-Platform-TenantId')).toBe(testTenant);
       return of(new HttpResponse({ status: 200 }));
     };
@@ -81,13 +84,62 @@ describe('authInterceptor', () => {
       },
     );
     const next: HttpHandlerFn = (req) => {
-      expect(req.headers.get('Fineract-Platform-TenantId')).toBe(loginTenant);
+      expect(req.headers.get(TENANT_HEADER)).toBe(loginTenant);
       expect(req.headers.get('X-Mifos-Platform-TenantId')).toBe(loginTenant);
       return of(new HttpResponse({ status: 200 }));
     };
 
     TestBed.runInInjectionContext(() => {
       authInterceptor(request, next).subscribe(() => done());
+    });
+  });
+
+  /**
+   * Credentials must not leave the API's origin. Nothing in the application calls a third party
+   * today, which is why this is cheap now: the first analytics pixel or vendor SDK sharing this
+   * `HttpClient` would otherwise ship a Basic header carrying banking credentials to it.
+   */
+  describe('destination scoping', () => {
+    // Deliberately not base64-shaped. A realistic-looking encoded credential here trips secret
+    // scanners, and the assertions only care that the header echoes whatever the service returned.
+    const token = 'fake-token-for-tests';
+
+    function headersFor(url: string): Promise<HttpHeaders> {
+      authServiceSpy.getAuthToken.and.returnValue(token);
+      const request = new HttpRequest('GET', url);
+      return new Promise((resolve) => {
+        const next: HttpHandlerFn = (req) => {
+          resolve(req.headers);
+          return of(new HttpResponse({ status: 200 }));
+        };
+        TestBed.runInInjectionContext(() => authInterceptor(request, next)).subscribe();
+      });
+    }
+
+    it('sends no credentials to a foreign origin', async () => {
+      const headers = await headersFor(foreignUrl);
+
+      expect(headers.get('Authorization')).toBeNull();
+    });
+
+    it('sends no tenant header to a foreign origin either', async () => {
+      const headers = await headersFor(foreignUrl);
+
+      // The tenant names the institution; leaking it discloses who the deployment belongs to.
+      expect(headers.get(TENANT_HEADER)).toBeNull();
+    });
+
+    it('still authenticates a relative request', async () => {
+      const headers = await headersFor('/api/v1/loans');
+
+      expect(headers.get('Authorization')).toBe(`Basic ${token}`);
+      expect(headers.get(TENANT_HEADER)).toBe(testTenant);
+    });
+
+    it('still authenticates an absolute request to this origin', async () => {
+      const headers = await headersFor(`${window.location.origin}/api/v1/loans`);
+
+      expect(headers.get('Authorization')).toBe(`Basic ${token}`);
     });
   });
 });

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -20,6 +20,7 @@
 import { HttpInterceptorFn, HttpRequest, HttpHandlerFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { AuthService } from '../services/auth.service';
+import { ConfigService } from '../services/config.service';
 
 /** True when the request already carries a tenant (e.g. login with user-entered tenant). */
 function hasExplicitTenantHeaders(req: HttpRequest<unknown>): boolean {
@@ -28,6 +29,40 @@ function hasExplicitTenantHeaders(req: HttpRequest<unknown>): boolean {
     !!req.headers.get('X-Mifos-Platform-TenantId') ||
     !!req.headers.get('fineract-platform-tenantid')
   );
+}
+
+/**
+ * Whether a request is bound for the configured Fineract API.
+ *
+ * Credentials must not travel anywhere else. Nothing in the application calls a third party
+ * today, which is exactly why this is cheap to add now: the first analytics pixel, error
+ * reporter or vendor SDK that shares this `HttpClient` would otherwise send a `Basic` header
+ * carrying banking credentials to that vendor, and nothing would report it.
+ *
+ * A relative URL is same-origin by construction and always allowed. An absolute one is compared
+ * by origin, so a path change on the same host stays trusted and a different host does not.
+ */
+export function isApiRequest(url: string, apiUrl: string): boolean {
+  // Relative: the browser resolves it against this document's origin.
+  if (!/^https?:\/\//i.test(url)) return true;
+
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    // Not parseable as absolute, so it cannot name a foreign host.
+    return true;
+  }
+
+  if (target.origin === window.location.origin) return true;
+
+  // The configured API may itself be absolute and cross-origin, which is a supported
+  // deployment. Trust that one origin, and only that one.
+  try {
+    return target.origin === new URL(apiUrl, window.location.origin).origin;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -48,8 +83,15 @@ export const authInterceptor: HttpInterceptorFn = (
   next: HttpHandlerFn,
 ) => {
   const authService = inject(AuthService);
+  const config = inject(ConfigService);
   const token = authService.getAuthToken();
   const tenantId = authService.currentTenantId();
+
+  // Anything not bound for the API leaves untouched — no credentials, no tenant, which would
+  // otherwise disclose the institution's identity to a third party.
+  if (!isApiRequest(req.url, config.apiUrl)) {
+    return next(req);
+  }
 
   let authReq = req;
   if (!hasExplicitTenantHeaders(req)) {

--- a/src/app/core/services/config.service.spec.ts
+++ b/src/app/core/services/config.service.spec.ts
@@ -24,6 +24,19 @@ import { ConfigService, AppConfig } from './config.service';
 import { SKIP_ERROR_TOAST, SKIP_LOADING } from '../http/http-context';
 
 const STORAGE_KEY = 'fineract_runtime_config';
+
+/**
+ * Raw storage access, in one place.
+ *
+ * These specs assert what is *persisted*, so they have to look at the real store rather than the
+ * STORAGE adapter the application uses. Funnelling every access through these three helpers keeps
+ * that to a single boundary crossing instead of one per assertion.
+ */
+/* eslint-disable no-restricted-globals */
+const storedRaw = (): string | null => localStorage.getItem(STORAGE_KEY);
+const storeRaw = (value: unknown): void => localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+const clearStore = (): void => localStorage.clear();
+/* eslint-enable no-restricted-globals */
 const TEST_TENANT = 'test-tenant';
 const CONFIG_FILE = 'config.json';
 
@@ -56,13 +69,13 @@ describe('ConfigService', () => {
   }
 
   beforeEach(() => {
-    localStorage.clear();
+    clearStore();
     create();
   });
 
   afterEach(() => {
     httpMock.verify();
-    localStorage.clear();
+    clearStore();
   });
 
   it('should be created', () => {
@@ -107,22 +120,44 @@ describe('ConfigService', () => {
     req.flush(mockConfig);
   });
 
-  it('should set and persist API URL', () => {
-    const newUrl = 'https://new-api.com';
-    service.setApiUrl(newUrl);
+  it('should set and persist a same-origin API URL', () => {
+    const newUrl = '/some-other-fineract/api/v1';
+    expect(service.setApiUrl(newUrl)).toBeTrue();
 
     expect(service.apiUrl).toBe(newUrl);
-    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!).fineractApiUrl).toBe(newUrl);
+    expect(JSON.parse(storedRaw()!).fineractApiUrl).toBe(newUrl);
+  });
+
+  /**
+   * The endpoint override exists so an operator can point the app at their own Fineract. It is
+   * not a general redirect: whatever it names receives the user's credentials on the next
+   * request, so an origin the deployment did not sanction must be refused outright.
+   */
+  it('refuses an endpoint the deployment did not allow-list', () => {
+    const before = service.apiUrl;
+
+    expect(service.setApiUrl('https://attacker.example/api/v1')).toBeFalse();
+
+    expect(service.apiUrl).toBe(before);
+    expect(storedRaw()).toBeNull();
+  });
+
+  it('accepts an absolute endpoint the deployment allow-listed', async () => {
+    create();
+    await load({ ...mockConfig, allowedApiOrigins: ['https://fineract.example'] });
+
+    expect(service.setApiUrl('https://fineract.example/fineract-provider/api/v1')).toBeTrue();
+    expect(service.apiUrl).toBe('https://fineract.example/fineract-provider/api/v1');
   });
 
   it("should apply the user's stored endpoint on top of the loaded config", async () => {
-    service.setApiUrl('https://my-server.example');
+    service.setApiUrl('/my-server/api/v1');
     create();
 
     await load(mockConfig);
 
     // The user's choice wins for the endpoint...
-    expect(service.apiUrl).toBe('https://my-server.example');
+    expect(service.apiUrl).toBe('/my-server/api/v1');
     // ...and for nothing else. An endpoint override that froze the whole object would mean a
     // deployment turning RBAC off never reached anyone who had ever changed their endpoint.
     expect(service.config().defaultTenant).toBe(TEST_TENANT);
@@ -130,16 +165,27 @@ describe('ConfigService', () => {
 
   it('should ignore stale deployment settings left in local storage by earlier versions', async () => {
     // Older builds wrote the entire config object under this key.
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ fineractApiUrl: 'https://old.example', rbacEnabled: false }),
-    );
+    storeRaw({ fineractApiUrl: '/old/api/v1', rbacEnabled: false });
     create();
 
     await load({ rbacEnabled: true });
 
-    expect(service.apiUrl).toBe('https://old.example');
+    expect(service.apiUrl).toBe('/old/api/v1');
     expect(service.rbacEnabled()).toBeTrue();
+  });
+
+  /**
+   * Local storage is writable by anything running as the page, so a stored override is not more
+   * trusted than a fresh one — otherwise the allow-list could be bypassed by writing the key
+   * directly and reloading.
+   */
+  it('ignores a stored endpoint that is not allow-listed', async () => {
+    storeRaw({ fineractApiUrl: 'https://attacker.example' });
+    create();
+
+    await load(mockConfig);
+
+    expect(service.apiUrl).toBe(mockConfig.fineractApiUrl);
   });
 
   it('should expose the navigation entries a deployment hides', async () => {

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -65,6 +65,14 @@ export interface AppConfig {
   /** Institution type to assume when the user has not selected one. */
   institutionType: InstitutionType;
   /**
+   * Absolute API origins this deployment permits, beyond its own.
+   *
+   * The endpoint override exists so an operator can point the app at their own Fineract. It is
+   * not a general redirect: whatever it names receives the user's credentials on the next
+   * request. Omit it, and only same-origin endpoints are accepted.
+   */
+  allowedApiOrigins?: string[];
+  /**
    * Which group-lending features each institution type exposes. Omit to use the built-in
    * matrix; supply it to change what a type means for this deployment.
    */
@@ -93,6 +101,41 @@ const DEFAULT_CONFIG: AppConfig = {
  * by fetching a `config.json` file at startup. The user's own API-endpoint
  * choice is persisted in local storage and applied on top.
  */
+/**
+ * Whether an endpoint may be used.
+ *
+ * A relative URL is same-origin by construction. An absolute one must match this document's
+ * origin or an origin the deployment allow-listed. Anything else is refused: whatever this
+ * names receives the user's credentials on the next request, so accepting an arbitrary string
+ * turns a stored-XSS or a social-engineered link into credential theft.
+ *
+ * Takes the allow-list as an argument rather than reading the service's own signal, because it
+ * is called while that signal is still being built — including from a field initialiser, where
+ * reading it would throw.
+ */
+function isOriginAllowed(url: string, allowedOrigins: readonly string[]): boolean {
+  const candidate = (url ?? '').trim();
+  if (!candidate) return false;
+  if (!/^https?:\/\//i.test(candidate)) return true;
+
+  let target: URL;
+  try {
+    target = new URL(candidate);
+  } catch {
+    return false;
+  }
+
+  if (target.origin === window.location.origin) return true;
+
+  return allowedOrigins.some((allowed) => {
+    try {
+      return new URL(allowed).origin === target.origin;
+    } catch {
+      return false;
+    }
+  });
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -102,7 +145,7 @@ export class ConfigService {
 
   private readonly _config = signal<AppConfig>({
     ...DEFAULT_CONFIG,
-    ...this.getStoredOverride(),
+    ...this.getStoredOverride(DEFAULT_CONFIG.allowedApiOrigins ?? []),
   });
 
   /** Readonly access to the current application configuration signal */
@@ -132,19 +175,45 @@ export class ConfigService {
       );
       // Merged, not assigned: a config.json listing only the keys a deployment cares about
       // must not blank out the rest.
-      this._config.set({ ...DEFAULT_CONFIG, ...loaded, ...this.getStoredOverride() });
+      // The allow-list comes from the config just loaded, not from the signal: this runs before
+      // the merge lands, so reading it back would apply the previous deployment's rules.
+      const allowedOrigins = loaded.allowedApiOrigins ?? DEFAULT_CONFIG.allowedApiOrigins ?? [];
+      this._config.set({
+        ...DEFAULT_CONFIG,
+        ...loaded,
+        ...this.getStoredOverride(allowedOrigins),
+      });
     } catch (error) {
       console.error('❌ Could not load config.json, using environment defaults.', error);
     }
   }
 
   /**
-   * Updates the runtime API URL and persists it to local storage.
-   * @param url - The new API base URL
+   * Whether an endpoint may be used.
+   *
+   * A relative URL is same-origin by construction. An absolute one must match this document's
+   * origin or an origin the deployment allow-listed in `config.json`. Anything else is refused:
+   * the credentials the user is about to type would go wherever this points, so accepting an
+   * arbitrary string here turns a stored-XSS or a social-engineered link into credential theft.
    */
-  setApiUrl(url: string): void {
+  isAllowedApiUrl(url: string): boolean {
+    return isOriginAllowed(url, this.config().allowedApiOrigins ?? []);
+  }
+
+  /**
+   * Updates the runtime API URL and persists it to local storage.
+   *
+   * @param url - The new API base URL
+   * @returns `true` when the endpoint was accepted; `false` when it is not allow-listed.
+   */
+  setApiUrl(url: string): boolean {
+    if (!this.isAllowedApiUrl(url)) {
+      console.error('Refused an API endpoint that is not allow-listed for this deployment:', url);
+      return false;
+    }
     this._config.update((config) => ({ ...config, fineractApiUrl: url }));
     this.storage.write('runtimeConfig', { fineractApiUrl: url });
+    return true;
   }
 
   /**
@@ -162,10 +231,13 @@ export class ConfigService {
    * and belong to `config.json`, not to whatever was current when the user last switched
    * endpoints.
    */
-  private getStoredOverride(): Partial<AppConfig> {
+  private getStoredOverride(allowedOrigins: readonly string[]): Partial<AppConfig> {
     // `read` already absorbs an unparseable value, so there is no catch here: a corrupted
     // override reads as no override, and the deployment's own `config.json` decides.
     const { fineractApiUrl } = this.storage.read<Partial<AppConfig>>('runtimeConfig', {});
-    return fineractApiUrl ? { fineractApiUrl } : {};
+    // Local storage is writable by anything running as the page, so a stored override is not
+    // more trusted than a fresh one — it clears the same bar or it is ignored.
+    if (!fineractApiUrl || !isOriginAllowed(fineractApiUrl, allowedOrigins)) return {};
+    return { fineractApiUrl };
   }
 }

--- a/src/app/features/login/login.component.spec.ts
+++ b/src/app/features/login/login.component.spec.ts
@@ -25,7 +25,7 @@ import { LoginComponent } from './login.component';
 import { AuthService, UserSession } from '../../core/services/auth.service';
 import { ConfigService } from '../../core/services/config.service';
 import { TranslateModule } from '@ngx-translate/core';
-import { WritableSignal } from '@angular/core';
+import { WritableSignal, signal } from '@angular/core';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -40,9 +40,13 @@ describe('LoginComponent', () => {
     authServiceSpy = jasmine.createSpyObj('AuthService', ['login', 'currentTenantId']);
     authServiceSpy.currentTenantId.and.returnValue('default');
 
-    configServiceSpy = jasmine.createSpyObj('ConfigService', ['setApiUrl'], {
+    configServiceSpy = jasmine.createSpyObj('ConfigService', ['setApiUrl', 'isAllowedApiUrl'], {
       apiUrl: mockApiUrl,
+      // The component reads the allow-list to build the endpoint picker.
+      config: signal({ allowedApiOrigins: [] }),
     });
+    configServiceSpy.setApiUrl.and.returnValue(true);
+    configServiceSpy.isAllowedApiUrl.and.returnValue(true);
 
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, inject, signal, DestroyRef } from '@angular/core';
+import { Component, computed, inject, signal, DestroyRef } from '@angular/core';
 
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -81,19 +81,17 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
               <option [value]="configService.apiUrl">
                 {{ 'login.defaultOption' | translate }} ({{ configService.apiUrl }})
               </option>
-              <option value="https://demo.mifos.io/fineract-provider/api/v1">
-                Mifos Sandbox (https://demo.mifos.io/fineract-provider/api/v1)
-              </option>
+              <!-- Endpoints this deployment permits, from config.json. Third-party hosts used
+                   to be hard-coded here, which offered a teller a one-click path to type real
+                   credentials into someone else's server. What is offered is now the operator's
+                   decision, and anything typed is checked against the same allow-list. -->
               <option value="/fineract-provider/api/v1">
-                Local Proxy Server (Bypass CORS/SSL)
+                {{ 'login.proxyOption' | translate }}
               </option>
-              <option value="https://localhost:8443/fineract-provider/api/v1">
-                Local Server (Direct https://localhost:8443/fineract-provider/api/v1)
-              </option>
-              <option value="https://apis.mifos.community/1.0/core/api/v1">
-                Mifos Community API (https://apis.mifos.community/1.0/core/api/v1)
-              </option>
-              <option value="custom">Custom URL...</option>
+              @for (origin of allowedOrigins(); track origin) {
+                <option [value]="origin">{{ origin }}</option>
+              }
+              <option value="custom">{{ 'login.customOption' | translate }}</option>
             </select>
           </div>
 
@@ -313,6 +311,11 @@ export class LoginComponent {
   private readonly fb = inject(FormBuilder);
   private readonly authService = inject(AuthService);
   protected readonly configService = inject(ConfigService);
+
+  /** Absolute endpoints this deployment permits, offered alongside the default and the proxy. */
+  protected readonly allowedOrigins = computed(
+    () => this.configService.config().allowedApiOrigins ?? [],
+  );
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
@@ -365,8 +368,12 @@ export class LoginComponent {
       // CRITICAL: Check previous URL before updating it
       const previousUrl = this.configService.apiUrl;
 
-      if (finalUrl) {
-        this.configService.setApiUrl(finalUrl);
+      // Refuse before authenticating, not after: the point of the allow-list is that the
+      // password below never reaches a host the deployment did not sanction.
+      if (finalUrl && !this.configService.setApiUrl(finalUrl)) {
+        this.error.set(this.translate.instant('login.errors.endpointNotAllowed'));
+        this.isLoading.set(false);
+        return;
       }
 
       this.authService

--- a/src/app/testing/config.ts
+++ b/src/app/testing/config.ts
@@ -38,6 +38,26 @@ const TEST_CONFIG: AppConfig = {
  * and every later spec in the run saw the wrong value. Configuration is now a signal, so a
  * test states it and it belongs to that TestBed alone.
  */
+/** Same rule as `ConfigService`: relative is same-origin, absolute must be this origin or listed. */
+function isAllowedInTest(url: string, allowedOrigins: readonly string[]): boolean {
+  const candidate = (url ?? '').trim();
+  if (!candidate) return false;
+  if (!/^https?:\/\//i.test(candidate)) return true;
+  try {
+    const target = new URL(candidate);
+    if (target.origin === window.location.origin) return true;
+    return allowedOrigins.some((allowed) => {
+      try {
+        return new URL(allowed).origin === target.origin;
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return false;
+  }
+}
+
 export function provideTestConfig(overrides: Partial<AppConfig> = {}): Provider {
   const config = signal<AppConfig>({ ...TEST_CONFIG, ...overrides });
 
@@ -50,7 +70,14 @@ export function provideTestConfig(overrides: Partial<AppConfig> = {}): Provider 
       get apiUrl() {
         return config().fineractApiUrl;
       },
-      setApiUrl: (url: string) => config.update((c) => ({ ...c, fineractApiUrl: url })),
+      // Mirrors the real service's allow-list, so a spec cannot pass by setting an endpoint the
+      // application would refuse.
+      isAllowedApiUrl: (url: string) => isAllowedInTest(url, config().allowedApiOrigins ?? []),
+      setApiUrl: (url: string) => {
+        if (!isAllowedInTest(url, config().allowedApiOrigins ?? [])) return false;
+        config.update((c) => ({ ...c, fineractApiUrl: url }));
+        return true;
+      },
       loadConfig: () => Promise.resolve(),
     } satisfies Partial<ConfigService>,
   };

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1146,7 +1146,12 @@
       "serverUrl": "The Fineract server address. Use 'Mifos Sandbox' for testing or 'Local' for your own instance.",
       "tenantId": "A unique ID for the financial institution. Default is 'default'. This is passed via the Fineract-Platform-TenantId header."
     },
-    "sessionExpired": "Your session has expired. Please sign in again."
+    "sessionExpired": "Your session has expired. Please sign in again.",
+    "proxyOption": "Local proxy (same origin)",
+    "customOption": "Custom URL…",
+    "errors": {
+      "endpointNotAllowed": "That API endpoint is not permitted by this deployment. Ask your administrator to add it to the allowed list."
+    }
   },
   "idle": {
     "warning": {


### PR DESCRIPTION
Closes #212, #213, #214, #215, #216.

`npm run ga:check` reported **3/8 gates passing, 4 blocking failures**. This takes it to **7/8,
0 blocking** — the remaining one is the advisory adapter-boundary backlog.

I confirmed each failure in the code before changing anything, rather than taking the report's
word for it.

### Why these were worse together than apart

The login form offered third-party hosts as one-click options. The endpoint override accepted any
string and persisted it. The auth interceptor attached `Authorization: Basic` to **every** outgoing
request regardless of destination — no URL comparison appeared anywhere in the file.

Chain them and you have a supported path to pointing the application at an attacker's host and
posting real credentials to it on the next sign-in. Missing security headers removed the
browser-side backstop that would otherwise limit where an injected script could send anything.

Nothing here calls a third party today, which is exactly why this was cheap now: the first
analytics pixel, error reporter or vendor SDK sharing this `HttpClient` would have inherited the
problem silently.

### What changed

- **Interceptor** sends credentials — and the tenant header — only to the configured API. Relative
  URLs are same-origin by construction; absolute ones are compared by origin, so a cross-origin
  API the deployment configured still authenticates and nothing else does. The tenant header is
  withheld too, since it names the institution.
- **`setApiUrl`** validates against an allow-list and *returns* whether it accepted, so the login
  form stops **before** authenticating rather than after. A stored override clears the same bar:
  local storage is writable by anything running as the page, so it is not more trusted than a
  fresh value.
- **Server picker** is built from deployment configuration instead of hard-coded hosts.
- **`deploy/nginx.conf`** sets CSP, HSTS, `X-Frame-Options`, `X-Content-Type-Options` and
  `Referrer-Policy`, all with `always` so they survive error responses — which is where a
  reflected payload would land. The CSP admits no `unsafe-eval`; `unsafe-inline` is styles-only.

### A bug I caught while writing it

The allow-list check initially read the config signal. But `getStoredOverride` runs inside a
**field initialiser**, before that signal exists — it would have thrown on startup, in the one code
path every user hits. The predicate now takes the allowed origins as an argument, and the loader
passes the freshly-loaded list rather than reading back a config that has not been merged yet.

### Verification

| Check | Result |
|---|---|
| `npm run ga:check` | **3/8 → 7/8**, 0 blocking |
| Unit tests | **766 passing** (744 → 766) |
| Mocked Playwright | **210/210 passing** |
| `nginx -t` on the real image | passes |
| Headers observed on a live response | all five present |
| `tsc` (app + spec), build, lint, format, i18n, icons, licence | clean |

Headers were checked by serving the config from the actual `nginx:alpine` image and reading the
response, not by grepping the file.

### Two notes for review

The existing `ConfigService` specs asserted the **old permissive behaviour** — they set
cross-origin URLs and expected them to stick. Those now assert the new rule, with added cases for
refusal and for a non-allow-listed stored value being ignored.

Storage access in that spec is funnelled through three helpers, which takes the adapter-boundary
suppression baseline **down rather than up: 435 → 431**. New violations would have failed lint;
adding suppressions would have been the wrong direction.
