### PR TITLE
docs: correct the pull request target branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ explaining why, start with Jira.
     failure locally, and the rules that most often surprise people — is documented in
     [`DOCS/CI_CHECKS.md`](DOCS/CI_CHECKS.md).
 
-7.  **Submit a Pull Request** against the `develop` branch.
+7.  **Submit a Pull Request** against the `main` branch.
 
 ## End-to-End Tests
 


### PR DESCRIPTION
## What and why

CONTRIBUTING.md step 7 told contributors to submit pull requests against develop. main is the repository's actual default branch and the target every merged PR uses.

Closes #282