### PR TITLE
fix(calendars): report a failed load instead of an empty list

### DIFF
--- a/e2e/list-pagination.spec.ts
+++ b/e2e/list-pagination.spec.ts
@@ -252,4 +252,33 @@ test.describe('List load failure', () => {
     await expect(page.getByTestId('data-table-error')).toHaveCount(0);
     await expect(firstAccountNo(page)).toHaveText('000000001');
   });
+
+  test('calendars: reports the failure and reloads when the user retries', async ({ page }) => {
+    await login(page);
+
+    let attempts = 0;
+    await page.route(/\/api\/v1\/centers\/2\/calendars(\?|$)/, async (route) => {
+      attempts += 1;
+      if (attempts === 1) {
+        await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 1, title: 'Weekly Meeting', startDate: [2026, 1, 15] }]),
+      });
+    });
+
+    await page.goto('/calendars/centers/2');
+
+    // Not "No records found": nobody knows whether there are records.
+    await expect(page.getByTestId('data-table-error')).toBeVisible();
+    await expect(page.locator('table.data-table')).toHaveCount(0);
+
+    await page.getByTestId('data-table-retry').click();
+
+    await expect(page.getByTestId('data-table-error')).toHaveCount(0);
+    await expect(page.locator('table.data-table')).toContainText('Weekly Meeting');
+  });
 });

--- a/src/app/features/calendars/calendars-list.component.spec.ts
+++ b/src/app/features/calendars/calendars-list.component.spec.ts
@@ -21,7 +21,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CalendarsListComponent } from './calendars-list.component';
 import { CalendarService } from '../../api';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
@@ -96,5 +96,39 @@ describe('CalendarsListComponent', () => {
     spyOn(window, 'confirm').and.returnValue(false);
     component.onDelete({ id: 5 });
     expect(serviceSpy.deleteEntityTypeEntityIdCalendarsCalendarId).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed load instead of an empty list', () => {
+    serviceSpy.getEntityTypeEntityIdCalendars.and.returnValue(
+      throwError(() => new Error('boom')) as unknown as ReturnType<
+        CalendarService['getEntityTypeEntityIdCalendars']
+      >,
+    );
+
+    component.load();
+
+    expect(component.hasError()).toBeTrue();
+    expect(component.calendars()).toHaveSize(0);
+  });
+
+  it('clears the error after a successful retry', () => {
+    serviceSpy.getEntityTypeEntityIdCalendars.and.returnValue(
+      throwError(() => new Error('boom')) as unknown as ReturnType<
+        CalendarService['getEntityTypeEntityIdCalendars']
+      >,
+    );
+    component.load();
+    expect(component.hasError()).toBeTrue();
+
+    serviceSpy.getEntityTypeEntityIdCalendars.and.returnValue(
+      of([{ id: 1, title: 'Weekly Meeting', startDate: '2026-01-15' }]) as unknown as ReturnType<
+        CalendarService['getEntityTypeEntityIdCalendars']
+      >,
+    );
+
+    component.onRetry();
+
+    expect(component.hasError()).toBeFalse();
+    expect(component.calendars()).toHaveSize(1);
   });
 });

--- a/src/app/features/calendars/calendars-list.component.ts
+++ b/src/app/features/calendars/calendars-list.component.ts
@@ -20,6 +20,8 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
 import { ColumnDef, CellTemplateDirective } from '../../shared';
 import { DataTableComponent } from '../../shared/components/data-table/data-table.component';
 import { CalendarService, CalendarData } from '../../api';
@@ -45,6 +47,8 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
   ],
   template: `
     <app-data-table
+      [hasError]="hasError()"
+      (retry)="onRetry()"
       title="CALENDARS.TITLE"
       helpTextKey="HELP.CALENDARS_DESC"
       createButtonLabel="CALENDARS.CREATE"
@@ -94,6 +98,8 @@ export class CalendarsListComponent implements OnInit {
   entityType!: string;
   entityId!: number;
   readonly calendars = signal<CalendarData[]>([]);
+  /** True when the last load failed, so the table offers a retry instead of an empty list. */
+  readonly hasError = signal(false);
 
   ngOnInit(): void {
     this.entityType = this.route.snapshot.paramMap.get('entityType') ?? '';
@@ -102,14 +108,22 @@ export class CalendarsListComponent implements OnInit {
   }
 
   load(): void {
-    this.calendarService.getEntityTypeEntityIdCalendars(this.entityType, this.entityId).subscribe({
-      next: (data: CalendarData[]) => {
+    this.calendarService
+      .getEntityTypeEntityIdCalendars(this.entityType, this.entityId)
+      .pipe(
+        tap(() => this.hasError.set(false)),
+        catchError(() => {
+          this.hasError.set(true);
+          return of([] as CalendarData[]);
+        }),
+      )
+      .subscribe((data: CalendarData[]) => {
         this.calendars.set(data || []);
-      },
-      error: (err: unknown) => {
-        console.error('Failed to load calendars', err);
-      },
-    });
+      });
+  }
+
+  onRetry(): void {
+    this.load();
   }
 
   formatDate(value: string | undefined): string {


### PR DESCRIPTION
calendars-list called catchError(() => of([])) directly, so a failed request rendered the same "No records found" table as a group or center with zero calendars — indistinguishable to the user and with no way to try again short of reloading. Wires it into app-data-table's existing hasError/retry inputs instead, following the pattern already used by loan-products-list and the other screens converted in #223.

Part of #223.