### PR TITLE
fix(data-table): make sort headers keyboard accessible

### DIFF
--- a/src/app/shared/components/data-table/data-table.component.spec.ts
+++ b/src/app/shared/components/data-table/data-table.component.spec.ts
@@ -43,6 +43,7 @@ const ROWS: TestData[] = [
 ];
 
 const CUSTOM_CELL = '.custom-cell';
+const SORT_BUTTON = 'button.sort-button';
 
 describe('DataTableComponent', () => {
   let fixture: ComponentFixture<DataTableComponent<TestData>>;
@@ -304,6 +305,29 @@ describe('DataTableComponent', () => {
   });
 
   describe('accessibility', () => {
+    it('renders native buttons only for sortable headers', () => {
+      const headers = fixture.nativeElement.querySelectorAll('th[cdk-header-cell]');
+      const sortButtons = fixture.nativeElement.querySelectorAll(SORT_BUTTON);
+
+      expect(sortButtons).toHaveSize(2);
+      expect(sortButtons[0].getAttribute('type')).toBe('button');
+      expect(headers[0].querySelector(SORT_BUTTON)).toBe(sortButtons[0]);
+      expect(headers[1].querySelector(SORT_BUTTON)).toBe(sortButtons[1]);
+      expect(headers[2].querySelector(SORT_BUTTON)).toBeNull();
+    });
+
+    it('sorts through the rendered keyboard-operable control', () => {
+      const nameSortButton: HTMLButtonElement =
+        fixture.nativeElement.querySelectorAll(SORT_BUTTON)[1];
+
+      nameSortButton.focus();
+      nameSortButton.click();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(nameSortButton);
+      expect(component.sort()).toEqual({ active: 'name', direction: 'asc' });
+    });
+
     it('exposes the sorted column via aria-sort', () => {
       component.onSortHeaderClick(COLUMNS[1]);
       fixture.detectChanges();

--- a/src/app/shared/components/data-table/data-table.component.ts
+++ b/src/app/shared/components/data-table/data-table.component.ts
@@ -161,16 +161,22 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
                     [appTooltip]="col.tooltip || ''"
                     [attr.aria-sort]="ariaSortFor(col)"
                     [class.sortable]="col.sortable"
-                    (click)="onSortHeaderClick(col)"
                   >
-                    {{ col.label | translate }}
-                    @if (col.sortable && sort().active === col.key && sort().direction) {
-                      <ion-icon
-                        class="sort-indicator"
-                        [name]="
-                          sort().direction === 'asc' ? 'arrow-up-outline' : 'arrow-down-outline'
-                        "
-                      ></ion-icon>
+                    @if (col.sortable) {
+                      <button type="button" class="sort-button" (click)="onSortHeaderClick(col)">
+                        {{ col.label | translate }}
+                        @if (sort().active === col.key && sort().direction) {
+                          <ion-icon
+                            aria-hidden="true"
+                            class="sort-indicator"
+                            [name]="
+                              sort().direction === 'asc' ? 'arrow-up-outline' : 'arrow-down-outline'
+                            "
+                          ></ion-icon>
+                        }
+                      </button>
+                    } @else {
+                      {{ col.label | translate }}
                     }
                   </th>
                   <td cdk-cell *cdkCellDef="let row">
@@ -271,11 +277,25 @@ const NEXT_DIRECTION: Record<SortDirection, SortDirection> = {
         white-space: nowrap;
       }
       .data-table th.sortable {
-        cursor: pointer;
         user-select: none;
       }
       .data-table th.sortable:hover {
         color: var(--primary-color);
+      }
+      .sort-button {
+        display: inline-flex;
+        align-items: center;
+        padding: 0;
+        border: 0;
+        color: inherit;
+        font: inherit;
+        background: transparent;
+        cursor: pointer;
+      }
+      .sort-button:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 3px;
+        border-radius: 2px;
       }
       .data-table th[aria-sort] {
         color: var(--primary-color);


### PR DESCRIPTION
## What and why

Render each sortable table header as a native button so keyboard users can focus it and activate sorting with Enter or Space. Non-sortable headers remain outside the tab order, aria-sort stays on the column header, and the control has an explicit focus-visible outline.

Closes #286

## Verification

- Targeted data-table suite: 33 tests passed.
- Full unit suite: 843 tests passed.
- npm run lint:prune passed.
- npm run build passed.
- Prettier and git diff checks passed.
- The rendered-DOM tests verify that only sortable columns expose native buttons, that the control receives focus and triggers sorting, and that aria-sort remains on the header.
- No real Fineract backend was used; this behavior is internal to the shared client-side table component.

## Screenshots

Not included. The change preserves the existing header layout and adds keyboard focus/activation behavior; the rendered DOM is covered by the focused component tests.

## Checklist

- [x] I did not hand-edit generated files under src/app/api/.
- [x] Not applicable: no component/service integration boundary or browser global was added.
- [x] No user-facing strings were added.
- [x] I added rendered-DOM tests for focusability, activation, sortable-only controls, and aria-sort.
- [x] Not applicable: this is native button behavior in the shared table component and does not depend on a backend workflow.
- [x] The commit is SSH-signed.
