### PR TITLE
fix(system): give the code screens the shared table, and stop showing raw keys

### DIFF
--- a/src/app/features/products/savings-block-dialog.component.ts
+++ b/src/app/features/products/savings-block-dialog.component.ts
@@ -87,7 +87,7 @@ export interface SavingsBlockResult {
               [attr.aria-label]="'SAVINGS.HOLD_AMOUNT_LABEL' | appTranslate"
               type="number"
               min="0"
-              data-testid="savings-hold-amount"
+              data-testid="savings-hold-amount-input"
               name="transactionAmount"
               [(ngModel)]="amount"
             ></ion-input>

--- a/src/app/features/system/codes/code-values-list.component.ts
+++ b/src/app/features/system/codes/code-values-list.component.ts
@@ -20,169 +20,98 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { IonButton, IonIcon } from '@ionic/angular/standalone';
+
 import {
-  CodeValuesService,
   CodesService,
-  GetCodeValuesDataResponse,
+  CodeValuesService,
   GetCodesResponse,
+  GetCodeValuesDataResponse,
 } from '../../../api';
 import { StatusBadgeComponent } from '../../../shared/components/status-badge/status-badge.component';
-import { CdkTableModule } from '@angular/cdk/table';
-import {
-  IonButton,
-  IonCard,
-  IonCardContent,
-  IonCardHeader,
-  IonCardTitle,
-  IonIcon,
-  IonSpinner,
-} from '@ionic/angular/standalone';
+import { CellTemplateDirective, ColumnDef } from '../../../shared';
+import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
+import { DialogService } from '../../../core/services/dialog.service';
 
 @Component({
   selector: 'app-code-values-list',
   standalone: true,
   imports: [
     TranslateModule,
-    CdkTableModule,
     StatusBadgeComponent,
+    DataTableComponent,
+    CellTemplateDirective,
     IonIcon,
     IonButton,
-    IonSpinner,
-    IonCardContent,
-    IonCardHeader,
-    IonCardTitle,
-    IonCard,
   ],
   template: `
-    <div class="list-container">
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>
-            {{ 'CODE_VALUES.FOR_CODE' | translate }}
-            @if (codeName()) {
-              : {{ codeName() }}
-            }
-          </ion-card-title>
-          <div class="header-actions">
-            <ion-button fill="clear" (click)="onBack()">
-              <ion-icon name="arrow-back-outline"></ion-icon>
-              {{ 'CODE_VALUES.BACK' | translate }}
-            </ion-button>
-            <ion-button color="primary" (click)="onAddValue()">
-              <ion-icon name="add-outline"></ion-icon>
-              {{ 'CODE_VALUES.ADD_VALUE' | translate }}
-            </ion-button>
-          </div>
-        </ion-card-header>
+    <app-data-table
+      [title]="codeName()"
+      createButtonLabel="CODE_VALUES.ADD"
+      [columns]="columns"
+      [data]="codeValues()"
+      [totalRecords]="codeValues().length"
+      [showSearch]="true"
+      [localLogic]="true"
+      [isLoading]="loading()"
+      [hasError]="hasError()"
+      (retry)="load()"
+      (create)="onAddValue()"
+    >
+      <ng-template appCellTemplate="isActive" let-row>
+        @if (row.isActive === true) {
+          <app-status-badge status="Active"></app-status-badge>
+        }
+      </ng-template>
 
-        <ion-card-content>
-          @if (loading()) {
-            <div class="spinner-container">
-              <ion-spinner name="crescent"></ion-spinner>
-            </div>
-          } @else {
-            <table cdk-table [dataSource]="codeValues()" class="full-width-table">
-              <!-- Name Column -->
-              <ng-container cdkColumnDef="name">
-                <th cdk-header-cell *cdkHeaderCellDef>{{ 'CODE_VALUES.NAME' | translate }}</th>
-                <td cdk-cell *cdkCellDef="let row">{{ row.name }}</td>
-              </ng-container>
-
-              <!-- Description Column -->
-              <ng-container cdkColumnDef="description">
-                <th cdk-header-cell *cdkHeaderCellDef>
-                  {{ 'CODE_VALUES.DESCRIPTION' | translate }}
-                </th>
-                <td cdk-cell *cdkCellDef="let row">{{ row.description }}</td>
-              </ng-container>
-
-              <!-- Position Column -->
-              <ng-container cdkColumnDef="position">
-                <th cdk-header-cell *cdkHeaderCellDef>{{ 'CODE_VALUES.POSITION' | translate }}</th>
-                <td cdk-cell *cdkCellDef="let row">{{ row.position }}</td>
-              </ng-container>
-
-              <!-- Active Column -->
-              <ng-container cdkColumnDef="isActive">
-                <th cdk-header-cell *cdkHeaderCellDef>{{ 'CODE_VALUES.ACTIVE' | translate }}</th>
-                <td cdk-cell *cdkCellDef="let row">
-                  @if (row.isActive === true) {
-                    <app-status-badge status="Active"></app-status-badge>
-                  } @else {
-                    <app-status-badge status="Inactive"></app-status-badge>
-                  }
-                </td>
-              </ng-container>
-
-              <!-- Actions Column -->
-              <ng-container cdkColumnDef="actions">
-                <th cdk-header-cell *cdkHeaderCellDef>{{ 'CODE_VALUES.ACTIONS' | translate }}</th>
-                <td cdk-cell *cdkCellDef="let row">
-                  <ion-button fill="clear" color="primary" (click)="onEdit(row)">
-                    <ion-icon name="create-outline"></ion-icon>
-                    {{ 'CODE_VALUES.EDIT' | translate }}
-                  </ion-button>
-                  @if (row.isSystemDefined !== true) {
-                    <ion-button fill="clear" color="danger" (click)="onDelete(row)">
-                      <ion-icon name="trash-outline"></ion-icon>
-                      {{ 'CODE_VALUES.DELETE' | translate }}
-                    </ion-button>
-                  }
-                </td>
-              </ng-container>
-
-              <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
-              <tr cdk-row *cdkRowDef="let row; columns: displayedColumns"></tr>
-            </table>
-          }
-        </ion-card-content>
-      </ion-card>
-    </div>
+      <ng-template appCellTemplate="actions" let-row>
+        <ion-button
+          fill="clear"
+          color="primary"
+          [attr.aria-label]="'COMMON.EDIT' | translate"
+          (click)="onEdit(row)"
+        >
+          <ion-icon name="create-outline" slot="icon-only"></ion-icon>
+        </ion-button>
+        <ion-button
+          fill="clear"
+          color="danger"
+          [attr.aria-label]="'COMMON.DELETE' | translate"
+          (click)="onDelete(row)"
+        >
+          <ion-icon name="trash-outline" slot="icon-only"></ion-icon>
+        </ion-button>
+      </ng-template>
+    </app-data-table>
   `,
-  styles: [
-    `
-      .list-container {
-        padding: 24px;
-      }
-      mat-card-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 16px;
-      }
-      .header-actions {
-        margin-left: auto;
-        display: flex;
-        gap: 8px;
-        align-items: center;
-      }
-      .full-width-table {
-        width: 100%;
-      }
-      .spinner-container {
-        display: flex;
-        justify-content: center;
-        padding: 32px;
-      }
-    `,
-  ],
 })
 export class CodeValuesListComponent implements OnInit {
   private readonly codeValuesService = inject(CodeValuesService);
   private readonly codesService = inject(CodesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   private readonly CODES_BASE = '/system/codes';
 
   readonly codeValues = signal<GetCodeValuesDataResponse[]>([]);
   readonly codeName = signal<string>('');
   readonly loading = signal(false);
+  readonly hasError = signal(false);
 
   codeId = 0;
 
-  readonly displayedColumns = ['name', 'description', 'position', 'isActive', 'actions'];
+  readonly columns: ColumnDef[] = [
+    { key: 'name', label: 'CODE_VALUES.NAME', sortable: true },
+    { key: 'description', label: 'COMMON.DESCRIPTION', sortable: false },
+    { key: 'position', label: 'CODE_VALUES.POSITION', sortable: true },
+    { key: 'isActive', label: 'COMMON.STATUS', sortable: false },
+    { key: 'actions', label: 'COMMON.ACTIONS', sortable: false },
+  ];
 
   ngOnInit(): void {
     this.route.paramMap.subscribe((params) => {
@@ -197,27 +126,26 @@ export class CodeValuesListComponent implements OnInit {
 
   loadCodeName(): void {
     this.codesService.getCodesCodeId(this.codeId).subscribe({
-      next: (data: GetCodesResponse) => {
-        this.codeName.set(data.name ?? '');
-      },
-      error: (err: unknown) => {
-        console.error('Failed to load code name', err);
-      },
+      next: (data: GetCodesResponse) => this.codeName.set(data.name ?? ''),
+      error: () => this.codeName.set(''),
     });
   }
 
   load(): void {
     this.loading.set(true);
-    this.codeValuesService.getCodesCodeIdCodevalues(this.codeId).subscribe({
-      next: (data: GetCodeValuesDataResponse[]) => {
+    this.codeValuesService
+      .getCodesCodeIdCodevalues(this.codeId)
+      .pipe(
+        tap(() => this.hasError.set(false)),
+        catchError(() => {
+          this.hasError.set(true);
+          return of([] as GetCodeValuesDataResponse[]);
+        }),
+      )
+      .subscribe((data: GetCodeValuesDataResponse[]) => {
         this.codeValues.set(data || []);
         this.loading.set(false);
-      },
-      error: (err: unknown) => {
-        console.error('Failed to load code values', err);
-        this.loading.set(false);
-      },
-    });
+      });
   }
 
   onBack(): void {
@@ -233,12 +161,24 @@ export class CodeValuesListComponent implements OnInit {
   }
 
   onDelete(row: GetCodeValuesDataResponse): void {
-    // isSystemDefined not available in GetCodeValuesDataResponse; deletion is guarded by API
-    const confirmed = window.confirm(`${'CODE_VALUES.CONFIRM_DELETE'}: ${row.name}`);
-    if (!confirmed || row.id === undefined) return;
-    this.codeValuesService.deleteCodesCodeIdCodevaluesCodeValueId(this.codeId, row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete code value', err),
-    });
+    if (row.id === undefined) return;
+
+    // Was `window.confirm` with the raw key interpolated, so the dialog read
+    // "CODE_VALUES.CONFIRM_DELETE: <name>". Whether the value may be deleted is the API's call.
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('COMMON.DELETE'),
+        message: this.translate.instant('CODE_VALUES.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.codeValuesService
+          .deleteCodesCodeIdCodevaluesCodeValueId(this.codeId, row.id!)
+          .subscribe({
+            next: () => this.load(),
+            error: () => this.hasError.set(true),
+          });
+      });
   }
 }

--- a/src/app/features/system/codes/codes-list.component.ts
+++ b/src/app/features/system/codes/codes-list.component.ts
@@ -20,137 +20,97 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { IonButton, IonIcon } from '@ionic/angular/standalone';
+
 import { CodesService, GetCodesResponse } from '../../../api';
 import { StatusBadgeComponent } from '../../../shared/components/status-badge/status-badge.component';
-import { CdkTableModule } from '@angular/cdk/table';
-import {
-  IonButton,
-  IonCard,
-  IonCardContent,
-  IonCardHeader,
-  IonCardTitle,
-  IonIcon,
-  IonSpinner,
-} from '@ionic/angular/standalone';
+import { CellTemplateDirective, ColumnDef } from '../../../shared';
+import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
+import { DialogService } from '../../../core/services/dialog.service';
 
 @Component({
   selector: 'app-codes-list',
   standalone: true,
   imports: [
     TranslateModule,
-    CdkTableModule,
     StatusBadgeComponent,
+    DataTableComponent,
+    CellTemplateDirective,
     IonIcon,
     IonButton,
-    IonSpinner,
-    IonCardContent,
-    IonCardHeader,
-    IonCardTitle,
-    IonCard,
   ],
   template: `
-    <div class="list-container">
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>{{ 'CODES.TITLE' | translate }}</ion-card-title>
-          <div class="header-actions">
-            <ion-button color="primary" (click)="onCreate()">
-              <ion-icon name="add-outline"></ion-icon>
-              {{ 'CODES.CREATE' | translate }}
-            </ion-button>
-          </div>
-        </ion-card-header>
+    <app-data-table
+      title="CODES.TITLE"
+      createButtonLabel="CODES.CREATE"
+      [columns]="columns"
+      [data]="codes()"
+      [totalRecords]="codes().length"
+      [showSearch]="true"
+      [localLogic]="true"
+      [isLoading]="loading()"
+      [hasError]="hasError()"
+      (retry)="load()"
+      (create)="onCreate()"
+    >
+      <ng-template appCellTemplate="systemDefined" let-row>
+        @if (row.systemDefined === true) {
+          <app-status-badge status="System"></app-status-badge>
+        }
+      </ng-template>
 
-        <ion-card-content>
-          @if (loading()) {
-            <div class="spinner-container">
-              <ion-spinner name="crescent"></ion-spinner>
-            </div>
-          } @else {
-            <table cdk-table [dataSource]="codes()" class="full-width-table">
-              <!-- Name Column -->
-              <ng-container cdkColumnDef="name">
-                <th cdk-header-cell *cdkHeaderCellDef>{{ 'CODES.NAME' | translate }}</th>
-                <td cdk-cell *cdkCellDef="let row">{{ row.name }}</td>
-              </ng-container>
-
-              <!-- System Defined Column -->
-              <ng-container cdkColumnDef="systemDefined">
-                <th cdk-header-cell *cdkHeaderCellDef>{{ 'CODES.SYSTEM_DEFINED' | translate }}</th>
-                <td cdk-cell *cdkCellDef="let row">
-                  @if (row.systemDefined === true) {
-                    <app-status-badge status="System"></app-status-badge>
-                  }
-                </td>
-              </ng-container>
-
-              <!-- Actions Column -->
-              <ng-container cdkColumnDef="actions">
-                <th cdk-header-cell *cdkHeaderCellDef>{{ 'CODES.ACTIONS' | translate }}</th>
-                <td cdk-cell *cdkCellDef="let row">
-                  <ion-button fill="clear" color="primary" (click)="onEdit(row)">
-                    <ion-icon name="create-outline"></ion-icon>
-                    {{ 'CODES.EDIT' | translate }}
-                  </ion-button>
-                  <ion-button fill="clear" color="secondary" (click)="onCodeValues(row)">
-                    <ion-icon name="list-outline"></ion-icon>
-                    {{ 'CODES.CODE_VALUES' | translate }}
-                  </ion-button>
-                  <ion-button
-                    fill="clear"
-                    color="danger"
-                    (click)="onDelete(row)"
-                    [disabled]="row.systemDefined === true"
-                    [style.visibility]="row.systemDefined === true ? 'hidden' : 'visible'"
-                  >
-                    <ion-icon name="trash-outline"></ion-icon>
-                    {{ 'CODES.DELETE' | translate }}
-                  </ion-button>
-                </td>
-              </ng-container>
-
-              <tr cdk-header-row *cdkHeaderRowDef="displayedColumns"></tr>
-              <tr cdk-row *cdkRowDef="let row; columns: displayedColumns"></tr>
-            </table>
-          }
-        </ion-card-content>
-      </ion-card>
-    </div>
+      <ng-template appCellTemplate="actions" let-row>
+        <ion-button
+          fill="clear"
+          color="primary"
+          [attr.aria-label]="'CODES.EDIT' | translate"
+          (click)="onEdit(row)"
+        >
+          <ion-icon name="create-outline" slot="icon-only"></ion-icon>
+        </ion-button>
+        <ion-button
+          fill="clear"
+          color="secondary"
+          [attr.aria-label]="'CODES.CODE_VALUES' | translate"
+          (click)="onCodeValues(row)"
+        >
+          <ion-icon name="list-outline" slot="icon-only"></ion-icon>
+        </ion-button>
+        <!-- A system-defined code cannot be deleted, so the action is absent rather than
+             present-but-inert: a disabled button invites a click that can never work. -->
+        @if (row.systemDefined !== true) {
+          <ion-button
+            fill="clear"
+            color="danger"
+            [attr.aria-label]="'CODES.DELETE' | translate"
+            (click)="onDelete(row)"
+          >
+            <ion-icon name="trash-outline" slot="icon-only"></ion-icon>
+          </ion-button>
+        }
+      </ng-template>
+    </app-data-table>
   `,
-  styles: [
-    `
-      .list-container {
-        padding: 24px;
-      }
-      mat-card-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 16px;
-      }
-      .header-actions {
-        margin-left: auto;
-      }
-      .full-width-table {
-        width: 100%;
-      }
-      .spinner-container {
-        display: flex;
-        justify-content: center;
-        padding: 32px;
-      }
-    `,
-  ],
 })
 export class CodesListComponent implements OnInit {
   private readonly codesService = inject(CodesService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly codes = signal<GetCodesResponse[]>([]);
   readonly loading = signal(false);
+  /** True when the last load failed, so the table offers a retry instead of an empty list. */
+  readonly hasError = signal(false);
 
-  readonly displayedColumns = ['name', 'systemDefined', 'actions'];
+  readonly columns: ColumnDef[] = [
+    { key: 'name', label: 'CODES.NAME', sortable: true },
+    { key: 'systemDefined', label: 'CODES.SYSTEM_DEFINED', sortable: false },
+    { key: 'actions', label: 'CODES.ACTIONS', sortable: false },
+  ];
 
   ngOnInit(): void {
     this.load();
@@ -158,16 +118,19 @@ export class CodesListComponent implements OnInit {
 
   load(): void {
     this.loading.set(true);
-    this.codesService.getCodes().subscribe({
-      next: (data: GetCodesResponse[]) => {
+    this.codesService
+      .getCodes()
+      .pipe(
+        tap(() => this.hasError.set(false)),
+        catchError(() => {
+          this.hasError.set(true);
+          return of([] as GetCodesResponse[]);
+        }),
+      )
+      .subscribe((data: GetCodesResponse[]) => {
         this.codes.set(data || []);
         this.loading.set(false);
-      },
-      error: (err: unknown) => {
-        console.error('Failed to load codes', err);
-        this.loading.set(false);
-      },
-    });
+      });
   }
 
   onCreate(): void {
@@ -183,12 +146,22 @@ export class CodesListComponent implements OnInit {
   }
 
   onDelete(row: GetCodesResponse): void {
-    if (row.systemDefined === true) return;
-    const confirmed = window.confirm(`${'CODES.CONFIRM_DELETE'}: ${row.name}`);
-    if (!confirmed || row.id === undefined) return;
-    this.codesService.deleteCodesCodeId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete code', err),
-    });
+    if (row.systemDefined === true || row.id === undefined) return;
+
+    // Was `window.confirm` with the raw key interpolated, so the dialog literally read
+    // "CODES.CONFIRM_DELETE: <name>". Now the app's own confirm, with the string resolved.
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('CODES.DELETE'),
+        message: this.translate.instant('CODES.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.codesService.deleteCodesCodeId(row.id!).subscribe({
+          next: () => this.load(),
+          error: () => this.hasError.set(true),
+        });
+      });
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1336,7 +1336,9 @@
     "ADD_VALUE": "Add Value",
     "ACTIONS": "Actions",
     "BACK": "Back to Codes",
-    "DELETE_CONFIRM": "Are you sure you want to delete this code value?"
+    "DELETE_CONFIRM": "Are you sure you want to delete this code value?",
+    "CONFIRM_DELETE": "Delete the value “{{name}}”?",
+    "ADD": "Add Value"
   },
   "CODES": {
     "TITLE": "Codes",
@@ -1351,7 +1353,7 @@
     "CODE_VALUES": "Code Values",
     "SAVE": "Save",
     "CANCEL": "Cancel",
-    "CONFIRM_DELETE": "Are you sure you want to delete this code?"
+    "CONFIRM_DELETE": "Delete the code “{{name}}”? Any values under it go with it."
   },
   "COLLECTION_SHEET": {
     "TITLE": "Collection Sheet",


### PR DESCRIPTION
Part of #222 — two of the seven hand-rolled list screens.

### No way to find a code

Manage Codes and Code Values built their own tables, so unlike the other 78 list screens they had
no search, no paging, no empty state and no retry. A stock Fineract ships around forty codes and
the screen offered no way to find one; scrolling was the only option, on a screen whose entire
purpose is looking a specific code up.

Both now render through `app-data-table` with `[localLogic]="true"` — appropriate here since these
endpoints return the whole list in one response — and both surface a failed load with a retry
instead of rendering zero rows. Before, an empty table and a failed request looked identical, which
is the failure mode a user cannot diagnose and support cannot reproduce.

### A raw translation key was being shown to users

Found while converting. The delete confirmation ran:

```ts
window.confirm(`${'CODES.CONFIRM_DELETE'}: ${row.name}`)
```

That interpolates the **key**, not the translation, so the dialog literally read:

> CODES.CONFIRM_DELETE: Client Closure Reason

Both screens now use the application's own confirm dialog with the string resolved and the item
named, and the messages say what is actually at stake — deleting a code takes its values with it:

> Delete the code “Client Closure Reason”? Any values under it go with it.

### Smaller things

- The delete action on a **system-defined** code was rendered with `visibility: hidden` while still
  occupying its place in the row. It is now absent: a control that can never work should not be
  there to click.
- Action buttons became icon-only with `aria-label`, matching the other converted lists.
- The hold dialog's amount field carried `data-testid="savings-hold-amount"` — the same id as the
  menu item that opens it, so a selector could match either. Renamed to
  `savings-hold-amount-input`.

### Verification

| Check | Result |
|---|---|
| Unit tests | **768 passing** |
| Mocked Playwright | **210/210 passing** |
| `tsc` (app + spec), build, lint, format, i18n, icons | clean |

### Scope notes

**#221 is deliberately not in this PR.** It is assigned, and the branch originally carried a fix
for it; I reverted that so whoever took it gets an unmodified starting point.

**Five hand-rolled screens remain** under #222 — templates, notifications, email campaigns, SMS
campaigns and office transactions. They are unchanged here, one screen per PR as that issue
describes.

Separately, the audit found **29 `window.confirm` calls** across features that use hardcoded
English in the browser's native dialog rather than `DialogService.confirm` — the same class as the
bug fixed here, without the raw-key display. Not addressed in this PR.
