### PR TITLE
fix(header): render toggle icons on first load

### DIFF
--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -59,9 +59,11 @@ import { TooltipDirective } from '../shared/directives/tooltip.directive';
           (click)="sidebarService.toggle()"
           [attr.aria-label]="'Toggle Sidebar'"
         >
-          <ion-icon
-            [name]="sidebarService.isCollapsed() ? 'menu-outline' : 'chevron-back-outline'"
-          ></ion-icon>
+          @if (sidebarService.isCollapsed()) {
+            <ion-icon name="menu-outline"></ion-icon>
+          } @else {
+            <ion-icon name="chevron-back-outline"></ion-icon>
+          }
         </button>
         <img src="favicon.png" alt="Fineract Logo" class="logo" />
         <span class="app-title">{{ 'app.title' | translate }}</span>
@@ -121,9 +123,11 @@ import { TooltipDirective } from '../shared/directives/tooltip.directive';
           [appTooltip]="'COMMON.TOGGLE_THEME' | translate"
           [attr.aria-label]="'COMMON.TOGGLE_THEME' | translate"
         >
-          <ion-icon
-            [name]="themeService.isDarkMode() ? 'sunny-outline' : 'moon-outline'"
-          ></ion-icon>
+          @if (themeService.isDarkMode()) {
+            <ion-icon name="sunny-outline"></ion-icon>
+          } @else {
+            <ion-icon name="moon-outline"></ion-icon>
+          }
         </button>
 
         <button class="tour-btn" (click)="startTour()" [attr.aria-label]="'Help Tour'">


### PR DESCRIPTION
## What and why

Render the sidebar and theme toggle icons from separate, statically named
`ion-icon` elements. This gives Ionic the icon name before each element is
connected, so both controls are visible on the initial page load while still
switching icons when their state changes.

Closes #263

## Verification

- `npm test -- --watch=false --include='src/app/layout/header.component.spec.ts'` (4 passed)
- `npm test -- --watch=false` (843 passed)
- `npm run check:icons` (114 registered icons)
- `npx eslint src/app/layout/header.component.ts --suppressions-location eslint-suppressions.json`
- `npx prettier --check src/app/layout/header.component.ts`
- `npm run build`

The local HTTPS development server built successfully. A screenshot is not
included because the Codex in-app browser does not trust the repository's
local self-signed certificate; no real Fineract backend was exercised.

## Screenshots

Not available for the local self-signed HTTPS environment. The change is
limited to how the two existing icons are instantiated; it does not alter
layout, styling, labels, or behavior.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] No new component or service code was added, so the adapter boundary is not applicable.
- [x] No user-facing strings were added or changed.
- [x] Existing header coverage and the complete 843-test suite pass. A new unit test would not reproduce Ionic's custom-element connection timing, because Angular DOM assertions run after bindings settle.
- [x] This is not a workflow change, so additional e2e coverage is not applicable.
- [x] The commit is signed and GitHub reports the signature as verified.
