### PR TITLE
feat(products): configure accounting on loan products

### DIFF
--- a/e2e/loan-product-accounting.spec.ts
+++ b/e2e/loan-product-accounting.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Product accounting, end to end against a real Fineract.
+ *
+ * This is the test that decides whether the feature works. Everything else — the unit specs, the
+ * mocked runs — proves the form renders and posts a body; only a real platform proves the body is
+ * one it accepts, and only the journal entries prove the product it created actually reaches the
+ * general ledger.
+ *
+ * Driven entirely through the screens, including the four GL accounts. Seeding those through the
+ * API would skip the one step an institution actually has to do first, and the chart of accounts
+ * is where a tenant that cannot configure accounting gets stuck.
+ *
+ *   npx playwright test e2e/loan-product-accounting.spec.ts --project=backend --workers=1
+ */
+
+import { test, expect, Page } from './fixtures';
+import { login, uniqueSuffix } from './utils/fineract-login';
+import { captureJson } from './utils/capture-response';
+import { ionSelect } from './utils/ionic-locators';
+import { selectOption } from './utils/select-option';
+
+/** The four account classes a cash-accounting loan product draws on. */
+const ACCOUNT_CLASSES = [
+  { type: 'Asset', label: 'Asset' },
+  { type: 'Liability', label: 'Liability' },
+  { type: 'Income', label: 'Income' },
+  { type: 'Expense', label: 'Expense' },
+] as const;
+
+/**
+ * The nine slots cash accounting requires, and the class each draws from.
+ *
+ * Not copied from documentation: posting a loan product with a rule and no mappings answers 400
+ * naming every missing parameter, which is where this list comes from.
+ */
+const CASH_SLOTS = [
+  { label: 'Fund source', accountClass: 'Asset' },
+  { label: 'Loan portfolio', accountClass: 'Asset' },
+  { label: 'Transfers in suspense', accountClass: 'Asset' },
+  { label: 'Interest on loans', accountClass: 'Income' },
+  { label: 'Income from fees', accountClass: 'Income' },
+  { label: 'Income from penalties', accountClass: 'Income' },
+  { label: 'Income from recovery repayments', accountClass: 'Income' },
+  { label: 'Losses written off', accountClass: 'Expense' },
+  { label: 'Overpayment liability', accountClass: 'Liability' },
+] as const;
+
+/** Creates one GL account through the chart of accounts and returns its display name. */
+async function createGlAccount(page: Page, type: string, suffix: string): Promise<string> {
+  const name = `E2E ${type} ${suffix}`;
+  const glCode = `E2E-${type.toUpperCase()}-${suffix}`;
+
+  await page.goto('/accounting/chart-of-accounts/create');
+  await page.locator('input[name="name"]').fill(name);
+  await page.locator('input[name="glCode"]').fill(glCode);
+  await selectOption(page, 'Account Type', type);
+  // Usage has no default and the form is invalid without it. Detail, not Header: only a detail
+  // account can be posted to, and a product mapping is a posting instruction.
+  await selectOption(page, 'Account Usage', 'Detail');
+  await page.getByRole('button', { name: /^save$/i }).click();
+  await expect(page).toHaveURL(/\/accounting\/chart-of-accounts$/, { timeout: 20000 });
+
+  // The picker labels each option with its code, which is how an accountant reads a chart.
+  return `${glCode} — ${name}`;
+}
+
+test.describe('Loan product accounting', () => {
+  // A real shared backend, and each test creates a product and a loan. Serial, like the other
+  // product-creating suites, so a pass does not overload it.
+  test.describe.configure({ mode: 'serial' });
+
+  test('a cash-accounting product is configured, round-trips on edit, and posts to the ledger', async ({
+    page,
+  }) => {
+    test.setTimeout(480000);
+    await login(page);
+
+    const suffix = uniqueSuffix();
+
+    // --- The institution's chart of accounts -------------------------------------------------
+    //
+    // A fresh tenant has none of these, and the product template omits an option list entirely
+    // for a class with no accounts — which is what the section's empty-state note is about.
+    const accounts: Record<string, string> = {};
+    for (const { type } of ACCOUNT_CLASSES) {
+      accounts[type] = await createGlAccount(page, type, suffix);
+    }
+
+    // --- A loan product that posts to the ledger ---------------------------------------------
+    const productName = `E2E Accounting ${suffix}`;
+    const shortName = suffix.slice(-4).toUpperCase();
+
+    await page.goto('/products/loan/create');
+    await expect(
+      ionSelect(page, 'Repayment Strategy').locator('ion-select-option').first(),
+    ).toBeAttached({ timeout: 20000 });
+
+    await page.getByRole('textbox', { name: 'Name', exact: true }).fill(productName);
+    await page.getByRole('textbox', { name: 'Short Name' }).fill(shortName);
+    await page.getByRole('spinbutton', { name: 'Principal' }).fill('1000');
+    await page.getByRole('spinbutton', { name: 'Interest Rate' }).fill('10');
+    await page.getByRole('spinbutton', { name: 'Number of Repayments' }).fill('3');
+    await page.getByRole('spinbutton', { name: 'Repayment Every' }).fill('1');
+
+    // Nothing accounting-related is on screen until a rule is chosen — the point of defaulting
+    // to NONE is that an existing product form behaves exactly as it did.
+    await expect(page.getByTestId('accounting-fundSourceAccountId')).toHaveCount(0);
+
+    await selectOption(page, 'Accounting rule', 'CASH BASED');
+
+    // The nine slots appear, grouped by account class, and no receivable does.
+    await expect(page.getByTestId('accounting-fundSourceAccountId')).toBeVisible({
+      timeout: 20000,
+    });
+    await expect(page.getByTestId('accounting-receivableInterestAccountId')).toHaveCount(0);
+    await expect(page.getByTestId('accounting-group-asset')).toBeVisible();
+
+    for (const slot of CASH_SLOTS) {
+      await selectOption(page, slot.label, accounts[slot.accountClass]);
+    }
+
+    const created = await captureJson<{ resourceId: number }>(page, /\/loanproducts$/, 'POST', () =>
+      page.getByRole('button', { name: /^save$/i }).click(),
+    );
+    await expect(page).toHaveURL(/\/products\/loan$/, { timeout: 20000 });
+    const productId = created.resourceId;
+
+    // --- Editing must not blank the ledger ---------------------------------------------------
+    //
+    // The failure mode this guards is silent: the form rebuilds its payload field by field, so a
+    // mapping it does not read back is a mapping the next save drops.
+    await page.goto(`/products/loan/edit/${productId}`);
+    await expect(page.getByTestId('product-accounting-rule')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId('accounting-fundSourceAccountId')).toContainText(
+      accounts['Asset'],
+      { timeout: 20000 },
+    );
+    await expect(page.getByTestId('accounting-overpaymentLiabilityAccountId')).toContainText(
+      accounts['Liability'],
+    );
+
+    // Change one unrelated field and save.
+    await page.getByRole('textbox', { name: 'Name', exact: true }).fill(`${productName} v2`);
+    await page.getByRole('button', { name: /^save$/i }).click();
+    await expect(page).toHaveURL(/\/products\/loan$/, { timeout: 20000 });
+
+    await page.goto(`/products/loan/edit/${productId}`);
+    await expect(page.getByTestId('accounting-fundSourceAccountId')).toContainText(
+      accounts['Asset'],
+      { timeout: 20000 },
+    );
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,7 @@ const BACKEND_SPECS = [
   'loan-account-actions.spec.ts',
   'loan-charge-off.spec.ts',
   'loan-lifecycle.spec.ts',
+  'loan-product-accounting.spec.ts',
   'loan-schedule-type.spec.ts',
   'loan-servicing.spec.ts',
   'login.spec.ts',

--- a/src/app/features/products/accounting/gl-account-select.component.ts
+++ b/src/app/features/products/accounting/gl-account-select.component.ts
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, computed, input, model } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { IonItem, IonLabel, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+
+import { TranslatePipe } from '../../../core/adapters';
+import { GlAccountOption } from './product-accounting.model';
+
+/**
+ * One GL-account slot: a labelled picker over the accounts a product may map into it.
+ *
+ * Options are always passed in, never fetched. They come from the product template alongside
+ * every other option list on the form, so fetching here would be a second round trip for data
+ * the parent already holds — and, on a tenant with a large chart of accounts, one per slot.
+ *
+ * The option text carries the GL code as well as the name. Charts of accounts are organised by
+ * code, and an accountant filling this in is reading from a numbered list; a name alone leaves
+ * them guessing which "Interest Income" is meant.
+ */
+@Component({
+  selector: 'app-gl-account-select',
+  standalone: true,
+  imports: [FormsModule, TranslatePipe, IonItem, IonLabel, IonSelect, IonSelectOption],
+  template: `
+    <ion-item fill="outline" class="form-item">
+      <!--
+        The label is the field name and nothing else. An asterisk here would be the only one in
+        the application, and it would also land inside the label's text, which is what every
+        label-scoped locator in the suite matches on.
+      -->
+      <ion-label position="stacked">{{ label() | appTranslate }}</ion-label>
+      <!--
+        The accessible name comes from aria-label, not from the ion-label above it. Ionic
+        associates a select with its own label property or a slotted label only; a sibling
+        ion-label is decorative, so without this the control announces as unlabelled.
+      -->
+      <ion-select
+        [attr.aria-label]="label() | appTranslate"
+        interface="popover"
+        [name]="name()"
+        [attr.data-testid]="testId()"
+        [ngModel]="accountId()"
+        (ngModelChange)="accountId.set($event)"
+        [required]="required()"
+        [disabled]="!options().length"
+        placeholder="{{ 'PRODUCTS.ACCOUNTING.SELECT_ACCOUNT' | appTranslate }}"
+      >
+        @for (account of options(); track account.id) {
+          <ion-select-option [value]="account.id">{{ optionLabel(account) }}</ion-select-option>
+        }
+      </ion-select>
+    </ion-item>
+  `,
+  styles: [
+    `
+      .form-item {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class GlAccountSelectComponent {
+  /** Translation key for the visible label. */
+  readonly label = input.required<string>();
+  /** Form control name — the request key of the slot, which keeps them unique within the form. */
+  readonly name = input.required<string>();
+  readonly options = input<GlAccountOption[]>([]);
+  readonly required = input(false);
+  readonly testId = input<string>();
+
+  readonly accountId = model<number | undefined>(undefined);
+
+  /** The disabled state is derived, so a template that reads it twice cannot disagree with itself. */
+  readonly hasOptions = computed(() => this.options().length > 0);
+
+  optionLabel(account: GlAccountOption): string {
+    return account.glCode ? `${account.glCode} — ${account.name}` : (account.name ?? '');
+  }
+}

--- a/src/app/features/products/accounting/product-accounting-section.component.spec.ts
+++ b/src/app/features/products/accounting/product-accounting-section.component.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { ProductAccountingSectionComponent } from './product-accounting-section.component';
+import {
+  ACCOUNTING_RULE,
+  GlAccountOptions,
+  LOAN_ACCOUNTING_FIELDS,
+  mappingsForRule,
+  mappingsFromResponse,
+} from './product-accounting.model';
+import { provideFakeAdapters } from '../../../testing/adapters';
+
+const OPTIONS: GlAccountOptions = {
+  assetAccountOptions: [{ id: 1, name: 'Loan Portfolio', glCode: '10201' }],
+  liabilityAccountOptions: [{ id: 2, name: 'Overpayment', glCode: '20101' }],
+  incomeAccountOptions: [{ id: 3, name: 'Interest Income', glCode: '40101' }],
+  expenseAccountOptions: [{ id: 4, name: 'Write-off', glCode: '50101' }],
+};
+
+/** The nine slots cash accounting requires, as the platform enumerates them. */
+const CASH_KEYS = [
+  'fundSourceAccountId',
+  'loanPortfolioAccountId',
+  'transfersInSuspenseAccountId',
+  'interestOnLoanAccountId',
+  'incomeFromFeeAccountId',
+  'incomeFromPenaltyAccountId',
+  'incomeFromRecoveryAccountId',
+  'writeOffAccountId',
+  'overpaymentLiabilityAccountId',
+];
+
+const RECEIVABLE_KEYS = [
+  'receivableInterestAccountId',
+  'receivableFeeAccountId',
+  'receivablePenaltyAccountId',
+];
+
+describe('ProductAccountingSectionComponent', () => {
+  let fixture: ComponentFixture<ProductAccountingSectionComponent>;
+  let component: ProductAccountingSectionComponent;
+
+  async function setup(rule: number, options: GlAccountOptions = OPTIONS): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [ProductAccountingSectionComponent],
+      providers: [provideNoopAnimations(), ...provideFakeAdapters().providers],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProductAccountingSectionComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('fields', LOAN_ACCOUNTING_FIELDS);
+    fixture.componentRef.setInput('accountOptions', options);
+    fixture.componentRef.setInput('accountingRule', rule);
+    fixture.detectChanges();
+  }
+
+  /** Every slot the section is currently showing, in render order. */
+  function renderedKeys(): string[] {
+    return component.groups().flatMap((group) => group.fields.map((field) => field.key));
+  }
+
+  it('shows no mapping fields at all under NONE', async () => {
+    await setup(ACCOUNTING_RULE.NONE);
+
+    expect(component.groups()).toEqual([]);
+    expect(fixture.nativeElement.querySelector('app-gl-account-select')).toBeNull();
+  });
+
+  it('shows the nine cash slots under CASH, and none of the receivables', async () => {
+    await setup(ACCOUNTING_RULE.CASH);
+
+    expect(renderedKeys().sort()).toEqual([...CASH_KEYS].sort());
+    for (const key of RECEIVABLE_KEYS) {
+      expect(renderedKeys()).not.toContain(key);
+    }
+  });
+
+  it('adds the receivables under both accrual rules', async () => {
+    for (const rule of [ACCOUNTING_RULE.ACCRUAL_PERIODIC, ACCOUNTING_RULE.ACCRUAL_UPFRONT]) {
+      await setup(rule);
+      expect(renderedKeys().sort()).toEqual([...CASH_KEYS, ...RECEIVABLE_KEYS].sort());
+      TestBed.resetTestingModule();
+    }
+  });
+
+  it('groups slots by account class and offers only accounts of that class', async () => {
+    await setup(ACCOUNTING_RULE.ACCRUAL_PERIODIC);
+
+    const groups = component.groups();
+    expect(groups.map((group) => group.accountType)).toEqual([
+      'asset',
+      'liability',
+      'income',
+      'expense',
+    ]);
+    // Pointing a slot at the wrong class is a 403 from the platform, so the picker must not
+    // offer accounts it would refuse.
+    expect(component.optionsFor('asset').map((account) => account.id)).toEqual([1]);
+    expect(component.optionsFor('income').map((account) => account.id)).toEqual([3]);
+  });
+
+  it('says so when the tenant has no accounts of a class the rule needs', async () => {
+    await setup(ACCOUNTING_RULE.CASH, { assetAccountOptions: OPTIONS.assetAccountOptions });
+
+    const empty = component.groups().filter((group) => !group.hasOptions);
+    expect(empty.map((group) => group.accountType)).toEqual(['liability', 'income', 'expense']);
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="accounting-empty-income"]'),
+    ).toBeTruthy();
+  });
+
+  it('records a selection without mutating the previous mappings object', async () => {
+    await setup(ACCOUNTING_RULE.CASH);
+    const before = component.mappings();
+
+    component.setMapping('fundSourceAccountId', 1);
+
+    expect(component.mappings()).toEqual({ fundSourceAccountId: 1 });
+    // A new object, so a parent holding this in a signal actually sees the change.
+    expect(component.mappings()).not.toBe(before);
+    expect(before).toEqual({});
+  });
+
+  it('clears every selection when the rule goes back to NONE', async () => {
+    await setup(ACCOUNTING_RULE.CASH);
+    component.setMapping('fundSourceAccountId', 1);
+
+    component.onRuleChange(ACCOUNTING_RULE.NONE);
+
+    // Otherwise the user sees no accounting on screen while the model still holds ids.
+    expect(component.mappings()).toEqual({});
+  });
+
+  it('keeps selections when moving between two posting rules', async () => {
+    await setup(ACCOUNTING_RULE.ACCRUAL_PERIODIC);
+    component.setMapping('fundSourceAccountId', 1);
+    component.setMapping('receivableFeeAccountId', 1);
+
+    component.onRuleChange(ACCOUNTING_RULE.CASH);
+
+    // Comparing cash against accrual should not mean filling the nine shared slots twice.
+    expect(component.mappings()['fundSourceAccountId']).toBe(1);
+  });
+});
+
+describe('product accounting payload', () => {
+  it('sends nothing under NONE, even when ids were picked earlier', () => {
+    const picked = { fundSourceAccountId: 1, loanPortfolioAccountId: 2 };
+
+    // A stray mapping key is a validation error from the platform, not a no-op.
+    expect(mappingsForRule(LOAN_ACCOUNTING_FIELDS, ACCOUNTING_RULE.NONE, picked)).toEqual({});
+  });
+
+  it('drops receivables when the rule moved from accrual to cash', () => {
+    const picked = {
+      fundSourceAccountId: 1,
+      receivableFeeAccountId: 9,
+    };
+
+    const payload = mappingsForRule(LOAN_ACCOUNTING_FIELDS, ACCOUNTING_RULE.CASH, picked);
+
+    expect(payload).toEqual({ fundSourceAccountId: 1 });
+  });
+
+  it('omits a slot the user has not filled rather than sending null', () => {
+    const payload = mappingsForRule(LOAN_ACCOUNTING_FIELDS, ACCOUNTING_RULE.CASH, {
+      fundSourceAccountId: 1,
+      loanPortfolioAccountId: undefined,
+    });
+
+    expect(Object.keys(payload)).toEqual(['fundSourceAccountId']);
+  });
+
+  it('reads a configured product back into the form', () => {
+    // The response nests each account under a key without the `Id` suffix.
+    const mappings = mappingsFromResponse(LOAN_ACCOUNTING_FIELDS, {
+      fundSourceAccount: { id: 3, name: 'Probe ASSET' },
+      loanPortfolioAccount: { id: 3, name: 'Probe ASSET' },
+      overpaymentLiabilityAccount: { id: 4, name: 'Probe LIAB' },
+    });
+
+    expect(mappings).toEqual({
+      fundSourceAccountId: 3,
+      loanPortfolioAccountId: 3,
+      overpaymentLiabilityAccountId: 4,
+    });
+  });
+
+  it('reads an unconfigured product as no mappings rather than throwing', () => {
+    expect(mappingsFromResponse(LOAN_ACCOUNTING_FIELDS, undefined)).toEqual({});
+  });
+});

--- a/src/app/features/products/accounting/product-accounting-section.component.ts
+++ b/src/app/features/products/accounting/product-accounting-section.component.ts
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, computed, input, model } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  IonCol,
+  IonGrid,
+  IonItem,
+  IonLabel,
+  IonRow,
+  IonSelect,
+  IonSelectOption,
+} from '@ionic/angular/standalone';
+
+import { TranslatePipe } from '../../../core/adapters';
+import { GlAccountSelectComponent } from './gl-account-select.component';
+import {
+  ACCOUNTING_RULE,
+  AccountingMappingField,
+  AccountingMappings,
+  GlAccountOption,
+  GlAccountOptions,
+  GlAccountType,
+  fieldsForRule,
+} from './product-accounting.model';
+
+interface AccountingRuleOption {
+  id?: number;
+  value?: string;
+}
+
+/** A heading and the slots under it, for one class of GL account. */
+interface MappingGroup {
+  accountType: GlAccountType;
+  label: string;
+  fields: AccountingMappingField[];
+  /** False when the tenant has no accounts of this class, which is worth saying out loud. */
+  hasOptions: boolean;
+}
+
+const GROUP_LABELS: Record<GlAccountType, string> = {
+  asset: 'ACCOUNTING.ASSET',
+  liability: 'ACCOUNTING.LIABILITY',
+  income: 'ACCOUNTING.INCOME',
+  expense: 'ACCOUNTING.EXPENSE',
+};
+
+/** Rendering order, which follows the order a trial balance is read in. */
+const GROUP_ORDER: readonly GlAccountType[] = ['asset', 'liability', 'income', 'expense'];
+
+/**
+ * The accounting block of a product form: pick a rule, then map the accounts it requires.
+ *
+ * Family-agnostic on purpose. It renders whatever {@link AccountingMappingField} list it is
+ * given, so loan, savings, deposit and share products share this one implementation and differ
+ * only in their field list. That is also why the rule options are an input rather than a
+ * constant — they come from each family's own template response, so the labels are the tenant's.
+ *
+ * The slots are grouped by account class rather than listed flat. A loan product under accrual
+ * maps twelve accounts, and twelve unbroken dropdowns on a form that is already long is not
+ * something anyone can check their way down.
+ */
+@Component({
+  selector: 'app-product-accounting-section',
+  standalone: true,
+  imports: [
+    FormsModule,
+    TranslatePipe,
+    GlAccountSelectComponent,
+    IonCol,
+    IonGrid,
+    IonItem,
+    IonLabel,
+    IonRow,
+    IonSelect,
+    IonSelectOption,
+  ],
+  template: `
+    <div class="accounting-section">
+      <h3 class="section-title">{{ 'PRODUCTS.ACCOUNTING.TITLE' | appTranslate }}</h3>
+
+      <ion-item fill="outline" class="form-item">
+        <ion-label position="stacked">{{ 'PRODUCTS.ACCOUNTING.RULE' | appTranslate }}</ion-label>
+        <ion-select
+          [attr.aria-label]="'PRODUCTS.ACCOUNTING.RULE' | appTranslate"
+          interface="popover"
+          name="accountingRule"
+          data-testid="product-accounting-rule"
+          [ngModel]="accountingRule()"
+          (ngModelChange)="onRuleChange($event)"
+        >
+          @for (option of ruleOptions(); track option.id) {
+            <ion-select-option [value]="option.id">{{ option.value }}</ion-select-option>
+          }
+        </ion-select>
+      </ion-item>
+
+      @if (groups().length) {
+        <ion-grid class="ion-no-padding">
+          @for (group of groups(); track group.accountType) {
+            <ion-row>
+              <ion-col size="12">
+                <h4
+                  class="group-title"
+                  [attr.data-testid]="'accounting-group-' + group.accountType"
+                >
+                  {{ group.label | appTranslate }}
+                </h4>
+                @if (!group.hasOptions) {
+                  <p
+                    class="group-note"
+                    [attr.data-testid]="'accounting-empty-' + group.accountType"
+                  >
+                    {{ 'PRODUCTS.ACCOUNTING.NO_ACCOUNTS_OF_TYPE' | appTranslate }}
+                  </p>
+                }
+              </ion-col>
+              @for (field of group.fields; track field.key) {
+                <ion-col size="12" size-md="6">
+                  <app-gl-account-select
+                    [label]="field.label"
+                    [name]="field.key"
+                    [testId]="'accounting-' + field.key"
+                    [options]="optionsFor(field.accountType)"
+                    [required]="true"
+                    [accountId]="mappings()[field.key]"
+                    (accountIdChange)="setMapping(field.key, $event)"
+                  ></app-gl-account-select>
+                </ion-col>
+              }
+            </ion-row>
+          }
+        </ion-grid>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .accounting-section {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .section-title {
+        margin: 16px 0 0;
+        font-size: 16px;
+        font-weight: 600;
+      }
+      .group-title {
+        margin: 16px 0 4px;
+        font-size: 13px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--text-muted, #6b7280);
+      }
+      .group-note {
+        margin: 0 0 4px;
+        font-size: 12px;
+        color: var(--text-muted, #6b7280);
+      }
+      .form-item {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class ProductAccountingSectionComponent {
+  /** The slots this product family maps. */
+  readonly fields = input.required<readonly AccountingMappingField[]>();
+  /** `accountingMappingOptions` from the family's template response. */
+  readonly accountOptions = input<GlAccountOptions>({});
+  /** `accountingRuleOptions` from the same response, so the labels are the platform's. */
+  readonly ruleOptions = input<AccountingRuleOption[]>([]);
+
+  readonly accountingRule = model<number>(ACCOUNTING_RULE.NONE);
+  readonly mappings = model<AccountingMappings>({});
+
+  readonly groups = computed<MappingGroup[]>(() => {
+    const required = fieldsForRule(this.fields(), this.accountingRule());
+
+    return GROUP_ORDER.map((accountType) => ({
+      accountType,
+      label: GROUP_LABELS[accountType],
+      fields: required.filter((field) => field.accountType === accountType),
+      hasOptions: this.optionsFor(accountType).length > 0,
+    })).filter((group) => group.fields.length > 0);
+  });
+
+  optionsFor(accountType: GlAccountType): GlAccountOption[] {
+    const options = this.accountOptions();
+    switch (accountType) {
+      case 'asset':
+        return Array.from(options.assetAccountOptions ?? []);
+      case 'liability':
+        return Array.from(options.liabilityAccountOptions ?? []);
+      case 'income':
+        return Array.from(options.incomeAccountOptions ?? []);
+      case 'expense':
+        return Array.from(options.expenseAccountOptions ?? []);
+    }
+  }
+
+  /**
+   * Records a selection as a new object rather than writing through the existing one.
+   *
+   * The parent holds these in a signal and reads them at submit. Mutating the object in place
+   * would leave that signal's value unchanged by identity, so nothing downstream would recompute
+   * — the same trap the form's other mutable-object fields document.
+   */
+  setMapping(key: string, accountId: number | undefined): void {
+    this.mappings.set({ ...this.mappings(), [key]: accountId });
+  }
+
+  /**
+   * Drops every selection when the rule moves to NONE.
+   *
+   * Leaving them would be invisible but not harmless: the user sees no mapping fields, so they
+   * believe the product has no accounting, while the model still holds the ids they picked
+   * before. Anything that later serialised the model wholesale would send them.
+   *
+   * Selections are deliberately *kept* when moving between the posting rules, so that switching
+   * cash → accrual → cash to compare them does not make the user fill the shared nine slots
+   * again. `mappingsForRule` is what stops the accrual-only ids being sent under cash.
+   */
+  onRuleChange(rule: number): void {
+    this.accountingRule.set(rule);
+    if (rule === ACCOUNTING_RULE.NONE) {
+      this.mappings.set({});
+    }
+  }
+}

--- a/src/app/features/products/accounting/product-accounting.model.ts
+++ b/src/app/features/products/accounting/product-accounting.model.ts
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * What a product's accounting configuration is made of, as data.
+ *
+ * The five product families each map a different set of GL accounts, but they map them the same
+ * way: pick a rule, then fill one account per slot the rule requires. Describing the slots as a
+ * list means the section component renders any family without knowing which one it is, and a
+ * family is added by writing its list rather than another form.
+ */
+
+/**
+ * Fineract's `accountingRuleType` enum.
+ *
+ * The platform returns these as `accountingRuleOptions` on every product template, and the
+ * section renders its selector from that response so the labels are the tenant's own. The ids
+ * are named here because the *behaviour* keys off them — which slots a rule requires is a fact
+ * about the rule, not a string the server sends.
+ */
+export const ACCOUNTING_RULE = {
+  NONE: 1,
+  CASH: 2,
+  ACCRUAL_PERIODIC: 3,
+  ACCRUAL_UPFRONT: 4,
+} as const;
+
+export type AccountingRuleId = (typeof ACCOUNTING_RULE)[keyof typeof ACCOUNTING_RULE];
+
+/** Every rule that posts to the ledger — i.e. everything except `NONE`. */
+export const ACCOUNTING_RULES_WITH_MAPPINGS: readonly AccountingRuleId[] = [
+  ACCOUNTING_RULE.CASH,
+  ACCOUNTING_RULE.ACCRUAL_PERIODIC,
+  ACCOUNTING_RULE.ACCRUAL_UPFRONT,
+];
+
+/** The two accrual rules, which require the receivable slots on top of the cash ones. */
+export const ACCRUAL_RULES: readonly AccountingRuleId[] = [
+  ACCOUNTING_RULE.ACCRUAL_PERIODIC,
+  ACCOUNTING_RULE.ACCRUAL_UPFRONT,
+];
+
+/**
+ * The four GL account classes a product slot can draw from.
+ *
+ * Not cosmetic. Pointing a slot at an account of the wrong class is refused —
+ * `403 validation.msg.domain.rule.violation`, "Passed in GLAccount fundSourceAccountId with Id 5
+ * maps to the account Probe INC of type INCOME, the expected account type was ASSET" — so the
+ * class each slot expects is what makes the picker able to only offer accounts that will work.
+ */
+export type GlAccountType = 'asset' | 'liability' | 'income' | 'expense';
+
+/** A GL account as the product template offers it. */
+export interface GlAccountOption {
+  id?: number;
+  name?: string;
+  glCode?: string;
+}
+
+/**
+ * The template's `accountingMappingOptions`, one list per account class.
+ *
+ * Every list is optional because the platform **omits the key entirely** when the tenant has no
+ * accounts of that class — a fresh install has none at all. A form that assumed four lists would
+ * render four empty dropdowns and no explanation; {@link ProductAccountingSectionComponent} says
+ * so instead.
+ */
+export interface GlAccountOptions {
+  assetAccountOptions?: Iterable<GlAccountOption>;
+  liabilityAccountOptions?: Iterable<GlAccountOption>;
+  incomeAccountOptions?: Iterable<GlAccountOption>;
+  expenseAccountOptions?: Iterable<GlAccountOption>;
+}
+
+/** One account slot on a product. */
+export interface AccountingMappingField {
+  /** The key the create/update request carries, e.g. `fundSourceAccountId`. */
+  readonly key: string;
+  /** The key the product response carries under `accountingMappings`, e.g. `fundSourceAccount`. */
+  readonly responseKey: string;
+  /** Which class of account the platform expects here. */
+  readonly accountType: GlAccountType;
+  /** Translation key for the field label. */
+  readonly label: string;
+  /** The rules that require this slot. A rule outside this list must not send the key. */
+  readonly rules: readonly AccountingRuleId[];
+}
+
+/** The id/name pair a product response carries for a mapped account. */
+export interface MappedGlAccount {
+  id?: number;
+  name?: string;
+}
+
+/** Selected accounts, keyed by request key. */
+export type AccountingMappings = Record<string, number | undefined>;
+
+/**
+ * The slots a **loan product** maps.
+ *
+ * Taken from the platform rather than from documentation: posting a loan product with a rule and
+ * no mappings answers 400 and names every missing parameter, which enumerates the mandatory set
+ * exactly. Against Fineract at the time of writing, `CASH` names nine and both accrual rules name
+ * those nine plus the three receivables — including `incomeFromRecoveryAccountId`, which is easy
+ * to miss because recovery is not part of the ordinary repayment story.
+ *
+ * Reproduce with:
+ *
+ *     POST /loanproducts  {"accountingRule": 2, …no mapping ids…}
+ */
+export const LOAN_ACCOUNTING_FIELDS: readonly AccountingMappingField[] = [
+  {
+    key: 'fundSourceAccountId',
+    responseKey: 'fundSourceAccount',
+    accountType: 'asset',
+    label: 'PRODUCTS.ACCOUNTING.FUND_SOURCE',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'loanPortfolioAccountId',
+    responseKey: 'loanPortfolioAccount',
+    accountType: 'asset',
+    label: 'PRODUCTS.ACCOUNTING.LOAN_PORTFOLIO',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'transfersInSuspenseAccountId',
+    responseKey: 'transfersInSuspenseAccount',
+    accountType: 'asset',
+    label: 'PRODUCTS.ACCOUNTING.TRANSFERS_IN_SUSPENSE',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'receivableInterestAccountId',
+    responseKey: 'receivableInterestAccount',
+    accountType: 'asset',
+    label: 'PRODUCTS.ACCOUNTING.RECEIVABLE_INTEREST',
+    rules: ACCRUAL_RULES,
+  },
+  {
+    key: 'receivableFeeAccountId',
+    responseKey: 'receivableFeeAccount',
+    accountType: 'asset',
+    label: 'PRODUCTS.ACCOUNTING.RECEIVABLE_FEE',
+    rules: ACCRUAL_RULES,
+  },
+  {
+    key: 'receivablePenaltyAccountId',
+    responseKey: 'receivablePenaltyAccount',
+    accountType: 'asset',
+    label: 'PRODUCTS.ACCOUNTING.RECEIVABLE_PENALTY',
+    rules: ACCRUAL_RULES,
+  },
+  {
+    key: 'interestOnLoanAccountId',
+    responseKey: 'interestOnLoanAccount',
+    accountType: 'income',
+    label: 'PRODUCTS.ACCOUNTING.INTEREST_ON_LOANS',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'incomeFromFeeAccountId',
+    responseKey: 'incomeFromFeeAccount',
+    accountType: 'income',
+    label: 'PRODUCTS.ACCOUNTING.INCOME_FROM_FEES',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'incomeFromPenaltyAccountId',
+    responseKey: 'incomeFromPenaltyAccount',
+    accountType: 'income',
+    label: 'PRODUCTS.ACCOUNTING.INCOME_FROM_PENALTIES',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'incomeFromRecoveryAccountId',
+    responseKey: 'incomeFromRecoveryAccount',
+    accountType: 'income',
+    label: 'PRODUCTS.ACCOUNTING.INCOME_FROM_RECOVERY',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'writeOffAccountId',
+    responseKey: 'writeOffAccount',
+    accountType: 'expense',
+    label: 'PRODUCTS.ACCOUNTING.LOSSES_WRITTEN_OFF',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+  {
+    key: 'overpaymentLiabilityAccountId',
+    responseKey: 'overpaymentLiabilityAccount',
+    accountType: 'liability',
+    label: 'PRODUCTS.ACCOUNTING.OVERPAYMENT_LIABILITY',
+    rules: ACCOUNTING_RULES_WITH_MAPPINGS,
+  },
+];
+
+/** The slots `rule` requires, in declaration order. */
+export function fieldsForRule(
+  fields: readonly AccountingMappingField[],
+  rule: number | undefined,
+): AccountingMappingField[] {
+  return fields.filter((field) => field.rules.includes(rule as AccountingRuleId));
+}
+
+/**
+ * The mapping keys to send for `rule`, and nothing else.
+ *
+ * Two things this exists to prevent. A rule of `NONE` must send no mapping keys at all — the
+ * platform rejects a stray `null`. And a slot left over from a previously selected rule must not
+ * ride along: switching accrual → cash while three receivable ids sit in the model would send
+ * receivables the cash rule has no slot for.
+ */
+export function mappingsForRule(
+  fields: readonly AccountingMappingField[],
+  rule: number | undefined,
+  mappings: AccountingMappings,
+): AccountingMappings {
+  const payload: AccountingMappings = {};
+  for (const field of fieldsForRule(fields, rule)) {
+    const accountId = mappings[field.key];
+    if (accountId !== undefined && accountId !== null) {
+      payload[field.key] = accountId;
+    }
+  }
+  return payload;
+}
+
+/**
+ * The mappings a loaded product already has, keyed the way the form holds them.
+ *
+ * The response nests each one as `{ id, name }` under a key without the `Id` suffix, so this is
+ * the only place that knows the two spellings are the same slot. Reading it is what stops an
+ * edit from blanking a configured product.
+ */
+export function mappingsFromResponse(
+  fields: readonly AccountingMappingField[],
+  accountingMappings: object | undefined,
+): AccountingMappings {
+  const mappings: AccountingMappings = {};
+  if (!accountingMappings) return mappings;
+
+  // The generated `GetLoanAccountingMappings` (and its four siblings) declare their slots as
+  // named properties with no index signature, so they cannot be read by a computed key without
+  // this. Widened rather than narrowed: each family's response names a different subset, and the
+  // field list is already the authority on which of them this product has.
+  const source = accountingMappings as Record<string, MappedGlAccount | undefined>;
+
+  for (const field of fields) {
+    const accountId = source[field.responseKey]?.id;
+    if (accountId !== undefined) {
+      mappings[field.key] = accountId;
+    }
+  }
+  return mappings;
+}

--- a/src/app/features/products/loan-product-form.component.spec.ts
+++ b/src/app/features/products/loan-product-form.component.spec.ts
@@ -37,10 +37,25 @@ import {
   DEFAULT_TRANSACTION_PROCESSING_STRATEGY,
   LOAN_SCHEDULE_TYPE,
 } from './loan-schedule-type';
+import { ACCOUNTING_RULE, LOAN_ACCOUNTING_FIELDS } from './accounting/product-accounting.model';
 
 const EQUAL_AMORTIZATION_LABEL = 'Equal amortization';
 
+const LOAN_PORTFOLIO = 'Loan Portfolio';
+
 const TEMPLATE = {
+  accountingRuleOptions: [
+    { id: 1, code: 'accountingRuleType.none', value: 'NONE' },
+    { id: 2, code: 'accountingRuleType.cash', value: 'CASH BASED' },
+    { id: 3, code: 'accountingRuleType.accrual.periodic', value: 'ACCRUAL PERIODIC' },
+    { id: 4, code: 'accountingRuleType.accrual.upfront', value: 'ACCRUAL UPFRONT' },
+  ],
+  accountingMappingOptions: {
+    assetAccountOptions: [{ id: 11, name: LOAN_PORTFOLIO, glCode: '10201' }],
+    liabilityAccountOptions: [{ id: 12, name: 'Overpayment', glCode: '20101' }],
+    incomeAccountOptions: [{ id: 13, name: 'Interest Income', glCode: '40101' }],
+    expenseAccountOptions: [{ id: 14, name: 'Write-off', glCode: '50101' }],
+  },
   loanScheduleTypeOptions: [
     { id: 1, code: LOAN_SCHEDULE_TYPE.CUMULATIVE, value: 'Cumulative' },
     { id: 2, code: LOAN_SCHEDULE_TYPE.PROGRESSIVE, value: 'Progressive' },
@@ -523,6 +538,171 @@ describe('LoanProductFormComponent', () => {
       expect(product.buyDownFeeIncomeType).toBe('FEE');
       expect(component.incomeCapitalizationEnabled()).toBeTrue();
       expect(component.buyDownFeeEnabled()).toBeTrue();
+    });
+  });
+  describe('accounting', () => {
+    /** Fills every slot the rule requires, the way a user working down the section would. */
+    function fillMappings(rule: number): void {
+      component.product().accountingRule = rule;
+      const byType: Record<string, number> = {
+        asset: 11,
+        liability: 12,
+        income: 13,
+        expense: 14,
+      };
+      const mappings: Record<string, number> = {};
+      for (const field of LOAN_ACCOUNTING_FIELDS) {
+        if (field.rules.includes(rule as never)) mappings[field.key] = byType[field.accountType];
+      }
+      component.accountingMappings.set(mappings);
+    }
+
+    it('defaults to NONE, so behaviour is unchanged until a rule is chosen', () => {
+      expect(component.product().accountingRule).toBe(ACCOUNTING_RULE.NONE);
+      expect(component.accountingMappings()).toEqual({});
+    });
+
+    it('reads the account options and rule labels off the template', () => {
+      // Hardcoding either would break on every tenant but the one it was written against.
+      expect(component.accountingRuleOptions().map((option) => option.id)).toEqual([1, 2, 3, 4]);
+      expect(
+        Array.from(component.accountingMappingOptions().assetAccountOptions ?? []).map((a) => a.id),
+      ).toEqual([11]);
+    });
+
+    it('submits no mapping keys under NONE', () => {
+      productServiceSpy.postLoanproducts.and.returnValue(of({}) as never);
+
+      component.onSubmit();
+
+      const body = productServiceSpy.postLoanproducts.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      expect(body['accountingRule']).toBe(ACCOUNTING_RULE.NONE);
+      expect(Object.keys(body).filter((key) => key.endsWith('AccountId'))).toEqual([]);
+    });
+
+    it('submits the nine slots cash accounting requires', () => {
+      productServiceSpy.postLoanproducts.and.returnValue(of({}) as never);
+      fillMappings(ACCOUNTING_RULE.CASH);
+
+      component.onSubmit();
+
+      const body = productServiceSpy.postLoanproducts.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      expect(body['fundSourceAccountId']).toBe(11);
+      expect(body['overpaymentLiabilityAccountId']).toBe(12);
+      expect(body['incomeFromRecoveryAccountId']).toBe(13);
+      expect(body['writeOffAccountId']).toBe(14);
+      expect(body['receivableInterestAccountId']).toBeUndefined();
+    });
+
+    it('adds the receivables under accrual', () => {
+      productServiceSpy.postLoanproducts.and.returnValue(of({}) as never);
+      fillMappings(ACCOUNTING_RULE.ACCRUAL_PERIODIC);
+
+      component.onSubmit();
+
+      const body = productServiceSpy.postLoanproducts.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      expect(body['receivableInterestAccountId']).toBe(11);
+      expect(body['receivableFeeAccountId']).toBe(11);
+      expect(body['receivablePenaltyAccountId']).toBe(11);
+    });
+
+    it('does not send the down-payment auto-repayment flag while down payment is off', () => {
+      productServiceSpy.postLoanproducts.and.returnValue(of({}) as never);
+      component.product().enableDownPayment = false;
+      component.product().enableAutoRepaymentForDownPayment = false;
+
+      component.onSubmit();
+
+      // The platform refuses the pair outright on update, which made every loan product without
+      // down payment unsaveable from the edit screen.
+      const body = productServiceSpy.postLoanproducts.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      expect('enableAutoRepaymentForDownPayment' in body).toBe(false);
+    });
+
+    it('keeps the flag once down payment is on', () => {
+      productServiceSpy.postLoanproducts.and.returnValue(of({}) as never);
+      component.product().enableDownPayment = true;
+      component.product().enableAutoRepaymentForDownPayment = true;
+
+      component.onSubmit();
+
+      const body = productServiceSpy.postLoanproducts.calls.mostRecent().args[0] as Record<
+        string,
+        unknown
+      >;
+      expect(body['enableAutoRepaymentForDownPayment']).toBe(true);
+    });
+
+    it('populates the mappings of a product opened for editing', async () => {
+      await setup('7');
+      productServiceSpy.getLoanproductsProductId.and.returnValue(
+        of({
+          name: 'Configured',
+          currency: { code: 'USD', decimalPlaces: 2 },
+          accountingRule: { id: 3, value: 'ACCRUAL PERIODIC' },
+          accountingMappings: {
+            fundSourceAccount: { id: 11, name: LOAN_PORTFOLIO },
+            overpaymentLiabilityAccount: { id: 12, name: 'Overpayment' },
+            receivableFeeAccount: { id: 11, name: LOAN_PORTFOLIO },
+          },
+        }) as never,
+      );
+      component.loadProductData();
+
+      expect(component.product().accountingRule).toBe(ACCOUNTING_RULE.ACCRUAL_PERIODIC);
+      expect(component.accountingMappings()).toEqual({
+        fundSourceAccountId: 11,
+        overpaymentLiabilityAccountId: 12,
+        receivableFeeAccountId: 11,
+      });
+    });
+
+    it("carries a configured product's mappings back out on save", async () => {
+      await setup('7');
+      productServiceSpy.getLoanproductsProductId.and.returnValue(
+        of({
+          name: 'Configured',
+          currency: { code: 'USD', decimalPlaces: 2 },
+          accountingRule: { id: 2, value: 'CASH BASED' },
+          accountingMappings: {
+            fundSourceAccount: { id: 11 },
+            loanPortfolioAccount: { id: 11 },
+            transfersInSuspenseAccount: { id: 11 },
+            interestOnLoanAccount: { id: 13 },
+            incomeFromFeeAccount: { id: 13 },
+            incomeFromPenaltyAccount: { id: 13 },
+            incomeFromRecoveryAccount: { id: 13 },
+            writeOffAccount: { id: 14 },
+            overpaymentLiabilityAccount: { id: 12 },
+          },
+        }) as never,
+      );
+      component.loadProductData();
+      productServiceSpy.putLoanproductsProductId.and.returnValue(of({}) as never);
+
+      // Opening a product, changing one unrelated field and saving must not blank the ledger.
+      component.product().name = 'Renamed';
+      component.onSubmit();
+
+      const body = productServiceSpy.putLoanproductsProductId.calls.mostRecent().args[1] as Record<
+        string,
+        unknown
+      >;
+      expect(body['name']).toBe('Renamed');
+      expect(Object.keys(body).filter((key) => key.endsWith('AccountId'))).toHaveSize(9);
+      expect(body['fundSourceAccountId']).toBe(11);
     });
   });
 });

--- a/src/app/features/products/loan-product-form.component.ts
+++ b/src/app/features/products/loan-product-form.component.ts
@@ -58,6 +58,15 @@ import {
 } from '../../api';
 import { LOAN_SCHEDULE_TYPE, isAdvancedPaymentAllocationStrategy } from './loan-schedule-type';
 import { PaymentCreditAllocationEditorComponent } from './payment-credit-allocation-editor.component';
+import { ProductAccountingSectionComponent } from './accounting/product-accounting-section.component';
+import {
+  ACCOUNTING_RULE,
+  AccountingMappings,
+  GlAccountOptions,
+  LOAN_ACCOUNTING_FIELDS,
+  mappingsForRule,
+  mappingsFromResponse,
+} from './accounting/product-accounting.model';
 import { TooltipDirective } from '../../shared/directives/tooltip.directive';
 
 /**
@@ -75,6 +84,7 @@ const DAILY_INTEREST_CALCULATION_PERIOD = 0;
   imports: [
     FormsModule,
     TranslateModule,
+    ProductAccountingSectionComponent,
     IonCard,
     IonCardHeader,
     IonCardTitle,
@@ -1111,8 +1121,13 @@ const DAILY_INTEREST_CALCULATION_PERIOD = 0;
                       name="chargeOffBehaviour"
                       [(ngModel)]="product().chargeOffBehaviour"
                     >
-                      @for (option of chargeOffBehaviourOptions(); track option.code) {
-                        <ion-select-option [value]="option.code">{{
+                      <!--
+                        The id, not the code. The template offers both — id "REGULAR", code
+                        "chargeOffBehaviour.regular" — and the platform accepts only the former.
+                        Sending the code answers validation.msg.enum.value.not.found.
+                      -->
+                      @for (option of chargeOffBehaviourOptions(); track option.id) {
+                        <ion-select-option [value]="option.id">{{
                           option.value
                         }}</ion-select-option>
                       }
@@ -1197,6 +1212,16 @@ const DAILY_INTEREST_CALCULATION_PERIOD = 0;
                 (creditAllocationChange)="product().creditAllocation = $event"
               ></app-payment-credit-allocation-editor>
             }
+
+            <app-product-accounting-section
+              [fields]="accountingFields"
+              [accountOptions]="accountingMappingOptions()"
+              [ruleOptions]="accountingRuleOptions()"
+              [accountingRule]="product().accountingRule ?? 1"
+              (accountingRuleChange)="product().accountingRule = $event"
+              [mappings]="accountingMappings()"
+              (mappingsChange)="accountingMappings.set($event)"
+            ></app-product-accounting-section>
 
             <div class="form-actions">
               <ion-button
@@ -1336,6 +1361,19 @@ export class LoanProductFormComponent implements OnInit {
   readonly repaymentStartDateTypeOptions = signal<GetLoanProductsRepaymentStartDateType[]>([]);
   readonly chargeOffBehaviourOptions = signal<StringEnumOptionData[]>([]);
 
+  /**
+   * Accounting.
+   *
+   * The selected accounts are held here rather than on `product()`, and merged into the body at
+   * submit. Keeping them out of the request object is what makes a rule change safe: the slots a
+   * rule does not have must not be sent, and a model that carried them would send whatever the
+   * user picked under a rule they have since moved away from. See `mappingsForRule`.
+   */
+  readonly accountingFields = LOAN_ACCOUNTING_FIELDS;
+  readonly accountingMappingOptions = signal<GlAccountOptions>({});
+  readonly accountingRuleOptions = signal<{ id?: number; value?: string }[]>([]);
+  readonly accountingMappings = signal<AccountingMappings>({});
+
   readonly product = signal<PostLoanProductsRequest>({
     currencyCode: 'USD',
     digitsAfterDecimal: 2,
@@ -1397,6 +1435,8 @@ export class LoanProductFormComponent implements OnInit {
         Array.from(template.repaymentStartDateTypeOptions ?? []),
       );
       this.chargeOffBehaviourOptions.set(template.chargeOffBehaviourOptions ?? []);
+      this.accountingMappingOptions.set(template.accountingMappingOptions ?? {});
+      this.accountingRuleOptions.set(Array.from(template.accountingRuleOptions ?? []));
 
       this.applyTransactionProcessingStrategyFilter();
     });
@@ -1716,11 +1756,16 @@ export class LoanProductFormComponent implements OnInit {
           data.interestRecalculationData?.recalculationCompoundingFrequencyInterval,
         preClosureInterestCalculationStrategy:
           data.interestRecalculationData?.preClosureInterestCalculationStrategy?.id,
-        chargeOffBehaviour: data.chargeOffBehaviour?.code,
+        chargeOffBehaviour: data.chargeOffBehaviour?.id,
         enableAccrualActivityPosting: data.enableAccrualActivityPosting,
         fixedLength: data.fixedLength,
         repaymentStartDateType: data.repaymentStartDateType?.id,
       });
+      // Without this, opening a configured product shows empty account pickers, and the first
+      // save under a *changed* rule would submit the product with nothing mapped.
+      this.accountingMappings.set(
+        mappingsFromResponse(this.accountingFields, data.accountingMappings),
+      );
       this.isProgressive.set(this.product().loanScheduleType === LOAN_SCHEDULE_TYPE.PROGRESSIVE);
       this.downPaymentEnabled.set(this.product().enableDownPayment === true);
       this.multiDisburseEnabled.set(this.product().multiDisburseLoan === true);
@@ -1734,19 +1779,49 @@ export class LoanProductFormComponent implements OnInit {
     });
   }
 
+  /**
+   * The request body: the form's own fields plus exactly the account slots the chosen rule has.
+   *
+   * Under `NONE` that adds nothing at all — the platform rejects a mapping key it has no slot
+   * for, including one whose value is null.
+   */
+  private buildRequest(): PostLoanProductsRequest {
+    const request: PostLoanProductsRequest = {
+      ...this.product(),
+      ...mappingsForRule(
+        this.accountingFields,
+        this.product().accountingRule ?? ACCOUNTING_RULE.NONE,
+        this.accountingMappings(),
+      ),
+    };
+
+    // `enableAutoRepaymentForDownPayment` is only a valid parameter while down payment is on.
+    // Sending `false` alongside `enableDownPayment: false` is refused —
+    // `validation.msg.loanproduct.enableAutoRepaymentForDownPayment.supported.only.for.enable.down.payment.true`
+    // — and a product loaded for editing carries exactly that pair, because Fineract returns the
+    // flag as `false` rather than omitting it. Create tolerates the combination; update does not,
+    // so every loan product without down payment was unsaveable from the edit screen.
+    if (request.enableDownPayment !== true) {
+      delete request.enableAutoRepaymentForDownPayment;
+    }
+
+    return request;
+  }
+
   onSubmit() {
     this.isSaving.set(true);
     this.product().locale = 'en';
+    const request = this.buildRequest();
 
     if (this.isEditMode() && this.productId) {
       this.productService
-        .putLoanproductsProductId(this.productId, this.product() as PutLoanProductsProductIdRequest)
+        .putLoanproductsProductId(this.productId, request as PutLoanProductsProductIdRequest)
         .subscribe({
           next: () => this.router.navigate([this.LIST_PATH]),
           error: () => this.isSaving.set(false),
         });
     } else {
-      this.productService.postLoanproducts(this.product()).subscribe({
+      this.productService.postLoanproducts(request).subscribe({
         next: () => this.router.navigate([this.LIST_PATH]),
         error: () => this.isSaving.set(false),
       });

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -388,7 +388,25 @@
     "REPAYMENT_START_DATE_TYPE": "Repayments are counted from",
     "FIXED_LENGTH": "Fixed term length (periods)",
     "ENABLE_ACCRUAL_ACTIVITY_POSTING": "Post accrual activity entries",
-    "INTEREST_CALC_PERIOD_LOCKED_NOTE": "Fixed to Daily because interest recalculation is on — Fineract only supports the two together. Turn recalculation off to choose a different period."
+    "INTEREST_CALC_PERIOD_LOCKED_NOTE": "Fixed to Daily because interest recalculation is on — Fineract only supports the two together. Turn recalculation off to choose a different period.",
+    "ACCOUNTING": {
+      "TITLE": "Accounting",
+      "RULE": "Accounting rule",
+      "SELECT_ACCOUNT": "Select an account",
+      "NO_ACCOUNTS_OF_TYPE": "No general ledger accounts of this type exist yet. Create them under Accounting > Chart of Accounts before configuring this product.",
+      "FUND_SOURCE": "Fund source",
+      "LOAN_PORTFOLIO": "Loan portfolio",
+      "TRANSFERS_IN_SUSPENSE": "Transfers in suspense",
+      "RECEIVABLE_INTEREST": "Interest receivable",
+      "RECEIVABLE_FEE": "Fees receivable",
+      "RECEIVABLE_PENALTY": "Penalties receivable",
+      "INTEREST_ON_LOANS": "Interest on loans",
+      "INCOME_FROM_FEES": "Income from fees",
+      "INCOME_FROM_PENALTIES": "Income from penalties",
+      "INCOME_FROM_RECOVERY": "Income from recovery repayments",
+      "LOSSES_WRITTEN_OFF": "Losses written off",
+      "OVERPAYMENT_LIABILITY": "Overpayment liability"
+    }
   },
   "CHARGES": {
     "CREATE": "Create Charge",


### PR DESCRIPTION
Closes #289. Closes #290. Part of #288.

Both sub-tasks in one PR rather than the two the issues describe: #290 is the only consumer of #289, and splitting them would have meant merging a shared component with nothing using it.

## The problem

`accountingRule: 1` (NONE) is hardcoded in all five product forms, and there is not one GL-account field anywhere in the application. An institution can create its entire product catalogue through this UI and produce no trial balance from it.

## What this adds

A rule selector and a rule-driven GL-account mapping section, wired into the loan product form.

**The section is data, not a form.** `product-accounting.model.ts` describes a slot as `{request key, response key, account class, label, the rules that require it}`, and `ProductAccountingSectionComponent` renders whatever list it is handed. Savings, deposit and share products differ only in their list — which is what the four remaining sub-tasks of #288 need from this one.

Both components live in `src/app/features/products/accounting/` rather than `shared/`, per the note on #289. They are shaped entirely by the product template response — option lists, rule labels, slot names — and nothing outside products has a use for them.

**Filtering each picker by account class is not cosmetic.** Pointing a slot at the wrong class is refused outright:

```
403 validation.msg.domain.rule.violation
Passed in GLAccount fundSourceAccountId with Id 5 maps to the account
Probe INC of type INCOME, the expected account type was ASSET
```

So the class a slot expects is what lets the picker offer only accounts that will work.

## Where the slot list came from

Not from documentation. Posting a product with a rule and no mappings answers 400 naming every missing parameter, which enumerates the mandatory set exactly:

```
POST /loanproducts {"accountingRule": 2, …no mapping ids…}
→ fundSourceAccountId, loanPortfolioAccountId, transfersInSuspenseAccountId,
  interestOnLoanAccountId, incomeFromFeeAccountId, incomeFromPenaltyAccountId,
  incomeFromRecoveryAccountId, writeOffAccountId, overpaymentLiabilityAccountId
```

Cash requires those nine; both accrual rules require them plus `receivableInterestAccountId`, `receivableFeeAccountId`, `receivablePenaltyAccountId`. That is where `incomeFromRecoveryAccountId` came from — reading the ordinary repayment story would have missed it, and the issue text I wrote listed eight.

Selections are held beside the request object and merged in at submit, so slots a rule does not have are never sent: `NONE` sends no mapping keys at all, and switching accrual → cash does not leak the receivables.

The template omits an option list entirely when the tenant has no accounts of that class — a fresh install has none — so the section says so instead of rendering empty dropdowns.

## Three pre-existing defects found on the way

All in the same submit path. The edit round-trip #290 asks for cannot pass without the first two, which is how they surfaced.

| | |
|---|---|
| `enableAutoRepaymentForDownPayment: false` sent alongside `enableDownPayment: false` | Create tolerates the pair; **update refuses it**. Every loan product without down payment was unsaveable from the edit screen. |
| `chargeOffBehaviour` bound to the option's `code` (`chargeOffBehaviour.regular`) where the platform accepts its `id` (`REGULAR`) | Choosing one answered `validation.msg.enum.value.not.found` — on **create** as well as edit. |
| The edit path dropped accounting entirely | A configured product opened and saved would have gone back with nothing mapped once the rule changed. |

## Verifying it

`e2e/loan-product-accounting.spec.ts` is the test that decides whether this works. Against a real platform it creates the four GL accounts **through the chart of accounts screen**, configures a cash-accounting product, reopens it, and proves the mappings survive an unrelated edit. No API seeding — the chart of accounts is where a tenant that cannot configure accounting actually gets stuck, so skipping it would skip the step that matters.

| | |
|---|---|
| `loan-product-accounting.spec.ts` (real backend) | passed |
| Full unit suite | 865 passed |
| `product-accounting-section.component.spec.ts` | 13 new |
| `loan-product-form.component.spec.ts` | 33 (10 new) |
| `npm run lint`, `npm run i18n:check`, `npm run build`, `tsc` | clean |

## Not in this PR

Savings (#291), deposit (#292), share (#293) and the advanced mappings (#294). The savings slot set is already probed — seven, and `interestOnSavingsAccount` is an expense rather than income — but each family needs its own verification pass against the platform, and this PR is already the size of one review.
