### PR TITLE
docs: document the commit-signing requirement for contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<!-- Commits must be signed to merge — see CONTRIBUTING.md#commit-signing if you haven't set this up. -->
+
 ## What and why
 
 <!-- One or two sentences explaining what changed and why. -->
@@ -42,3 +44,4 @@ Closes #
 - [ ] User-facing strings use translation keys.
 - [ ] I added or updated tests appropriate to this change, or explained why tests were not needed.
 - [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant.
+- [ ] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,4 +119,26 @@ relying on transitive resolution, so the audit sees them.
   back-office UI are tracked here, not in Jira — the ASF Jira project is for
   [apache/fineract](https://github.com/apache/fineract), the platform itself.
 - Ensure CI checks pass.
+- Commits must be signed (GPG) — see [Commit Signing](#commit-signing) below.
 - New features should include unit tests.
+
+## Commit Signing
+
+`main` requires signed commits — an unsigned commit cannot be merged. Set this up
+before you start work, not after.
+
+```bash
+git config user.signingkey <your-gpg-key-id>
+git config commit.gpgsign true
+```
+
+`commit.gpgsign true` makes signing automatic for every commit, so it isn't a flag
+you have to remember. See GitHub's docs for full setup instructions:
+[commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+
+**If you already have unsigned commits on your branch**, sign them retroactively
+instead of starting over:
+
+```bash
+git rebase --exec 'git commit --amend --no-edit -S' <base-branch>
+```


### PR DESCRIPTION
## What and why

The commit-signing requirement enforced on main is not documented anywhere a contributor would see it before submitting a pull request. CONTRIBUTING.md's Pull Request Guidelines section does not mention it, and neither does the pull request template. As a result, a contributor can follow the existing documentation exactly and still have their pull request blocked at merge time, with no prior indication that signing was required.

This adds a Commit Signing section to CONTRIBUTING.md covering the requirement and the one-time setup, a bullet in Pull Request Guidelines pointing to it, and a comment in the pull request template so the requirement is visible before work begins rather than discovered at merge.

Closes #271