### PR TITLE
chore(asf): describe the project and add repository topics

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -3,6 +3,26 @@ notifications:
   pullrequests: issues@fineract.apache.org
   issues: issues@fineract.apache.org
 github:
+  description: 'Angular back-office UI for Apache Fineract, the open-source core banking platform'
+  homepage: https://fineract.apache.org
+  labels:
+    - angular
+    - apache
+    - backoffice
+    - banking
+    - core-banking
+    - fintech
+    - group-lending
+    - group-savings
+    - ionic
+    - lending
+    - loans
+    - microfinance
+    - savings
+    - social-impact
+    - tech4good
+    - typescript
+    - ui
   features:
     wiki: true
     issues: true


### PR DESCRIPTION
`.asf.yaml` configured notifications, features, merge buttons and branch protection — but never
said what this repository **is**. GitHub therefore showed it carrying the parent project's
description and no topics, making it indistinguishable from Fineract itself in search and in the
ASF project listing. That listing is the first place someone looking for the back-office UI would
land.

### What this adds

```yaml
github:
  description: 'Angular back-office UI for Apache Fineract, the open-source core banking platform'
  homepage: https://fineract.apache.org
  labels: [17 topics]
```

The topics cover both what the project *does* and what it is *built with*:

**Domain** — `banking`, `core-banking`, `microfinance`, `lending`, `loans`, `savings`,
`group-lending`, `group-savings`, `fintech`, `social-impact`, `tech4good`
**Stack** — `angular`, `typescript`, `ionic`, `ui`, `backoffice`
**Foundation** — `apache`

### Why these differ from the parent repository's

Deliberately not a copy of `apache/fineract`'s list:

- **`java` is omitted** — it would be wrong here. This is Angular 22 / TypeScript with Ionic.
- **`angular`, `typescript`, `ionic`, `backoffice` are added** — these are what someone looking for
  *this* repository, rather than the platform, would actually search for. Sharing every topic with
  the parent is precisely what makes the two indistinguishable.

The shared domain topics are kept so the repository still surfaces alongside the rest of the
project.

### What is deliberately untouched

Nothing outside those three keys changed. The merge buttons, branch-protection ruleset and
notification addresses already reflect decisions this project has made — the ruleset targets `main`
and requires **zero** approving reviews, both of which differ from the parent repository's file —
so they are left exactly as they are rather than quietly aligned to someone else's configuration.
Changing merge policy or branch protection is a governance decision for the PMC, not a side effect
of a metadata PR.

### Verification

- `.asf.yaml` parses as valid YAML.
- All 17 topics satisfy GitHub's rules: lowercase, alphanumeric-plus-hyphen, ≤50 characters, no
  duplicates, under the 20-topic limit.
- Alphabetically ordered, matching the parent repository's convention.
- Existing `notifications`, `features`, `enabled_merge_buttons` and `rulesets` keys verified
  present and unchanged after the edit.
- Licence and formatting checks pass.
