### PR TITLE
fix: show domain rule errors for 403 responses

### DIFF
--- a/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/src/app/core/interceptors/error.interceptor.spec.ts
@@ -268,6 +268,33 @@ describe('errorInterceptor', () => {
       expect(routerSpy.navigate).not.toHaveBeenCalled();
     });
 
+    it('should report the platform reason for a domain rule violation', () => {
+      httpClient.get(testUrl, authorized).subscribe({ error: () => expect().nothing() });
+
+      httpTestingController.expectOne(testUrl).flush(
+        {
+          userMessageGlobalisationCode: 'validation.msg.domain.rule.violation',
+          defaultUserMessage: 'Errors contain reason for domain rule violation.',
+          errors: [
+            {
+              defaultUserMessage:
+                'Group cannot be closed because of active clients associated with it.',
+              userMessageGlobalisationCode: 'error.msg.Group.close.active.clients.exist',
+              parameterName: 'id',
+            },
+          ],
+        },
+        { status: 403, statusText: 'Forbidden' },
+      );
+
+      expect(notificationsSpy.error).toHaveBeenCalledWith(
+        'Errors contain reason for domain rule violation.\n\n' +
+          '\u2022 [id] Group cannot be closed because of active clients associated with it.',
+      );
+      expect(authSpy.logout).not.toHaveBeenCalled();
+      expect(routerSpy.navigate).not.toHaveBeenCalled();
+    });
+
     it('should stay silent when the caller opts out', () => {
       httpClient
         .get(testUrl, { context: skipErrorToast() })

--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -55,14 +55,19 @@ function messageFor(error: HttpErrorResponse, i18n: I18nAdapter): string {
     return `Error: ${error.error.message}`;
   }
 
+  const hasValidationErrors = Array.isArray(error.error?.errors) && error.error.errors.length > 0;
+  const isDomainRuleViolation =
+    error.error?.userMessageGlobalisationCode === 'validation.msg.domain.rule.violation' ||
+    hasValidationErrors;
+
   // Fineract's 403 body describes the missing permission in backend terms ("NOT_ALLOWED",
   // a permission code) which means nothing to the user. What they can act on is that this
   // account lacks the right, not which internal code was checked.
-  if (error.status === 403) {
+  if (error.status === 403 && !isDomainRuleViolation) {
     return i18n.translate('COMMON.ERRORS.FORBIDDEN');
   }
 
-  if (error.error?.errors && Array.isArray(error.error.errors) && error.error.errors.length > 0) {
+  if (hasValidationErrors) {
     const stacked = error.error.errors
       .map((err: Record<string, unknown>) => {
         const msg = err['developerMessage'] || err['defaultUserMessage'] || 'Validation error';


### PR DESCRIPTION
## What and why

Show Fineract's domain-rule explanation for 403 responses while keeping the generic permission message for authorization failures.

Closes #258

## Verification

- Focused interceptor suite: 13 passed
- npm run lint
- npm run build
- npm run check:icons
- npm run i18n:check

## Screenshots

Not applicable.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] No new component or service code was added.
- [x] No user-facing strings were added.
- [x] I added regression coverage for the domain-rule response.
- [x] No UI workflow changed.