### PR TITLE
Fix two defects that block saving entirely: unpadded dates and blank optional fields

### DIFF
--- a/src/app/core/utils/date-formatter.spec.ts
+++ b/src/app/core/utils/date-formatter.spec.ts
@@ -17,7 +17,12 @@
  * under the License.
  */
 
-import { formatArrayDate, formatDateToFineract, toIsoDate } from './date-formatter';
+import {
+  FINERACT_DATE_FORMAT,
+  formatArrayDate,
+  formatDateToFineract,
+  toIsoDate,
+} from './date-formatter';
 
 const JAN_5_2026 = '2026-01-05';
 
@@ -67,6 +72,32 @@ describe('date-formatter', () => {
 
     it('accepts a Fineract array date', () => {
       expect(formatDateToFineract([2026, 1, 15])).toBe('15 January 2026');
+    });
+
+    it('pads a single-digit day to two digits', () => {
+      // Callers send this alongside FINERACT_DATE_FORMAT ('dd MMMM yyyy'). Fineract parses the
+      // value strictly against that format, so '2 August 2026' fails to parse and the request
+      // comes back 500 — every dated submission in the application broke on the 1st to the 9th.
+      expect(formatDateToFineract(new Date(2026, 7, 2))).toBe('02 August 2026');
+      expect(formatDateToFineract(new Date(2026, 0, 1))).toBe('01 January 2026');
+      expect(formatDateToFineract(new Date(2026, 0, 9))).toBe('09 January 2026');
+    });
+
+    it('pads a single-digit day from an array date too', () => {
+      expect(formatDateToFineract([2026, 8, 2])).toBe('02 August 2026');
+    });
+
+    it('leaves a two-digit day alone', () => {
+      expect(formatDateToFineract(new Date(2026, 0, 10))).toBe('10 January 2026');
+      expect(formatDateToFineract(new Date(2026, 11, 31))).toBe('31 December 2026');
+    });
+
+    it('agrees with the format string it is always sent with', () => {
+      // The guarantee that actually matters: day and month are fixed-width, matching 'dd'.
+      expect(FINERACT_DATE_FORMAT).toBe('dd MMMM yyyy');
+      for (let day = 1; day <= 28; day++) {
+        expect(formatDateToFineract(new Date(2026, 0, day)).split(' ')[0]).toHaveSize(2);
+      }
     });
 
     it('returns empty string for invalid input', () => {

--- a/src/app/core/utils/date-formatter.ts
+++ b/src/app/core/utils/date-formatter.ts
@@ -34,7 +34,13 @@ const MONTHS = [
 
 /**
  * Formats a Date object (or date-like string/array) into the Fineract-preferred
- * 'D Month YYYY' format (e.g., '15 January 2026').
+ * 'dd Month yyyy' format (e.g., '15 January 2026', '02 August 2026').
+ *
+ * The day is zero-padded to two digits because every caller sends this alongside
+ * `FINERACT_DATE_FORMAT`, which declares `dd`. Fineract parses the value strictly against the
+ * format it is told to use, so an unpadded '2 August 2026' does not merely fail validation — it
+ * fails to parse at all and the request comes back 500. That made every dated submission in the
+ * application fail on the 1st through the 9th of any month, and succeed for the rest of it.
  *
  * @param date - The date to format.
  * @returns The formatted date string, or empty string if invalid.
@@ -57,7 +63,7 @@ export function formatDateToFineract(date: Date | string | number[] | null | und
 
   if (isNaN(d.getTime())) return '';
 
-  const day = d.getDate();
+  const day = String(d.getDate()).padStart(2, '0');
   const month = MONTHS[d.getMonth()];
   const year = d.getFullYear();
 

--- a/src/app/features/loans/interest-pauses/interest-pause-form.component.spec.ts
+++ b/src/app/features/loans/interest-pauses/interest-pause-form.component.spec.ts
@@ -72,8 +72,8 @@ describe('InterestPauseFormComponent', () => {
     expect(serviceSpy.postLoansLoanIdInterestPauses).toHaveBeenCalledWith(
       1,
       jasmine.objectContaining({
-        startDate: '1 January 2026',
-        endDate: '1 February 2026',
+        startDate: '01 January 2026',
+        endDate: '01 February 2026',
         dateFormat: 'dd MMMM yyyy',
         locale: 'en',
       }),

--- a/src/app/features/loans/post-dated-checks/post-dated-check-form.component.spec.ts
+++ b/src/app/features/loans/post-dated-checks/post-dated-check-form.component.spec.ts
@@ -94,7 +94,7 @@ describe('PostDatedCheckFormComponent', () => {
         name: 'Updated',
         amount: 2000,
         accountNo: 34,
-        date: '1 January 2026',
+        date: '01 January 2026',
         dateFormat: 'dd MMMM yyyy',
         locale: 'en',
       }),

--- a/src/app/features/organization/staff/staff-form.component.spec.ts
+++ b/src/app/features/organization/staff/staff-form.component.spec.ts
@@ -100,4 +100,34 @@ describe('StaffFormComponent', () => {
     );
     expect(staffServiceSpy.putStaffStaffId).not.toHaveBeenCalled();
   });
+
+  it('omits optional fields the user left blank', () => {
+    staffServiceSpy.postStaff.and.returnValue(
+      of({}) as unknown as ReturnType<StaffService['postStaff']>,
+    );
+    // The form seeds these to '' so the inputs bind. Sending the empty string made Fineract
+    // reject the whole submission with "mobileNo must contain only digits", naming a field the
+    // user had deliberately left blank — so a staff member could not be created without one.
+    component.staff.set({
+      officeId: 1,
+      firstname: 'Ada',
+      lastname: 'Lovelace',
+      mobileNo: '',
+      externalId: '',
+      isLoanOfficer: false,
+    });
+    component.joiningDate.set('2026-01-15');
+
+    component.onSubmit();
+
+    const payload = staffServiceSpy.postStaff.calls.mostRecent().args[0] as unknown as Record<
+      string,
+      unknown
+    >;
+    expect('mobileNo' in payload).toBe(false);
+    expect('externalId' in payload).toBe(false);
+    expect(payload['firstname']).toBe('Ada');
+    // false is a real value, not a blank — it must survive.
+    expect(payload['isLoanOfficer']).toBe(false);
+  });
 });

--- a/src/app/features/organization/staff/staff-form.component.ts
+++ b/src/app/features/organization/staff/staff-form.component.ts
@@ -52,6 +52,21 @@ import {
   toIsoDate,
 } from '../../../core/utils/date-formatter';
 
+/**
+ * Drops optional fields the user left empty.
+ *
+ * The form seeds `mobileNo`, `externalId` and `emailAddress` to `''` so the inputs bind cleanly,
+ * but an empty string is a *value* on the wire, not an omission — and Fineract validates it as
+ * one. Leaving the mobile number blank produced "must contain only digits with an optional
+ * leading '+'", which named a field the user had deliberately not filled in and left the form
+ * unsaveable until they typed something into it.
+ */
+function withoutBlanks<T extends Record<string, unknown>>(payload: T): T {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== '' && value !== null),
+  ) as T;
+}
+
 @Component({
   selector: 'app-staff-form',
   standalone: true,
@@ -304,7 +319,7 @@ export class StaffFormComponent implements OnInit {
       });
     } else {
       const payload = {
-        ...this.staff(),
+        ...withoutBlanks(this.staff()),
         joiningDate: formatDateToFineract(this.joiningDate()),
         dateFormat: FINERACT_DATE_FORMAT,
         locale: FINERACT_LOCALE,


### PR DESCRIPTION
Two defects, both of which stop a save from going through and neither of which any existing test could catch. Found by driving the UI end to end against a real Fineract with no API seeding.

Closes #226
Closes #225

---

### 1. Every dated submission fails on the 1st to the 9th of the month

`formatDateToFineract` built the day with `d.getDate()`, producing `"2 August 2026"`, while all **39** of its callers send that value alongside `FINERACT_DATE_FORMAT = 'dd MMMM yyyy'`. `dd` means two digits, and Fineract parses strictly against the format it is told to use — so the unpadded day did not fail validation with a readable message, it failed to parse and came back an unhandled **500**.

A/B against a live instance, day padding the only variable:

```
joiningDate='2 August 2026'  -> HTTP 500
joiningDate='02 August 2026' -> HTTP 200
```

That covers staff, loan and savings creation, disbursement, repayment, interest pauses, post-dated checks, journal entries — essentially every dated write — for roughly a third of the calendar, including the 1st of the month, when disbursements and month-start bookings land. The toast says only "Operation failed", the date on screen looks valid, and retrying changes nothing.

It survived because `date-formatter.spec.ts` only ever exercised the 15th:

```ts
expect(formatDateToFineract(new Date(2026, 0, 15))).toBe('15 January 2026');
```

and two component specs then asserted the unpadded output as the expected payload, pinning the bug in place as intended behaviour. Both are corrected here.

Added coverage: single-digit days from both `Date` and array inputs, two-digit days left alone, and the invariant that actually matters — the formatter's day is fixed-width, matching the `dd` it is always sent with.

### 2. Staff cannot be created without a mobile number

The form seeds `mobileNo` and `externalId` to `''` so the inputs bind, then spreads them into the payload. An empty string is a value on the wire, not an omission:

> The parameter 'mobileNo' must contain only digits with an optional leading '+' and be between 7 and 15 digits

So an employee could not be created without typing a phone number, and the error named a field the form itself presents as optional. Employee records gate a lot of downstream work — loan officer and savings officer assignment, relationship managers, portfolio attribution — so a branch setting up its first office could not get started.

Blank optional fields are now dropped before submitting. `false` and `0` survive, since they are real values and `isLoanOfficer: false` would otherwise vanish.

Checked rather than assumed: the funds form has the same `''` seeding, but that endpoint accepts an empty `externalId`, so it is left alone.

---

### Verification

- `773` unit tests pass (up from 768: four new formatter cases, one new staff case). The one pre-existing failure was `interest-pause-form`, which had encoded the unpadded format.
- `tsc`, `lint`, `format:check` clean.
- Both fixes confirmed against a live Fineract, and the end-to-end walkthrough that surfaced them now gets past both steps.

### Note on why the mocked suite could not catch either

No mock parses a date or applies Fineract's parameter validation, so both defects are invisible to the mocked e2e project and to unit tests by construction — a spec can assert what the UI *sends*, but not that the server accepts it. Both were found only by driving real screens against a real backend.
