### PR TITLE
fix(groups): floor a lifecycle date at the one the platform already stamped

### DIFF
--- a/e2e/group-membership.spec.ts
+++ b/e2e/group-membership.spec.ts
@@ -188,7 +188,9 @@ test.describe('Group membership and lifecycle', () => {
     await page.getByTestId('group-action-activate').click();
     const activateDialog = modalFor(page, 'app-group-action-dialog');
     await expect(activateDialog).toBeVisible();
-    // The date defaults to the platform's business date, which is what the command wants.
+    // Confirmed without touching the date. That default has to be one the platform accepts
+    // from a browser whose clock disagrees with the tenant's about what day it is — this run
+    // is UTC in CI against a tenant on `Asia/Kolkata`, which are different days after 18:30.
     await activateDialog.getByTestId('group-action-confirm').click();
 
     await expect(page.getByTestId('group-status')).toContainText('Active', { timeout: 20000 });

--- a/src/app/features/groups/group-action-dialog.component.spec.ts
+++ b/src/app/features/groups/group-action-dialog.component.spec.ts
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+import { GroupActionDialogComponent, GroupActionDialogData } from './group-action-dialog.component';
+import { BusinessDateManagementService, GroupsService } from '../../api';
+import { provideFakeAdapters } from '../../testing/adapters';
+import { toIsoDate } from '../../core/utils/date-formatter';
+
+const ACTIVATE: GroupActionDialogData['title'] = 'GROUPS.ACTIVATE';
+
+/**
+ * The dialog's date, and specifically the floor under it.
+ *
+ * The floor is what keeps the browser's clock out of a command the platform validates against
+ * a date it stamped itself, in the tenant's timezone. `group-membership.spec.ts` exercises the
+ * same thing end to end, but only reproduces the disagreement while the two zones are on
+ * different days — for a UTC runner against the stock `Asia/Kolkata` tenant, a five-and-a-half
+ * hour window each evening. These cases hold whatever time it is.
+ */
+describe('GroupActionDialogComponent', () => {
+  let fixture: ComponentFixture<GroupActionDialogComponent>;
+  let component: GroupActionDialogComponent;
+  let businessDateService: jasmine.SpyObj<BusinessDateManagementService>;
+
+  /** A date relative to the browser's today, as the ISO string the dialog compares. */
+  function offsetFromToday(days: number): string {
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    return toIsoDate(date);
+  }
+
+  /** The same date as the `[year, month, day]` the business-date endpoint answers with. */
+  function fineractDate(iso: string): number[] {
+    return iso.split('-').map(Number);
+  }
+
+  async function setup(data: GroupActionDialogData, businessDate?: number[]): Promise<void> {
+    businessDateService = jasmine.createSpyObj('BusinessDateManagementService', [
+      'getBusinessdate',
+    ]);
+    businessDateService.getBusinessdate.and.returnValue(
+      of(businessDate ? [{ type: 'BUSINESS_DATE', date: businessDate }] : []) as never,
+    );
+
+    const groupsService = jasmine.createSpyObj('GroupsService', ['getGroupsTemplate']);
+    groupsService.getGroupsTemplate.and.returnValue(of({ closureReasons: [] }) as never);
+
+    await TestBed.configureTestingModule({
+      imports: [GroupActionDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        ...provideFakeAdapters().providers,
+        { provide: BusinessDateManagementService, useValue: businessDateService },
+        { provide: GroupsService, useValue: groupsService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GroupActionDialogComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('data', data);
+    fixture.detectChanges();
+  }
+
+  it('defaults to today when the platform has committed to nothing earlier', async () => {
+    await setup({ title: ACTIVATE, command: 'activate' });
+
+    expect(component.actionDate()).toBe(toIsoDate(new Date()));
+    expect(component.minDate()).toBeUndefined();
+  });
+
+  it('moves the default up to a floor that is later than the browser thinks today is', async () => {
+    // The shape of the CI failure: Fineract stamped the group's submitted-on date in a tenant
+    // timezone already on tomorrow, so activating "today" is activating before submission.
+    const tomorrow = offsetFromToday(1);
+    await setup({ title: ACTIVATE, command: 'activate', minDate: tomorrow });
+
+    expect(component.actionDate()).toBe(tomorrow);
+    expect(component.minDate()).toBe(tomorrow);
+  });
+
+  it('leaves the default at today when the floor is already behind it', async () => {
+    // A group submitted last week: activation belongs today, not on the day it was recorded.
+    const lastWeek = offsetFromToday(-7);
+    await setup({ title: ACTIVATE, command: 'activate', minDate: lastWeek });
+
+    expect(component.actionDate()).toBe(toIsoDate(new Date()));
+    // Still floored, so the picker cannot offer a date the command would refuse.
+    expect(component.minDate()).toBe(lastWeek);
+  });
+
+  it('caps at the business date and defaults there', async () => {
+    await setup({ title: ACTIVATE, command: 'activate' }, [2026, 3, 4]);
+
+    expect(component.actionDate()).toBe('2026-03-04');
+    expect(component.maxDate()).toBe('2026-03-04');
+  });
+
+  it('drops a business-date cap that falls below the floor rather than contradicting it', async () => {
+    // Both constraints cannot hold. The floor is the one the command itself validates, so the
+    // picker keeps it and lets the platform speak for the business date on submit — a range
+    // with max < min is one no date satisfies.
+    const tomorrow = offsetFromToday(1);
+    await setup(
+      { title: ACTIVATE, command: 'activate', minDate: tomorrow },
+      fineractDate(offsetFromToday(-30)),
+    );
+
+    expect(component.actionDate()).toBe(tomorrow);
+    expect(component.minDate()).toBe(tomorrow);
+    expect(component.maxDate()).toBeUndefined();
+  });
+});

--- a/src/app/features/groups/group-action-dialog.component.ts
+++ b/src/app/features/groups/group-action-dialog.component.ts
@@ -39,6 +39,13 @@ export interface GroupActionDialogData {
   title: string;
   /** The Fineract command this dialog collects arguments for. */
   command: 'activate' | 'close';
+  /**
+   * ISO `YYYY-MM-DD`: the earliest date the platform will accept for this command, taken from
+   * a date Fineract has already stamped — the group's submitted-on date for an activation, its
+   * activation date for a closure. Optional, because a caller that has neither is no worse off
+   * than before. See {@link GroupActionDialogComponent.applyMinDate}.
+   */
+  minDate?: string;
 }
 
 export interface GroupActionResult {
@@ -91,6 +98,7 @@ export interface GroupActionResult {
                 [ngModel]="actionDate()"
                 (ngModelChange)="actionDate.set($event)"
                 required
+                [min]="minDate()"
                 [max]="maxDate()"
               ></ion-datetime>
             </ng-template>
@@ -164,6 +172,7 @@ export class GroupActionDialogComponent implements OnInit {
   readonly data = input.required<GroupActionDialogData>();
 
   readonly actionDate = signal(toIsoDate(new Date()));
+  readonly minDate = signal<string | undefined>(undefined);
   readonly maxDate = signal<string | undefined>(undefined);
   readonly closureReasons = signal<{ id?: number; name?: string }[]>([]);
   closureReasonId?: number;
@@ -173,9 +182,37 @@ export class GroupActionDialogComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.applyMinDate();
     this.loadBusinessDate();
     if (this.data().command === 'close') {
       this.loadClosureReasons();
+    }
+  }
+
+  /**
+   * Floors the picker at the date the platform has already committed to, and moves the default
+   * up to meet it.
+   *
+   * The default above comes from the browser's clock. The date it has to sit on or after —
+   * the group's submitted-on date for an activation, its activation date for a closure — was
+   * stamped by Fineract in the *tenant's* timezone, and the two disagree about what day it is
+   * for as long as the offset between them. A browser in UTC against the stock `Asia/Kolkata`
+   * tenant is a day behind from 18:30 UTC onwards, and sending that day answers
+   * `error.msg.group.submittedOnDate.after.activation.date`: the group stays pending, with a
+   * toast as the only sign of why. Taking the later of the two takes the browser's clock out
+   * of the decision wherever the platform has already made it.
+   *
+   * A lexical comparison is the right one here — both sides are zero-padded `YYYY-MM-DD`, which
+   * orders identically to the dates it spells, and parsing them back into `Date` would put the
+   * browser's timezone back into a comparison this exists to keep it out of.
+   */
+  private applyMinDate(): void {
+    const min = this.data().minDate;
+    if (!min) return;
+
+    this.minDate.set(min);
+    if (min > this.actionDate()) {
+      this.actionDate.set(min);
     }
   }
 
@@ -192,8 +229,15 @@ export class GroupActionDialogComponent implements OnInit {
         const parts = businessDate?.date as unknown as number[] | undefined;
         if (parts?.length) {
           const iso = toIsoDate(new Date(parts[0], parts[1] - 1, parts[2]));
-          this.actionDate.set(iso);
-          this.maxDate.set(iso);
+          const min = this.minDate();
+          // A business date earlier than the floor would leave the picker with a range it
+          // cannot satisfy. The floor wins, because it is the constraint the command itself
+          // validates; a business date that far behind is a tenant configuration question and
+          // the platform will say so on submit.
+          if (!min || iso >= min) {
+            this.actionDate.set(iso);
+            this.maxDate.set(iso);
+          }
         }
       },
       // A tenant with the business-date module off answers 403 here. Today's date is the

--- a/src/app/features/groups/group-view.component.ts
+++ b/src/app/features/groups/group-view.component.ts
@@ -56,6 +56,7 @@ import {
 } from '../../core/utils/date-formatter';
 import {
   GROUP_STATUS,
+  FineractDate,
   GroupClientMember,
   GroupDetail,
   GroupRoleAssignment,
@@ -543,7 +544,12 @@ export class GroupViewComponent implements OnInit {
   // --- Lifecycle commands -------------------------------------------------------------------
 
   async onActivate(): Promise<void> {
-    const result = await this.openActionDialog('GROUPS.ACTIVATE', 'activate');
+    // The platform will not activate a group before the day it was submitted on.
+    const result = await this.openActionDialog(
+      'GROUPS.ACTIVATE',
+      'activate',
+      this.isoDate(this.group()?.timeline?.submittedOnDate),
+    );
     if (!result) return;
 
     this.runCommand('activate', {
@@ -554,7 +560,12 @@ export class GroupViewComponent implements OnInit {
   }
 
   async onClose(): Promise<void> {
-    const result = await this.openActionDialog('GROUPS.CLOSE', 'close');
+    // And it will not close one before the day it was activated on.
+    const result = await this.openActionDialog(
+      'GROUPS.CLOSE',
+      'close',
+      this.isoDate(this.group()?.timeline?.activatedOnDate),
+    );
     if (!result) return;
 
     this.runCommand('close', {
@@ -568,10 +579,22 @@ export class GroupViewComponent implements OnInit {
   private openActionDialog(
     title: string,
     command: GroupActionDialogData['command'],
+    minDate?: string,
   ): Promise<GroupActionResult | undefined> {
     return this.dialogService.open<GroupActionResult>(GroupActionDialogComponent, {
-      data: { title, command } satisfies GroupActionDialogData,
+      data: { title, command, minDate } satisfies GroupActionDialogData,
     });
+  }
+
+  /**
+   * A date the platform has stamped, as the ISO `YYYY-MM-DD` the action dialog floors on.
+   *
+   * These arrive rendered in the tenant's timezone, which is exactly what makes them usable as
+   * a floor for a picker that would otherwise only know what day it is in the browser's.
+   */
+  private isoDate(value: FineractDate | undefined): string | undefined {
+    const iso = formatArrayDate(value);
+    return iso === '-' ? undefined : iso;
   }
 
   // --- Staff --------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the two `group-membership.spec.ts` failures on the backend e2e job.

```
[backend] › a group is activated, staffed, given members and a committee, then emptied
[backend] › an empty group is closed with a reason, and a group with members is refused

  Expected substring: "Active"
  Received string:    " Pending "
  44 × locator resolved to <app-status-badge data-testid="group-status">
```

Not flaky — all three retries failed identically.

## What was wrong

A timezone disagreement between the browser and the tenant.

Fineract's default tenant runs in `Asia/Kolkata` and stamps `submittedOnDate` using **tenant** time. The activation dialog defaulted its date from the **browser's** clock. CI runners are UTC, and for part of every day those are different calendar days:

```
UTC   2026-08-08 19:40
IST   2026-08-09 01:10   ← the tenant is already on tomorrow
```

So the group is submitted on the 9th, the browser offers the 8th, and the platform refuses:

```json
{
  "userMessageGlobalisationCode": "error.msg.group.submittedOnDate.after.activation.date",
  "defaultUserMessage": "Submitted on date cannot be after the activation date",
  "args": [{ "value": "2026-08-09" }]
}
```

The screen handles the refusal correctly — `errorInterceptor` raises a toast carrying the platform's own message — but the group stays pending, and that is what the assertion sees.

The window is **18:30–24:00 UTC**, five and a half hours a day. Outside it the two zones agree and everything passes, which is why this reads as intermittent and why it does not reproduce for anyone developing in IST.

## The fix

The dialog now takes a floor: the date Fineract has already committed to — the group's submitted-on date for an activation, its activation date for a closure. It becomes the picker's `min`, and the default moves up to meet it when the browser is behind. Those dates arrive rendered in the tenant's timezone, which is exactly what makes them usable as a floor for a picker that otherwise only knows what day it is in the browser's.

Both sides are zero-padded `YYYY-MM-DD` and are compared lexically. Parsing them back into `Date` would put the browser's timezone back into a comparison this exists to keep it out of.

Where the two constraints cannot both hold — a business date earlier than the floor — the floor wins and the cap is dropped. It is the constraint the command itself validates, and a range with `max < min` is one no date satisfies.

## Verifying it

Reproduced two ways: the raw API call above against a live platform, and `TZ=UTC` on the Playwright run, which fails exactly as CI does.

| | |
|---|---|
| `TZ=UTC` backend e2e — the failing condition | 4 passed |
| backend e2e in local TZ | 4 passed |
| mocked `group-detail.spec.ts` | 6 passed |
| `groups/*.spec.ts` unit | 21 passed |
| `npm run lint`, `tsc` | clean |

`group-action-dialog.component.spec.ts` is new. The e2e only catches this during that 5.5-hour window, so the regression guard has to be a unit spec — those five cases hold whatever time it is.

## Not addressed here

**The `NG0100` noise in the job log is unrelated.** Those `ng-untouched` errors come from `ClientFormComponent` / `StaffFormComponent` / `GroupFormComponent` on pages visited earlier in each test, and they appear identically on runs that pass.

**The same skew almost certainly exists elsewhere.** Any screen that derives a date from the browser and sends it to a command Fineract validates against a server-stamped date has this bug; groups is just where a test caught it. `formatDateToFineract` compounds it — it does `new Date('2026-08-09')`, which parses as UTC midnight and then reads `getDate()` in local time, so a user west of Greenwich sends the wrong day. That is a shared utility with many call sites and belongs in its own change.
