### PR TITLE
feat(loans): disburse to savings, unassign loan officer, undo last disbursal, and the asset transfers tab

### DIFF
--- a/e2e/loan-servicing-gaps.spec.ts
+++ b/e2e/loan-servicing-gaps.spec.ts
@@ -43,9 +43,13 @@ const LOAN_ID = 456;
 const MENU_TRIGGER = '#loanMenu-trigger';
 const UNDO_APPROVAL_ITEM = 'loan-undo-approval-action';
 const WRONG_CLIENT = 'approved against the wrong client';
+const OFFICER_NAME = 'Field Officer';
 
 interface LoanOverrides {
   status?: Record<string, unknown>;
+  loanOfficerId?: number;
+  loanOfficerName?: string;
+  multiDisburseLoan?: boolean;
   loanTermVariations?: unknown[];
   overdueCharges?: unknown[];
   originators?: unknown[];
@@ -271,6 +275,88 @@ test.describe('Loan servicing gaps', () => {
 
     await tab(page, 'loan-tab-originators').click();
     await expect(page.getByRole('cell', { name: 'Partner Agent' })).toBeVisible();
+  });
+
+  test('disburse to savings sends the date and amount, with the platform date format', async ({
+    page,
+  }) => {
+    const probe = await loginWithLoan(page, { status: APPROVED });
+
+    await page.goto(`/loans/view/${LOAN_ID}`);
+    await page.locator(MENU_TRIGGER).click();
+    await page.getByTestId('loan-disburse-to-savings-action').click();
+    await page.getByTestId('disburse-to-savings-confirm').click();
+
+    await expect.poll(() => probe.commands.length).toBe(1);
+    expect(probe.commands[0].command).toBe('disbursetosavings');
+    const body = probe.commands[0].body as Record<string, unknown>;
+    // Unlike undoapproval, this command *does* take locale and dateFormat, and the date has to
+    // be in the platform's own format rather than the ISO the picker produces.
+    expect(body['dateFormat']).toBe('dd MMMM yyyy');
+    expect(body['locale']).toBe('en');
+    expect(body['actualDisbursementDate']).toMatch(/^\d{2} \w+ \d{4}$/);
+    expect(body['transactionAmount']).toBe(5000);
+  });
+
+  test('disburse to savings is offered only on an approved loan', async ({ page }) => {
+    await loginWithLoan(page, {});
+
+    await page.goto(`/loans/view/${LOAN_ID}`);
+    await page.locator(MENU_TRIGGER).click();
+
+    await expect(page.getByTestId('loan-disburse-to-savings-action')).toHaveCount(0);
+  });
+
+  test('unassign loan officer sends the date, and appears only when one is assigned', async ({
+    page,
+  }) => {
+    const probe = await loginWithLoan(page, { loanOfficerId: 7, loanOfficerName: OFFICER_NAME });
+
+    await page.goto(`/loans/view/${LOAN_ID}`);
+    await page.locator(MENU_TRIGGER).click();
+    await page.getByTestId('loan-unassign-officer-action').click();
+    await page.getByTestId('unassign-officer-confirm').click();
+
+    await expect.poll(() => probe.commands.length).toBe(1);
+    expect(probe.commands[0].command).toBe('unassignloanofficer');
+    const body = probe.commands[0].body as Record<string, unknown>;
+    expect(body['unassignedDate']).toMatch(/^\d{2} \w+ \d{4}$/);
+    expect(body['dateFormat']).toBe('dd MMMM yyyy');
+  });
+
+  test('unassign loan officer is hidden on a loan with no officer', async ({ page }) => {
+    await loginWithLoan(page, {});
+
+    await page.goto(`/loans/view/${LOAN_ID}`);
+    await page.locator(MENU_TRIGGER).click();
+
+    await expect(page.getByTestId('loan-unassign-officer-action')).toHaveCount(0);
+  });
+
+  test('undo last disbursal appears only on a multi-disbursal loan, and sends an empty body', async ({
+    page,
+  }) => {
+    const probe = await loginWithLoan(page, { multiDisburseLoan: true });
+
+    await page.goto(`/loans/view/${LOAN_ID}`);
+    await page.locator(MENU_TRIGGER).click();
+    await page.getByTestId('loan-undo-last-disbursal-action').click();
+    await page.getByRole('button', { name: 'Confirm' }).click();
+
+    await expect.poll(() => probe.commands.length).toBe(1);
+    expect(probe.commands[0].command).toBe('undoLastDisbursal');
+    expect(probe.commands[0].body).toEqual({});
+  });
+
+  test('undo last disbursal is hidden on a single-disbursal loan', async ({ page }) => {
+    await loginWithLoan(page, {});
+
+    await page.goto(`/loans/view/${LOAN_ID}`);
+    await page.locator(MENU_TRIGGER).click();
+
+    // The platform can only ever answer 403 there. An action whose sole outcome is an error
+    // is worse than no action at all.
+    await expect(page.getByTestId('loan-undo-last-disbursal-action')).toHaveCount(0);
   });
 
   test('close as rescheduled is offered on an active loan', async ({ page }) => {

--- a/src/app/features/loans/loan-command-dialogs.spec.ts
+++ b/src/app/features/loans/loan-command-dialogs.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { LoanDisburseToSavingsDialogComponent } from './loan-disburse-to-savings-dialog.component';
+import { LoanUnassignOfficerDialogComponent } from './loan-unassign-officer-dialog.component';
+import { provideFakeAdapters, FakeOverlayAdapter } from '../../testing/adapters';
+
+const DISBURSEMENT_DATE = '2026-08-08';
+
+describe('LoanDisburseToSavingsDialogComponent', () => {
+  let fixture: ComponentFixture<LoanDisburseToSavingsDialogComponent>;
+  let component: LoanDisburseToSavingsDialogComponent;
+  let overlay: FakeOverlayAdapter;
+
+  async function setup(amount?: number): Promise<void> {
+    const adapters = provideFakeAdapters();
+    overlay = adapters.overlay;
+
+    await TestBed.configureTestingModule({
+      imports: [LoanDisburseToSavingsDialogComponent],
+      providers: [provideNoopAnimations(), ...adapters.providers],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoanDisburseToSavingsDialogComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('data', { amount });
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  it('offers the loan principal as the amount, without demanding it', async () => {
+    await setup(1000);
+
+    expect(component.amount()).toBe(1000);
+    expect(component.isValid()).toBeTrue();
+  });
+
+  it('refuses to submit an amount of zero', async () => {
+    await setup(1000);
+    component.amount.set(0);
+
+    // A disbursement of nothing is not a disbursement, and the platform would reject it after
+    // a round trip. Better to not send it.
+    expect(component.isValid()).toBeFalse();
+    component.onConfirm();
+    expect(overlay.dismissals).toEqual([]);
+  });
+
+  it('sends the date and amount, and omits an empty note', async () => {
+    await setup(1000);
+    component.disbursementDate.set(DISBURSEMENT_DATE);
+
+    component.onConfirm();
+
+    expect(overlay.dismissals).toEqual([
+      { actualDisbursementDate: DISBURSEMENT_DATE, transactionAmount: 1000 },
+    ]);
+  });
+
+  it('carries a note when one was written', async () => {
+    await setup(500);
+    component.disbursementDate.set(DISBURSEMENT_DATE);
+    component.note.set('  paid into the group account  ');
+
+    component.onConfirm();
+
+    expect(overlay.dismissals).toEqual([
+      {
+        actualDisbursementDate: DISBURSEMENT_DATE,
+        transactionAmount: 500,
+        note: 'paid into the group account',
+      },
+    ]);
+  });
+});
+
+describe('LoanUnassignOfficerDialogComponent', () => {
+  let fixture: ComponentFixture<LoanUnassignOfficerDialogComponent>;
+  let component: LoanUnassignOfficerDialogComponent;
+  let overlay: FakeOverlayAdapter;
+
+  beforeEach(async () => {
+    const adapters = provideFakeAdapters();
+    overlay = adapters.overlay;
+
+    await TestBed.configureTestingModule({
+      imports: [LoanUnassignOfficerDialogComponent],
+      providers: [provideNoopAnimations(), ...adapters.providers],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoanUnassignOfficerDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('sends the date the officer stopped being responsible', () => {
+    component.unassignedDate.set('2026-07-31');
+
+    component.onConfirm();
+
+    expect(overlay.dismissals).toEqual([{ unassignedDate: '2026-07-31' }]);
+  });
+
+  it('sends nothing when cancelled, so no command is issued', () => {
+    component.onCancel();
+
+    expect(overlay.dismissals).toEqual([undefined]);
+  });
+
+  it('will not submit without a date', () => {
+    component.unassignedDate.set('');
+
+    component.onConfirm();
+
+    // The date is the substance of this command — it decides which officer the loan counts
+    // against for the period — so there is no sensible default to fall back on.
+    expect(overlay.dismissals).toEqual([]);
+  });
+});

--- a/src/app/features/loans/loan-disburse-to-savings-dialog.component.ts
+++ b/src/app/features/loans/loan-disburse-to-savings-dialog.component.ts
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  IonButton,
+  IonDatetime,
+  IonDatetimeButton,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonModal,
+  IonTextarea,
+} from '@ionic/angular/standalone';
+
+import { OVERLAY, TranslatePipe } from '../../core/adapters';
+import { toIsoDate } from '../../core/utils/date-formatter';
+
+export interface LoanDisburseToSavingsData {
+  /** Defaults the amount, so the common case is a single click. */
+  amount?: number;
+  currency?: string;
+}
+
+export interface LoanDisburseToSavingsResult {
+  actualDisbursementDate: string;
+  transactionAmount: number;
+  note?: string;
+}
+
+/**
+ * Collects what `disbursetosavings` needs: the date the money moved and how much.
+ *
+ * There is deliberately no savings-account picker. The destination is the savings account
+ * linked to the loan when the application was made, not something chosen at disbursement —
+ * the platform refuses the command outright on a loan without one, answering
+ * "requires linked savings account for payment". Offering a picker would imply a choice that
+ * does not exist.
+ */
+@Component({
+  selector: 'app-loan-disburse-to-savings-dialog',
+  standalone: true,
+  imports: [
+    FormsModule,
+    TranslatePipe,
+    IonButton,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonTextarea,
+    IonDatetime,
+    IonDatetimeButton,
+    IonModal,
+  ],
+  template: `
+    <h2 class="dialog-title">{{ 'LOANS.ACTIONS.DISBURSE_TO_SAVINGS' | appTranslate }}</h2>
+    <div class="dialog-content">
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'LOANS.DISBURSEMENT_DATE' | appTranslate }}</ion-label>
+        <ion-datetime-button datetime="disburse-to-savings-date"></ion-datetime-button>
+        <ion-modal [keepContentsMounted]="true">
+          <ng-template>
+            <ion-datetime
+              id="disburse-to-savings-date"
+              data-testid="disburse-to-savings-date"
+              presentation="date"
+              name="actualDisbursementDate"
+              [ngModel]="disbursementDate()"
+              (ngModelChange)="disbursementDate.set($event)"
+              required
+            ></ion-datetime>
+          </ng-template>
+        </ion-modal>
+      </ion-item>
+
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'COMMON.AMOUNT' | appTranslate }}</ion-label>
+        <ion-input
+          type="number"
+          name="transactionAmount"
+          data-testid="disburse-to-savings-amount"
+          [attr.aria-label]="'COMMON.AMOUNT' | appTranslate"
+          [ngModel]="amount()"
+          (ngModelChange)="amount.set($event)"
+          required
+        ></ion-input>
+      </ion-item>
+
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'COMMON.NOTE' | appTranslate }}</ion-label>
+        <ion-textarea
+          name="note"
+          data-testid="disburse-to-savings-note"
+          rows="2"
+          [ngModel]="note()"
+          (ngModelChange)="note.set($event)"
+        ></ion-textarea>
+      </ion-item>
+    </div>
+    <div class="dialog-actions">
+      <ion-button fill="clear" color="medium" (click)="onCancel()">
+        {{ 'COMMON.CANCEL' | appTranslate }}
+      </ion-button>
+      <ion-button
+        color="primary"
+        data-testid="disburse-to-savings-confirm"
+        [disabled]="!isValid()"
+        (click)="onConfirm()"
+      >
+        {{ 'COMMON.CONFIRM' | appTranslate }}
+      </ion-button>
+    </div>
+  `,
+  styles: [
+    `
+      .dialog-content {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding-top: 8px;
+        min-width: 350px;
+      }
+      .full-width {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class LoanDisburseToSavingsDialogComponent {
+  private readonly overlay = inject(OVERLAY);
+
+  readonly data = input<LoanDisburseToSavingsData>({});
+
+  readonly disbursementDate = signal(toIsoDate(new Date()));
+  readonly amount = signal<number | null>(null);
+  readonly note = signal('');
+
+  constructor() {
+    // The loan's own principal is what is normally disbursed, so it is offered rather than
+    // demanded — but it stays editable, because a tranche is not the whole principal.
+    queueMicrotask(() => this.amount.set(this.data().amount ?? null));
+  }
+
+  isValid(): boolean {
+    const amount = this.amount();
+    return !!this.disbursementDate() && amount !== null && Number(amount) > 0;
+  }
+
+  onCancel(): void {
+    void this.overlay.dismissModal();
+  }
+
+  onConfirm(): void {
+    if (!this.isValid()) return;
+    const note = this.note().trim();
+    void this.overlay.dismissModal<LoanDisburseToSavingsResult>({
+      actualDisbursementDate: this.disbursementDate(),
+      transactionAmount: Number(this.amount()),
+      ...(note ? { note } : {}),
+    });
+  }
+}

--- a/src/app/features/loans/loan-unassign-officer-dialog.component.ts
+++ b/src/app/features/loans/loan-unassign-officer-dialog.component.ts
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  IonButton,
+  IonDatetime,
+  IonDatetimeButton,
+  IonItem,
+  IonLabel,
+  IonModal,
+} from '@ionic/angular/standalone';
+
+import { OVERLAY, TranslatePipe } from '../../core/adapters';
+import { toIsoDate } from '../../core/utils/date-formatter';
+
+export interface LoanUnassignOfficerResult {
+  unassignedDate: string;
+}
+
+/**
+ * Collects the date a loan officer stopped being responsible for a loan.
+ *
+ * The date is the whole point rather than a formality: it decides which officer a loan counts
+ * against in every per-officer report for the period, so backdating it to the day someone
+ * actually left is the difference between a correct portfolio figure and a fictional one.
+ */
+@Component({
+  selector: 'app-loan-unassign-officer-dialog',
+  standalone: true,
+  imports: [
+    FormsModule,
+    TranslatePipe,
+    IonButton,
+    IonItem,
+    IonLabel,
+    IonDatetime,
+    IonDatetimeButton,
+    IonModal,
+  ],
+  template: `
+    <h2 class="dialog-title">{{ 'LOANS.ACTIONS.UNASSIGN_LOAN_OFFICER' | appTranslate }}</h2>
+    <div class="dialog-content">
+      <p class="dialog-message">{{ 'LOANS.CONFIRM_UNASSIGN_LOAN_OFFICER' | appTranslate }}</p>
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'LOANS.UNASSIGNED_DATE' | appTranslate }}</ion-label>
+        <ion-datetime-button datetime="unassign-officer-date"></ion-datetime-button>
+        <ion-modal [keepContentsMounted]="true">
+          <ng-template>
+            <ion-datetime
+              id="unassign-officer-date"
+              data-testid="unassign-officer-date"
+              presentation="date"
+              name="unassignedDate"
+              [ngModel]="unassignedDate()"
+              (ngModelChange)="unassignedDate.set($event)"
+              required
+            ></ion-datetime>
+          </ng-template>
+        </ion-modal>
+      </ion-item>
+    </div>
+    <div class="dialog-actions">
+      <ion-button fill="clear" color="medium" (click)="onCancel()">
+        {{ 'COMMON.CANCEL' | appTranslate }}
+      </ion-button>
+      <ion-button
+        color="primary"
+        data-testid="unassign-officer-confirm"
+        [disabled]="!unassignedDate()"
+        (click)="onConfirm()"
+      >
+        {{ 'COMMON.CONFIRM' | appTranslate }}
+      </ion-button>
+    </div>
+  `,
+  styles: [
+    `
+      .dialog-content {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding-top: 8px;
+        min-width: 350px;
+      }
+      .dialog-message {
+        margin: 0;
+      }
+      .full-width {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class LoanUnassignOfficerDialogComponent {
+  private readonly overlay = inject(OVERLAY);
+
+  readonly unassignedDate = signal(toIsoDate(new Date()));
+
+  onCancel(): void {
+    void this.overlay.dismissModal();
+  }
+
+  onConfirm(): void {
+    if (!this.unassignedDate()) return;
+    void this.overlay.dismissModal<LoanUnassignOfficerResult>({
+      unassignedDate: this.unassignedDate(),
+    });
+  }
+}

--- a/src/app/features/loans/loan-view.component.ts
+++ b/src/app/features/loans/loan-view.component.ts
@@ -50,6 +50,7 @@ import {
   LoanUnassignOfficerDialogComponent,
   LoanUnassignOfficerResult,
 } from './loan-unassign-officer-dialog.component';
+import { LoanAssetTransfersTabComponent } from './tabs/loan-asset-transfers-tab.component';
 import { LoanOverdueCharge } from './tabs/loan-overdue-charge.model';
 import { LoanNotesTabComponent } from './loan-notes-tab.component';
 import { LoanDocumentsTabComponent } from './loan-documents-tab.component';
@@ -126,6 +127,7 @@ import {
     LoanOverdueChargesTabComponent,
     LoanOriginatorsTabComponent,
     LoanStandingInstructionsTabComponent,
+    LoanAssetTransfersTabComponent,
   ],
   template: `
     @if (loan()) {
@@ -553,6 +555,9 @@ import {
           }
           <ion-segment-button value="15" data-testid="loan-tab-standing-instructions">
             <ion-label>{{ 'LOANS.STANDING_INSTRUCTIONS' | translate }}</ion-label>
+          </ion-segment-button>
+          <ion-segment-button value="16" data-testid="loan-tab-asset-transfers">
+            <ion-label>{{ 'LOANS.ASSET_TRANSFERS' | translate }}</ion-label>
           </ion-segment-button>
         </ion-segment>
 
@@ -1289,6 +1294,11 @@ import {
               [loanId]="loanId()"
               [clientId]="loan()?.clientId"
             ></app-loan-standing-instructions-tab>
+          </div>
+        }
+        @if (activeTab() === '16') {
+          <div class="tab-content">
+            <app-loan-asset-transfers-tab [loanId]="loanId()"></app-loan-asset-transfers-tab>
           </div>
         }
       </div>

--- a/src/app/features/loans/loan-view.component.ts
+++ b/src/app/features/loans/loan-view.component.ts
@@ -27,6 +27,11 @@ import { StatusBadgeComponent } from '../../shared/components/status-badge/statu
 import { EntityDatatablesComponent } from '../../shared/components/entity-datatables/entity-datatables.component';
 import { LOAN_SCHEDULE_TYPE } from '../products/loan-schedule-type';
 import { DialogService } from '../../core/services/dialog.service';
+import {
+  FINERACT_DATE_FORMAT,
+  FINERACT_LOCALE,
+  formatDateToFineract,
+} from '../../core/utils/date-formatter';
 import { HasPermissionDirective } from '../../shared';
 import {
   LoanUndoApprovalDialogComponent,
@@ -37,6 +42,14 @@ import { LoanTermVariationsTabComponent } from './tabs/loan-term-variations-tab.
 import { LoanOverdueChargesTabComponent } from './tabs/loan-overdue-charges-tab.component';
 import { LoanOriginatorsTabComponent } from './tabs/loan-originators-tab.component';
 import { LoanStandingInstructionsTabComponent } from './tabs/loan-standing-instructions-tab.component';
+import {
+  LoanDisburseToSavingsDialogComponent,
+  LoanDisburseToSavingsResult,
+} from './loan-disburse-to-savings-dialog.component';
+import {
+  LoanUnassignOfficerDialogComponent,
+  LoanUnassignOfficerResult,
+} from './loan-unassign-officer-dialog.component';
 import { LoanOverdueCharge } from './tabs/loan-overdue-charge.model';
 import { LoanNotesTabComponent } from './loan-notes-tab.component';
 import { LoanDocumentsTabComponent } from './loan-documents-tab.component';
@@ -231,6 +244,18 @@ import {
                     @if (isLoanApproved) {
                       <ion-item
                         button
+                        data-testid="loan-disburse-to-savings-action"
+                        (click)="onDisburseToSavings()"
+                        *appHasPermission="'DISBURSETOSAVINGS_LOAN'"
+                      >
+                        <ion-icon slot="start" name="wallet-outline"></ion-icon>
+                        <ion-label>
+                          {{ 'LOANS.ACTIONS.DISBURSE_TO_SAVINGS' | translate }}
+                        </ion-label>
+                      </ion-item>
+
+                      <ion-item
+                        button
                         data-testid="loan-undo-approval-action"
                         (click)="onUndoApproval()"
                         *appHasPermission="'APPROVALUNDO_LOAN'"
@@ -249,6 +274,34 @@ import {
                       <ion-icon slot="start" name="person-add-outline"></ion-icon>
                       <ion-label>{{ 'LOANS.ACTIONS.ASSIGN_LOAN_OFFICER' | translate }}</ion-label>
                     </ion-item>
+
+                    @if (hasLoanOfficer()) {
+                      <ion-item
+                        button
+                        data-testid="loan-unassign-officer-action"
+                        (click)="onUnassignLoanOfficer()"
+                        *appHasPermission="'REMOVELOANOFFICER_LOAN'"
+                      >
+                        <ion-icon slot="start" name="person-remove-outline"></ion-icon>
+                        <ion-label>
+                          {{ 'LOANS.ACTIONS.UNASSIGN_LOAN_OFFICER' | translate }}
+                        </ion-label>
+                      </ion-item>
+                    }
+
+                    @if (isLoanActive && isMultiDisburse()) {
+                      <ion-item
+                        button
+                        data-testid="loan-undo-last-disbursal-action"
+                        (click)="onUndoLastDisbursal()"
+                        *appHasPermission="'DISBURSALLASTUNDO_LOAN'"
+                      >
+                        <ion-icon slot="start" name="arrow-undo-outline"></ion-icon>
+                        <ion-label>
+                          {{ 'LOANS.ACTIONS.UNDO_LAST_DISBURSAL' | translate }}
+                        </ion-label>
+                      </ion-item>
+                    }
 
                     @if (isLoanActive) {
                       <ion-item button (click)="onUndoDisbursal()">
@@ -1499,6 +1552,19 @@ export class LoanViewComponent implements OnInit {
   readonly hasOverdueCharges = computed(() => this.overdueCharges().length > 0);
   readonly hasOriginators = computed(() => (this.loan()?.originators ?? []).length > 0);
 
+  readonly hasLoanOfficer = computed(() => !!this.loan()?.loanOfficerId);
+
+  /**
+   * `multiDisburseLoan` is absent from the generated response type even though every loan
+   * carries it, so it is read through a declared shape — same as `overdueCharges`.
+   *
+   * Gating on it keeps "Undo Last Disbursal" off a single-disbursal loan, where the platform
+   * can only ever answer 403 `loan.product.does.not.support.multiple.disbursals`.
+   */
+  readonly isMultiDisburse = computed(
+    () => (this.loan() as unknown as { multiDisburseLoan?: boolean })?.multiDisburseLoan === true,
+  );
+
   private readonly conditionalTabs: Record<string, Signal<boolean>> = {
     '7': this.showBuyDownFees,
     '8': this.showCapitalizedIncome,
@@ -1799,6 +1865,72 @@ export class LoanViewComponent implements OnInit {
         this.loadLoanData();
       },
       // No toast here: errorInterceptor already raises one with the platform's own message.
+      error: () => undefined,
+    });
+  }
+
+  /**
+   * Disburses into the savings account the loan was linked to at application time.
+   *
+   * There is no destination to choose — the platform refuses the command on a loan with no
+   * linked account ("requires linked savings account for payment"), so the dialog collects
+   * only the date and the amount.
+   */
+  async onDisburseToSavings(): Promise<void> {
+    const result = await this.dialogService.open<LoanDisburseToSavingsResult>(
+      LoanDisburseToSavingsDialogComponent,
+      { data: { amount: this.loan()?.principal } },
+    );
+    if (!result) return;
+
+    this.runLoanCommand('disbursetosavings', {
+      ...result,
+      actualDisbursementDate: formatDateToFineract(new Date(result.actualDisbursementDate)),
+      dateFormat: FINERACT_DATE_FORMAT,
+      locale: FINERACT_LOCALE,
+    });
+  }
+
+  /** Takes the loan officer off the loan from a given date. */
+  async onUnassignLoanOfficer(): Promise<void> {
+    const result = await this.dialogService.open<LoanUnassignOfficerResult>(
+      LoanUnassignOfficerDialogComponent,
+    );
+    if (!result) return;
+
+    this.runLoanCommand('unassignloanofficer', {
+      unassignedDate: formatDateToFineract(new Date(result.unassignedDate)),
+      dateFormat: FINERACT_DATE_FORMAT,
+      locale: FINERACT_LOCALE,
+    });
+  }
+
+  /**
+   * Reverses the most recent tranche of a multi-disbursal loan.
+   *
+   * Sends an empty body, matching its sibling `undoDisbursal` rather than the shared action
+   * form — see {@link onUndoApproval} for why that form is not usable for parameterless
+   * commands.
+   */
+  onUndoLastDisbursal(): void {
+    this.confirm(
+      'LOANS.ACTIONS.UNDO_LAST_DISBURSAL',
+      'LOANS.CONFIRM_UNDO_LAST_DISBURSAL',
+      true,
+    ).subscribe((confirmed) => {
+      if (!confirmed) return;
+      this.runLoanCommand('undoLastDisbursal', {});
+    });
+  }
+
+  /** Posts a loan state-transition command and re-reads the loan, with one success toast. */
+  private runLoanCommand(command: string, body: Record<string, unknown>): void {
+    this.loansService.postLoansLoanId(this.loanId(), body, command).subscribe({
+      next: () => {
+        this.notifications.success(this.translate.instant('LOANS.COMMAND_APPLIED'));
+        this.loadLoanData();
+      },
+      // No toast: errorInterceptor already raises one with the platform's own message.
       error: () => undefined,
     });
   }

--- a/src/app/features/loans/tabs/loan-asset-transfers-tab.component.ts
+++ b/src/app/features/loans/tabs/loan-asset-transfers-tab.component.ts
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit, inject, input, signal } from '@angular/core';
+
+import { CellTemplateDirective, ColumnDef, DataTableComponent } from '../../../shared';
+import { ExternalAssetOwnersService } from '../../../api';
+
+interface AssetTransferRow {
+  transferExternalId?: string;
+  owner?: { externalId?: string };
+  ownerExternalId?: string;
+  status?: string;
+  purchasePriceRatio?: number;
+  settlementDate?: string;
+  effectiveFrom?: string;
+  effectiveTo?: string;
+}
+
+/**
+ * Whether this loan has been sold on, and to whom.
+ *
+ * An officer looking at a loan the institution no longer owns has no indication of it today —
+ * the screen looks exactly the same as for a loan still on the books, which is the wrong
+ * impression to give anyone deciding how to service it.
+ *
+ * Always offered rather than hidden when empty, unlike the term-variation and originator tabs.
+ * "This loan has not been sold" is a real and reassuring answer; the absence of a tab is not.
+ */
+@Component({
+  selector: 'app-loan-asset-transfers-tab',
+  standalone: true,
+  imports: [DataTableComponent, CellTemplateDirective],
+  template: `
+    <app-data-table
+      [data]="transfers()"
+      [columns]="columns"
+      [isLoading]="isLoading()"
+      [hasError]="hasError()"
+      (retry)="load()"
+      [localLogic]="true"
+    >
+      <ng-template appCellTemplate="ownerExternalId" let-row>
+        {{ row.owner?.externalId || row.ownerExternalId || '-' }}
+      </ng-template>
+    </app-data-table>
+  `,
+})
+export class LoanAssetTransfersTabComponent implements OnInit {
+  readonly loanId = input.required<number>();
+
+  private readonly assetOwners = inject(ExternalAssetOwnersService);
+
+  readonly transfers = signal<AssetTransferRow[]>([]);
+  readonly isLoading = signal(false);
+  readonly hasError = signal(false);
+
+  columns: ColumnDef[] = [
+    { key: 'transferExternalId', label: 'LOANS.TRANSFER_ID' },
+    { key: 'ownerExternalId', label: 'LOANS.OWNER' },
+    { key: 'status', label: 'COMMON.STATUS' },
+    { key: 'purchasePriceRatio', label: 'LOANS.PURCHASE_PRICE_RATIO' },
+    { key: 'settlementDate', label: 'LOANS.SETTLEMENT_DATE' },
+    { key: 'effectiveFrom', label: 'LOANS.EFFECTIVE_FROM' },
+  ];
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    // This endpoint answers a Spring page envelope — `content`, not the `pageItems` the rest of
+    // the platform returns — so the rows are read from there. Positional arguments again:
+    // (transferExternalId, loanId, loanExternalId, offset, limit), so `loanId` is second.
+    this.assetOwners
+      .getExternalAssetOwnersTransfers(undefined, this.loanId(), undefined, 0, 200)
+      .subscribe({
+        next: (page) => {
+          const envelope = page as unknown as { content?: AssetTransferRow[] };
+          this.transfers.set(envelope?.content ?? []);
+          this.hasError.set(false);
+          this.isLoading.set(false);
+        },
+        error: () => {
+          this.hasError.set(true);
+          this.isLoading.set(false);
+        },
+      });
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -596,7 +596,13 @@
     "UNASSIGNED_DATE": "Unassigned Date",
     "COMMAND_APPLIED": "Done.",
     "CONFIRM_UNASSIGN_LOAN_OFFICER": "The loan stops counting towards this officer from the date you choose. Backdate it to the day they actually stopped, or every report for the period in between will still credit them.",
-    "CONFIRM_UNDO_LAST_DISBURSAL": "This reverses the most recent tranche released on this loan. The schedule is recalculated without it."
+    "CONFIRM_UNDO_LAST_DISBURSAL": "This reverses the most recent tranche released on this loan. The schedule is recalculated without it.",
+    "ASSET_TRANSFERS": "Asset Transfers",
+    "TRANSFER_ID": "Transfer ID",
+    "OWNER": "Owner",
+    "PURCHASE_PRICE_RATIO": "Purchase Price Ratio",
+    "SETTLEMENT_DATE": "Settlement Date",
+    "EFFECTIVE_FROM": "Effective From"
   },
   "TEMPLATES": {
     "TITLE": "Document Templates",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -512,7 +512,10 @@
       "RE_AGE": "Re-age Loan",
       "RE_AMORTIZE": "Re-amortise Loan",
       "UNDO_APPROVAL": "Undo Approval",
-      "CLOSE_AS_RESCHEDULED": "Close as Rescheduled"
+      "CLOSE_AS_RESCHEDULED": "Close as Rescheduled",
+      "DISBURSE_TO_SAVINGS": "Disburse to Savings",
+      "UNASSIGN_LOAN_OFFICER": "Unassign Loan Officer",
+      "UNDO_LAST_DISBURSAL": "Undo Last Disbursal"
     },
     "CREATE_LOAN_ACCOUNT": "Create Loan Account",
     "EDIT_LOAN_APPLICATION": "Edit Loan Application",
@@ -588,7 +591,12 @@
     "STANDING_INSTRUCTIONS": "Standing Instructions",
     "DIRECTION": "Direction",
     "TRANSFER_TYPE": "Transfer Type",
-    "VALID_FROM": "Valid From"
+    "VALID_FROM": "Valid From",
+    "DISBURSEMENT_DATE": "Disbursement Date",
+    "UNASSIGNED_DATE": "Unassigned Date",
+    "COMMAND_APPLIED": "Done.",
+    "CONFIRM_UNASSIGN_LOAN_OFFICER": "The loan stops counting towards this officer from the date you choose. Backdate it to the day they actually stopped, or every report for the period in between will still credit them.",
+    "CONFIRM_UNDO_LAST_DISBURSAL": "This reverses the most recent tranche released on this loan. The schedule is recalculated without it."
   },
   "TEMPLATES": {
     "TITLE": "Document Templates",


### PR DESCRIPTION
Closes #268. Follows #267, and finishes the loan gaps that needed their own UI rather than a menu entry.

## What this adds

| | |
|---|---|
| **Unassign loan officer** | the counterpart to the assign action that already existed |
| **Disburse to savings** | for an approved loan, into the account linked at application time |
| **Undo last disbursal** | offered only where the product allows multiple disbursals |
| **Asset transfers tab** | whether this loan has been sold on, and to whom |

## Comparing against a mature implementation caught two mistakes before any code

I filed #268 claiming disburse-to-savings **needs a savings-account picker**. It does not. The destination is the savings account linked to the loan when the application was made, and the platform refuses the command outright without one:

```
403  Disburse Loan with id:4 requires linked savings account for payment
```

A picker would have implied a choice that does not exist. Corrected on the issue.

The second was the permission. The command is `unassignloanofficer`, so I had assumed `UNASSIGNLOANOFFICER_LOAN`. The platform publishes no such code — only `UPDATELOANOFFICER_LOAN` and `REMOVELOANOFFICER_LOAN`. Gating on the name I assumed would have hidden the action from every user, silently. Every permission code here was read from `/permissions` rather than inferred from a command name.

One gap the comparison did not help with: unassign-officer does not exist in the reference either, so it is built from the platform contract alone.

## Verified before it was written, and again after

Round trip against a running Fineract: created a loan officer, `assignLoanOfficer` → 200, `unassignloanofficer` with `{unassignedDate, locale, dateFormat}` → **200** with `loanOfficerId` cleared.

Then through the real screen on an active loan: the dialog opened, confirming raised a success toast, and the platform showed the officer cleared. The conditional gating held live — **Unassign shown** while an officer was assigned, **Undo Last Disbursal hidden** on that single-disbursal loan, **Disburse to Savings hidden** because the loan was Active rather than Approved.

## What the specs pin

Request bodies, because that is where this class of work goes wrong — #267 found `undoapproval` rejecting the `locale` and `dateFormat` that the shared action form sends on every call. The three commands here differ from each other and from that one:

- `disbursetosavings` and `unassignloanofficer` **do** take `locale` and `dateFormat`, and need the platform's `dd MMMM yyyy` rather than the ISO the date picker produces
- `undoLastDisbursal` takes an **empty body**, like its sibling `undoDisbursal`

Each is asserted in both directions: the action sends what it should, and stays hidden wherever the platform could only answer 403.

## A limitation stated rather than hidden

**Neither `disbursetosavings` nor `undoLastDisbursal` can be driven end to end against a fresh platform** — one needs a loan with a linked savings account, the other a multi-tranche product. Their coverage is mocked, and the spec says so. A green real-backend run would otherwise imply more than it proves.

## Checks

- **817 unit specs** pass (was 810 — 7 new)
- **13 mocked e2e** in `loan-servicing-gaps.spec.ts` pass (was 7 — 6 new)
- `lint`, HTML lint, `format:check`, `i18n:check`, `check:icons` all pass
- rebased on `origin/main` (`4c884831`)

## Not included

The **original schedule** tab. `GET /loans/{id}/schedule` answers **405 Method Not Allowed**, so there is no verified way to fetch a loan's schedule as first generated. Building against a guess would ship a tab that silently shows nothing, which is worse than its absence.
