### PR TITLE
fix(routing): redirect bare calendar and meeting paths

### DIFF
--- a/src/app/features/calendars/calendars.routes.spec.ts
+++ b/src/app/features/calendars/calendars.routes.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { CALENDARS_ROUTES } from './calendars.routes';
+
+@Component({
+  standalone: true,
+  template: '',
+})
+class RouteStub {}
+
+describe('CALENDARS_ROUTES', () => {
+  beforeEach(() => {
+    const routes = CALENDARS_ROUTES.map((route) =>
+      route.path === ':entityType/:entityId' ? { path: route.path, component: RouteStub } : route,
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'calendars', children: routes },
+          { path: 'dashboard', component: RouteStub },
+        ]),
+      ],
+    });
+  });
+
+  it('redirects the feature root to the dashboard', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/calendars');
+
+    expect(TestBed.inject(Router).url).toBe('/dashboard');
+  });
+
+  it('keeps entity-scoped routes reachable', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/calendars/groups/1');
+
+    expect(TestBed.inject(Router).url).toBe('/calendars/groups/1');
+  });
+});

--- a/src/app/features/calendars/calendars.routes.ts
+++ b/src/app/features/calendars/calendars.routes.ts
@@ -21,6 +21,11 @@ import { Routes } from '@angular/router';
 
 export const CALENDARS_ROUTES: Routes = [
   {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: '/dashboard',
+  },
+  {
     path: ':entityType/:entityId',
     loadComponent: () => import('./calendars-list.component').then((m) => m.CalendarsListComponent),
   },

--- a/src/app/features/meetings/meetings.routes.spec.ts
+++ b/src/app/features/meetings/meetings.routes.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { MEETINGS_ROUTES } from './meetings.routes';
+
+@Component({
+  standalone: true,
+  template: '',
+})
+class RouteStub {}
+
+describe('MEETINGS_ROUTES', () => {
+  beforeEach(() => {
+    const routes = MEETINGS_ROUTES.map((route) =>
+      route.path === ':entityType/:entityId' ? { path: route.path, component: RouteStub } : route,
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'meetings', children: routes },
+          { path: 'dashboard', component: RouteStub },
+        ]),
+      ],
+    });
+  });
+
+  it('redirects the feature root to the dashboard', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/meetings');
+
+    expect(TestBed.inject(Router).url).toBe('/dashboard');
+  });
+
+  it('keeps entity-scoped routes reachable', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/meetings/groups/1');
+
+    expect(TestBed.inject(Router).url).toBe('/meetings/groups/1');
+  });
+});

--- a/src/app/features/meetings/meetings.routes.ts
+++ b/src/app/features/meetings/meetings.routes.ts
@@ -21,6 +21,11 @@ import { Routes } from '@angular/router';
 
 export const MEETINGS_ROUTES: Routes = [
   {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: '/dashboard',
+  },
+  {
     path: ':entityType/:entityId',
     loadComponent: () => import('./meetings-list.component').then((m) => m.MeetingsListComponent),
   },


### PR DESCRIPTION
## What and why

Redirect the bare `/calendars` and `/meetings` feature roots to `/dashboard`, matching the application's existing fallback behavior. Those lazy-loaded route trees previously had no empty-path child, so both URLs matched the feature prefix but left the outlet blank instead of reaching the global wildcard redirect.

The existing entity-scoped list, create, and edit routes are unchanged.

Closes #264

## Verification

- Focused RouterTestingHarness specs: 4 passed
- CI full Karma suite: 821 passed
- Exercised both redirects with Angular Router 22.0.7 against the real feature route arrays and pinned representative entity-scoped routes against regressions
- `npm run lint`
- HTML ESLint
- `npm run format:check`
- `npm run i18n:check`
- `npm run check:icons`
- `npm run build`
- API client regeneration and drift check
- ASF license-header check
- Production dependency license check
- `npm audit --audit-level=high --omit=dev` (0 vulnerabilities)

`npm run api:surface` still reports the same three pre-existing manifest gaps reproduced on clean `main` at `4c884831`; this change does not touch the generated API or its surface manifest.

## Screenshots

Not applicable. This is a route-configuration fix with no visual change.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] Not applicable: no component or service code was added.
- [x] Not applicable: no user-facing strings were added.
- [x] I added regression coverage for both feature roots.
- [x] Not applicable: no Fineract backend interaction changed; Angular Router recognition was verified directly.
