### PR TITLE
ci(e2e): shard mocked Playwright tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,7 +136,7 @@ jobs:
         env:
           PLAYWRIGHT_HTML_OPEN: 'never'
           PLAYWRIGHT_JSON_OUTPUT_NAME: 'playwright-results.json'
-        run: npx playwright merge-reports --reporter=html,json ./all-blob-reports
+        run: npx playwright merge-reports --reporter=line,html,json ./all-blob-reports
 
       - name: Upload merged report and videos
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,21 +36,25 @@ permissions: {}
 # The suite is split in two so a broken mock does not wait behind a Fineract
 # boot, and so the slow half is not on the critical path for the fast one.
 #
-#   mocked  — 188 tests that stub the backend with page.route(). Needs no
+#   mocked  — 220 tests that stub the backend with page.route(). Needs no
 #             Fineract at all, so it skips the docker bring-up entirely and
 #             reports in a couple of minutes.
-#   backend — 16 tests that drive a real Fineract end to end. Slow, and the
+#   backend — 23 tests that drive a real Fineract end to end. Slow, and the
 #             only half that needs the stack.
 #
 # The split lives in playwright.config.ts as two projects, so `--project=mocked`
 # and `--project=backend` mean the same thing locally as they do here.
 jobs:
   mocked:
-    name: E2E (mocked backend)
+    name: E2E (mocked backend, shard ${{ matrix.shard }}/${{ matrix.total }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+        total: [4]
     permissions:
       contents: read # checkout
-      pull-requests: write # upsert this job's summary comment
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
@@ -81,19 +85,63 @@ jobs:
 
       - name: Run mocked E2E tests
         env:
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_TOTAL: ${{ matrix.total }}
+          PLAYWRIGHT_OUTPUT_DIR: ${{ runner.temp }}/e2e-output
+        run: npx playwright test --project=mocked --shard="$SHARD_INDEX/$SHARD_TOTAL" --reporter=blob
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-blob-mocked-${{ matrix.shard }}
+          path: blob-report/
+          if-no-files-found: warn
+          retention-days: 1
+
+  mocked-report:
+    name: E2E (mocked backend report)
+    if: ${{ !cancelled() }}
+    needs: mocked
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      pull-requests: write # upsert the merged summary comment
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: all-blob-reports
+          pattern: playwright-blob-mocked-*
+          merge-multiple: true
+
+      - name: Merge mocked E2E reports
+        env:
           PLAYWRIGHT_HTML_OPEN: 'never'
           PLAYWRIGHT_JSON_OUTPUT_NAME: 'playwright-results.json'
-          PLAYWRIGHT_OUTPUT_DIR: ${{ runner.temp }}/e2e-output
-        run: npx playwright test --project=mocked --reporter=line,html,json
+        run: npx playwright merge-reports --reporter=html,json ./all-blob-reports
 
-      - name: Upload report and videos
+      - name: Upload merged report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
+        if: ${{ !cancelled() }}
         with:
           name: playwright-report-mocked
           path: |
             playwright-report/
-            ${{ runner.temp }}/e2e-output/
+            playwright-results.json
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,14 +36,18 @@ permissions: {}
 # The suite is split in two so a broken mock does not wait behind a Fineract
 # boot, and so the slow half is not on the critical path for the fast one.
 #
-#   mocked  — 220 tests that stub the backend with page.route(). Needs no
+#   mocked  — tests that stub the backend with page.route(). Needs no
 #             Fineract at all, so it skips the docker bring-up entirely and
 #             reports in a couple of minutes.
-#   backend — 23 tests that drive a real Fineract end to end. Slow, and the
+#   backend — tests that drive a real Fineract end to end. Slow, and the
 #             only half that needs the stack.
 #
 # The split lives in playwright.config.ts as two projects, so `--project=mocked`
 # and `--project=backend` mean the same thing locally as they do here.
+# Branch protection must replace the former `E2E (mocked backend)` requirement
+# with all four shard checks. Do not require `E2E (mocked backend report)`
+# instead: merging reports can succeed when a shard fails, so only the shard
+# jobs enforce the mocked E2E result.
 jobs:
   mocked:
     name: E2E (mocked backend, shard ${{ matrix.shard }}/${{ matrix.total }})
@@ -134,7 +138,7 @@ jobs:
           PLAYWRIGHT_JSON_OUTPUT_NAME: 'playwright-results.json'
         run: npx playwright merge-reports --reporter=html,json ./all-blob-reports
 
-      - name: Upload merged report
+      - name: Upload merged report and videos
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements. See the NOTICE file
distributed with this work for additional information
regarding copyright ownership. The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License. You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied. See the License for the
specific language governing permissions and limitations
under the License.
-->

## What and why

Shards the mocked Playwright project across four GitHub Actions matrix jobs, then merges their blob reports in a dependent job. This reduces the mocked-suite wall-clock time while preserving the combined HTML/JSON report and PR summary. The backend project remains unchanged.

Closes #259

## Verification

- `npx playwright test --list --project=mocked` — 220 tests in 13 files
- Verified four shards contain 55 tests each, totaling 220
- Dry-ran four list-only blob reports and merged them successfully — merged JSON contained 220 tests across 13 suites
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `bash scripts/check-license.sh`
- No UI or real Fineract backend was exercised; this is a workflow-only change

## Screenshots

Not applicable — workflow-only change with no visual UI changes.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. Not applicable; no component or service code changed.
- [x] User-facing strings use translation keys. Not applicable; no user-facing strings changed.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed. The existing 220-test suite was verified across four shards and through a merged-report dry run.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. Not applicable; no UI workflow changed, and the backend job remains unchanged.