### PR TITLE
fix: use translations for savings account action buttons

### DIFF
--- a/src/app/features/products/savings-account-view.component.ts
+++ b/src/app/features/products/savings-account-view.component.ts
@@ -132,7 +132,7 @@ import {
                   [appTooltip]="'SAVINGS.APPROVE' | translate"
                 >
                   <ion-icon name="checkmark-circle-outline"></ion-icon>
-                  Approve
+                  {{ 'SAVINGS.APPROVE' | translate }}
                 </ion-button>
               }
               @if (account()?.status?.submittedAndPendingApproval) {
@@ -165,7 +165,7 @@ import {
                   [appTooltip]="'SAVINGS.ACTIVATE' | translate"
                 >
                   <ion-icon name="play-circle-outline"></ion-icon>
-                  Activate
+                  {{ 'SAVINGS.ACTIVATE' | translate }}
                 </ion-button>
               }
               @if (account()?.status?.active) {
@@ -176,7 +176,7 @@ import {
                   [appTooltip]="'SAVINGS.CLOSE' | translate"
                 >
                   <ion-icon name="power-outline"></ion-icon>
-                  Close
+                  {{ 'SAVINGS.CLOSE' | translate }}
                 </ion-button>
               }
               <ion-button
@@ -185,8 +185,8 @@ import {
                 (click)="onTransaction('deposit')"
                 [appTooltip]="'SAVINGS.DEPOSIT_CASH' | translate"
               >
-                <ion-icon name="add-circle-outline"></ion-icon>
-                Deposit
+                  <ion-icon name="add-circle-outline"></ion-icon>
+                  {{ 'SAVINGS.DEPOSIT' | translate }}
               </ion-button>
               <ion-button
                 color="danger"
@@ -194,8 +194,8 @@ import {
                 (click)="onTransaction('withdrawal')"
                 [appTooltip]="'SAVINGS.WITHDRAW_CASH' | translate"
               >
-                <ion-icon name="remove-circle-outline"></ion-icon>
-                Withdraw
+                  <ion-icon name="remove-circle-outline"></ion-icon>
+                  {{ 'SAVINGS.WITHDRAW' | translate }}
               </ion-button>
               @if (isActive()) {
                 <ion-button color="primary" id="savingsMenu-trigger" data-testid="savings-actions">

--- a/src/app/features/products/savings-account-view.component.ts
+++ b/src/app/features/products/savings-account-view.component.ts
@@ -185,8 +185,8 @@ import {
                 (click)="onTransaction('deposit')"
                 [appTooltip]="'SAVINGS.DEPOSIT_CASH' | translate"
               >
-                  <ion-icon name="add-circle-outline"></ion-icon>
-                  {{ 'SAVINGS.DEPOSIT' | translate }}
+                <ion-icon name="add-circle-outline"></ion-icon>
+                {{ 'SAVINGS.DEPOSIT' | translate }}
               </ion-button>
               <ion-button
                 color="danger"
@@ -194,8 +194,8 @@ import {
                 (click)="onTransaction('withdrawal')"
                 [appTooltip]="'SAVINGS.WITHDRAW_CASH' | translate"
               >
-                  <ion-icon name="remove-circle-outline"></ion-icon>
-                  {{ 'SAVINGS.WITHDRAW' | translate }}
+                <ion-icon name="remove-circle-outline"></ion-icon>
+                {{ 'SAVINGS.WITHDRAW' | translate }}
               </ion-button>
               @if (isActive()) {
                 <ion-button color="primary" id="savingsMenu-trigger" data-testid="savings-actions">


### PR DESCRIPTION
## What

Fixes #221 . Localizes the savings account view action buttons that were hard-coded in English.

## Why

On `/products/savings-accounts/view/:id`, the header row buttons **Approve**, **Activate**, **Close**, **Deposit**, and **Withdraw** had their labels written directly into the template, so they remained in English regardless of the selected application language.

Adjacent buttons such as **ACTIONS** and **BACK** already use the `translate` pipe and correctly update when the language changes. The loan account screen follows the same pattern using `{{ 'LOANS.APPROVE' | translate }}`, and each savings action button already had an `[appTooltip]` bound to the corresponding `SAVINGS.*` translation key.

## Changes

- Replaced the five hard-coded button labels in `savings-account-view.component.ts` with the existing translation keys:
  - `SAVINGS.APPROVE`
  - `SAVINGS.ACTIVATE`
  - `SAVINGS.CLOSE`
  - `SAVINGS.DEPOSIT`
  - `SAVINGS.WITHDRAW`
- No changes to `src/assets/i18n/en.json` were required, as all five translation keys already exist under the `SAVINGS` block.