### PR TITLE
ci: cancel superseded workflow runs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ on:
       - main
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dependencies:
     name: Dependency Integrity

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,10 @@ on:
   schedule:
     - cron: '40 11 * * 4'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,10 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Granted per job rather than here: a workflow-level `pull-requests: write` hands
 # that token to every step in every job, including the ones that run npm install
 # and Playwright. Each job below re-declares the minimum it needs.


### PR DESCRIPTION
## What and why

Add a `concurrency` group to `ci.yml`, `e2e.yml` and `codeql.yml` so a new push to a pull request cancels the run for the code it replaced. This speeds up feedback (superseded runs no longer hold runner slots) and removes ambiguous results where a PR briefly shows two commits' worth of statuses.

The group is keyed on `${{ github.workflow }}-${{ github.ref }}` so the workflows never cancel each other, and `cancel-in-progress` is `${{ github.event_name == 'pull_request' }}` so only PR runs are cancelled — pushes to `main` still run to completion and each commit keeps its result.

Closes #235

## Verification

- Confirmed `zizmor.yml` and `api-spec-sync.yml` already declare `concurrency` groups, so only the three missing workflows were changed.
- All three edited files parse as valid YAML and pass `prettier --check`.
- This is native GitHub Actions syntax — no new action, so nothing to review against the ASF third-party Actions allowlist.

## Screenshots

Not applicable (non-UI change).

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. (N/A — workflow-only change)
- [x] User-facing strings use translation keys. (N/A — no UI strings)
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed. (Workflow-only change; verified YAML parses and passes Prettier. The repo's own `zizmor` and CodeQL `actions` analysis will lint the new blocks on CI.)
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. (N/A — no UI workflow changes)
