### PR TITLE
fix(reporting): discover report parameters dynamically

### DIFF
--- a/e2e/functional-coverage.spec.ts
+++ b/e2e/functional-coverage.spec.ts
@@ -1035,6 +1035,36 @@ test.describe('Reporting — Run Report Flow', () => {
         }),
       });
     });
+    await page.route('**/api/v1/runreports/FullParameterList**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            {
+              row: [
+                'OfficeIdSelectOne',
+                'officeId',
+                'Office',
+                'select',
+                'number',
+                '0',
+                null,
+                null,
+                null,
+              ],
+            },
+          ],
+        }),
+      });
+    });
+    await page.route('**/api/v1/runreports/OfficeIdSelectOne**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [{ row: [1, HEAD_OFFICE] }] }),
+      });
+    });
 
     await page.getByRole('link', { name: 'Reports' }).click();
     await expect(page).toHaveURL('/reporting');
@@ -1044,7 +1074,7 @@ test.describe('Reporting — Run Report Flow', () => {
     await expect(page).toHaveURL(/\/reporting\/run/);
 
     /* select office and run */
-    await page.locator('ion-select').click();
+    await page.getByTestId('report-parameter-officeId').locator('ion-select').click();
     await page.locator('ion-alert, ion-popover').getByRole('radio', { name: HEAD_OFFICE }).click();
     await page.getByRole('button', { name: 'Run Report' }).click();
 

--- a/e2e/report-enhancements.spec.ts
+++ b/e2e/report-enhancements.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { test, expect } from './fixtures';
+import { selectOption } from './utils/select-option';
 
 const HEAD_OFFICE = 'Head Office';
 const ALICE_SMITH = 'Alice Smith';
@@ -25,7 +26,10 @@ const KEVIN_BACON = 'Kevin Bacon';
 const CARD_TITLE = 'ion-card-title';
 
 test.describe('Report Enhancements, Pagination, and Help Tour', () => {
+  let latestRunRequestUrl = '';
+
   test.beforeEach(async ({ page }) => {
+    latestRunRequestUrl = '';
     // Intercept config.json
     await page.route('**/config.json*', async (route) => {
       await route.fulfill({
@@ -74,6 +78,32 @@ test.describe('Report Enhancements, Pagination, and Help Tour', () => {
       });
     });
 
+    // The dashboard requests this before navigation completes. Keep the mocked journey free of
+    // an unrelated 404 toast so screenshots show only the report interaction under test.
+    await page.route('**/api/v1/loans?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ pageItems: [], totalFilteredRecords: 0 }),
+      });
+    });
+    for (const dashboardResource of ['clients', 'savingsaccounts', 'accounttransfers']) {
+      await page.route(`**/api/v1/${dashboardResource}?**`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ pageItems: [], totalFilteredRecords: 0 }),
+        });
+      });
+    }
+    await page.route('**/api/v1/businessdate**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ type: 'BUSINESS_DATE', date: [2026, 8, 9] }]),
+      });
+    });
+
     // Intercept Reports API
     await page.route('**/api/v1/reports', async (route) => {
       await route.fulfill({
@@ -92,8 +122,70 @@ test.describe('Report Enhancements, Pagination, and Help Tour', () => {
       });
     });
 
+    await page.route('**/api/v1/runreports/FullParameterList**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            {
+              row: [
+                'OfficeIdSelectOne',
+                'officeId',
+                'Office',
+                'select',
+                'number',
+                '0',
+                null,
+                null,
+                null,
+              ],
+            },
+            {
+              row: [
+                'loanOfficerIdSelectAll',
+                'loanOfficerId',
+                'Loan Officer',
+                'select',
+                'number',
+                '0',
+                null,
+                'Y',
+                null,
+              ],
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route('**/api/v1/runreports/OfficeIdSelectOne**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [{ row: [1, HEAD_OFFICE] }] }),
+      });
+    });
+
+    await page.route('**/api/v1/runreports/loanOfficerIdSelectAll**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [{ row: [42, 'Ada Officer'] }] }),
+      });
+    });
+
     // Intercept RunReport API with mock paginated data (12 rows)
     await page.route('**/api/v1/runreports/Active%20Clients%20Summary**', async (route) => {
+      latestRunRequestUrl = route.request().url();
+      if (new URL(latestRunRequestUrl).searchParams.get('exportCSV') === 'true') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/csv',
+          body: 'Client ID,Display Name,Office,Activation Date',
+        });
+        return;
+      }
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -133,7 +225,7 @@ test.describe('Report Enhancements, Pagination, and Help Tour', () => {
     }
   });
 
-  test('should run report, show paginated data, and download CSV', async ({ page }) => {
+  test('should run report, show paginated data, and download CSV', async ({ page }, testInfo) => {
     // Navigate to Reporting
     await page.getByRole('link', { name: 'Reports' }).click();
     await expect(page).toHaveURL('/reporting');
@@ -144,9 +236,18 @@ test.describe('Report Enhancements, Pagination, and Help Tour', () => {
     await expect(page).toHaveURL(/\/reporting\/run\/Active%20Clients%20Summary/);
 
     // Select an office and click Run
-    await page.locator('ion-select').click();
-    await page.locator('ion-alert, ion-popover').getByRole('radio', { name: HEAD_OFFICE }).click();
+    await selectOption(page, 'Office', HEAD_OFFICE);
+    await selectOption(page, 'Loan Officer', 'Ada Officer');
+    await expect(page.locator('ion-toast')).toHaveCount(0);
+    await page.screenshot({
+      path: testInfo.outputPath('dynamic-report-parameters.png'),
+      fullPage: true,
+    });
     await page.getByRole('button', { name: 'Run Report' }).click();
+
+    const runQuery = new URL(latestRunRequestUrl).searchParams;
+    expect(runQuery.get('R_officeId')).toBe('1');
+    expect(runQuery.get('R_loanOfficerId')).toBe('42');
 
     // Verify report results are shown
     const resultsHeader = page.locator('.results-header h3');

--- a/e2e/report-parameter-backend.spec.ts
+++ b/e2e/report-parameter-backend.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Proves dynamic report parameters against a real Fineract instance.
+ *
+ * Client Listing scopes its rows by Office. Head Office includes descendants, while a branch
+ * includes only that branch. Two seeded clients therefore make the selected parameter observable
+ * in the returned row set. A test that only checked that a table rendered would miss the original
+ * bug, where the UI silently omitted a declared parameter and Fineract returned the wrong scope.
+ */
+
+import { test, expect } from './fixtures';
+import { login } from './utils/fineract-login';
+import { ionSelect } from './utils/ionic-locators';
+import { selectOption } from './utils/select-option';
+import { createApiContext, seedClient, seedOffice } from './utils/seed-api';
+
+const REPORT_NAME = 'Client Listing';
+const HEAD_OFFICE = 'Head Office';
+
+test.describe('Dynamic report parameters against Fineract', () => {
+  test('changing Office changes the Client Listing row set', async ({ page }) => {
+    const api = await createApiContext();
+    const branch = await seedOffice(api, 'E2EReportParameters');
+    const headOfficeClient = await seedClient(api, 'E2EReportHead');
+    const branchClient = await seedClient(api, 'E2EReportBranch', branch.officeId);
+    await api.dispose();
+
+    await login(page);
+    await page.goto(`/reporting/run/${encodeURIComponent(REPORT_NAME)}?type=Table`);
+    await expect(page.locator('ion-card-title')).toContainText(REPORT_NAME);
+
+    const runForOffice = async (
+      officeName: string,
+      expectedClientName: string,
+      optionName: string | RegExp = officeName,
+    ): Promise<string[]> => {
+      if (typeof optionName === 'string') {
+        await selectOption(page, 'Office', optionName);
+      } else {
+        await ionSelect(page, 'Office').click();
+        await page
+          .locator('ion-alert, ion-popover, ion-action-sheet')
+          .getByRole('radio', { name: optionName })
+          .click();
+      }
+      const reportResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          url.pathname.endsWith(`/runreports/${encodeURIComponent(REPORT_NAME)}`) &&
+          url.searchParams.get('exportCSV') === 'false' &&
+          response.ok()
+        );
+      });
+      await page.getByTestId('run-report').click();
+      await reportResponse;
+      const rows = page.locator('table tbody tr');
+      await expect(rows.first()).toBeVisible({ timeout: 20000 });
+      await expect(page.locator('table')).toContainText(expectedClientName);
+      const pageSize = page.getByTestId('paginator-page-size');
+      if ((await pageSize.evaluate((select: HTMLIonSelectElement) => select.value)) !== 100) {
+        await pageSize.click();
+        await page.locator('ion-popover').getByRole('radio', { name: '100' }).click();
+      }
+      return rows.allTextContents();
+    };
+
+    const headOfficeRows = await runForOffice(HEAD_OFFICE, headOfficeClient.displayName);
+    // Fineract indents descendant office labels with dots. Match the seeded office name at the
+    // end so this proof is independent of its depth in the office hierarchy.
+    const escapedBranchName = branch.officeName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const branchRows = await runForOffice(
+      branch.officeName,
+      branchClient.displayName,
+      new RegExp(`${escapedBranchName}$`),
+    );
+
+    expect(headOfficeRows.join(' ')).toContain(headOfficeClient.displayName);
+    expect(branchRows.join(' ')).toContain(branchClient.displayName);
+    expect(branchRows.join(' ')).not.toContain(headOfficeClient.displayName);
+    expect(branchRows).not.toEqual(headOfficeRows);
+  });
+});

--- a/e2e/report-parameter-backend.spec.ts
+++ b/e2e/report-parameter-backend.spec.ts
@@ -33,9 +33,22 @@ import { selectOption } from './utils/select-option';
 import { createApiContext, seedClient, seedOffice } from './utils/seed-api';
 
 const REPORT_NAME = 'Client Listing';
+const CASCADING_REPORT_NAME = 'Active Loans - Summary';
 const HEAD_OFFICE = 'Head Office';
 
 test.describe('Dynamic report parameters against Fineract', () => {
+  test('keeps the parameter form available when a report has cascading lookups', async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto(`/reporting/run/${encodeURIComponent(CASCADING_REPORT_NAME)}?type=Table`);
+
+    await expect(page.locator('ion-card-title')).toContainText(CASCADING_REPORT_NAME);
+    await expect(page.getByTestId('report-parameters-error')).toHaveCount(0);
+    await expect(page.getByTestId('report-parameter-officeId')).toBeVisible();
+    await expect(page.getByTestId('report-parameter-loanOfficerId')).toBeVisible();
+  });
+
   test('changing Office changes the Client Listing row set', async ({ page }) => {
     const api = await createApiContext();
     const branch = await seedOffice(api, 'E2EReportParameters');

--- a/e2e/report-parameter-backend.spec.ts
+++ b/e2e/report-parameter-backend.spec.ts
@@ -86,12 +86,12 @@ test.describe('Dynamic report parameters against Fineract', () => {
       await reportResponse;
       const rows = page.locator('table tbody tr');
       await expect(rows.first()).toBeVisible({ timeout: 20000 });
-      await expect(page.locator('table')).toContainText(expectedClientName);
       const pageSize = page.getByTestId('paginator-page-size');
       if ((await pageSize.evaluate((select: HTMLIonSelectElement) => select.value)) !== 100) {
         await pageSize.click();
         await page.locator('ion-popover').getByRole('radio', { name: '100' }).click();
       }
+      await expect(page.locator('table')).toContainText(expectedClientName);
       return rows.allTextContents();
     };
 

--- a/e2e/reporting.spec.ts
+++ b/e2e/reporting.spec.ts
@@ -71,6 +71,14 @@ test.describe('Reporting', () => {
       });
     });
 
+    await page.route('**/api/v1/runreports/FullParameterList**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [] }),
+      });
+    });
+
     await page.goto('/login');
     await page.locator('#tenantId').fill('default');
     await page.locator('#username').fill('mifos');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,7 @@ const BACKEND_SPECS = [
   'loan-schedule-type.spec.ts',
   'loan-servicing.spec.ts',
   'login.spec.ts',
+  'report-parameter-backend.spec.ts',
   'teller-cash-management.spec.ts',
 ];
 

--- a/src/app/features/reporting/report-execution.service.spec.ts
+++ b/src/app/features/reporting/report-execution.service.spec.ts
@@ -27,6 +27,8 @@ import { ReportExecutionService } from './report-execution.service';
 describe('ReportExecutionService', () => {
   const REPORT_NAME = 'Client Listing';
   const OUTPUT_TYPE = 'output-type';
+  const FULL_PARAMETER_LIST_URL = '/api/v1/runreports/FullParameterList';
+  const HEAD_OFFICE = 'Head Office';
   let service: ReportExecutionService;
   let http: HttpTestingController;
 
@@ -52,15 +54,13 @@ describe('ReportExecutionService', () => {
       expect(parameters).toHaveSize(2);
       expect(parameters[0].queryParameter).toBe('R_officeId');
       expect(parameters[0].options).toEqual([
-        { id: 1, name: 'Head Office' },
+        { id: 1, name: HEAD_OFFICE },
         { id: '-1', name: '', isAll: true },
       ]);
       expect(parameters[1].displayType).toBe('date');
     });
 
-    const template = http.expectOne(
-      (request) => request.url === '/api/v1/runreports/FullParameterList',
-    );
+    const template = http.expectOne((request) => request.url === FULL_PARAMETER_LIST_URL);
     expect(template.request.params.get('R_reportListing')).toBe('Portfolio at Risk');
     expect(template.request.params.get('parameterType')).toBe('true');
     template.flush({
@@ -98,8 +98,104 @@ describe('ReportExecutionService', () => {
       (request) => request.url === '/api/v1/runreports/OfficeIdSelectAll',
     );
     expect(lookup.request.params.get('parameterType')).toBe('true');
-    lookup.flush({ data: [{ row: [1, 'Head Office'] }] });
+    lookup.flush({ data: [{ row: [1, HEAD_OFFICE] }] });
     expect(discovered).toBeTrue();
+  });
+
+  it('keeps cascading selects empty until their parent has a value', () => {
+    service.getReportParameters('Active Loans - Summary').subscribe((parameters) => {
+      expect(parameters).toHaveSize(2);
+      expect(parameters[0].options).toEqual([{ id: 1, name: HEAD_OFFICE }]);
+      expect(parameters[1].queryParameter).toBe('R_loanOfficerId');
+      expect(parameters[1].parentParameterName).toBe('OfficeIdSelectOne');
+      expect(parameters[1].options).toEqual([]);
+    });
+
+    http
+      .expectOne((request) => request.url === FULL_PARAMETER_LIST_URL)
+      .flush({
+        data: [
+          {
+            row: [
+              'OfficeIdSelectOne',
+              'officeId',
+              'Office',
+              'select',
+              'number',
+              '0',
+              null,
+              null,
+              null,
+            ],
+          },
+          {
+            row: [
+              'loanOfficerIdSelectAll',
+              'loanOfficerId',
+              'Loan Officer',
+              'select',
+              'number',
+              '0',
+              null,
+              null,
+              'OfficeIdSelectOne',
+            ],
+          },
+        ],
+      });
+
+    http.expectNone((request) => request.url === '/api/v1/runreports/loanOfficerIdSelectAll');
+    http
+      .expectOne((request) => request.url === '/api/v1/runreports/OfficeIdSelectOne')
+      .flush({ data: [{ row: [1, HEAD_OFFICE] }] });
+  });
+
+  it('isolates a failed lookup instead of dropping the parameter form', () => {
+    service.getReportParameters('Tenant Report').subscribe((parameters) => {
+      expect(parameters).toHaveSize(2);
+      expect(parameters[0].options).toEqual([]);
+      expect(parameters[1].options).toEqual([{ id: 'USD', name: 'US Dollar' }]);
+    });
+
+    http
+      .expectOne((request) => request.url === FULL_PARAMETER_LIST_URL)
+      .flush({
+        data: [
+          {
+            row: [
+              'OfficeIdSelectOne',
+              'officeId',
+              'Office',
+              'select',
+              'number',
+              '0',
+              null,
+              null,
+              null,
+            ],
+          },
+          {
+            row: [
+              'currencyIdSelectAll',
+              'currencyId',
+              'Currency',
+              'select',
+              'string',
+              '',
+              null,
+              null,
+              null,
+            ],
+          },
+        ],
+      });
+
+    http
+      .expectOne((request) => request.url === '/api/v1/runreports/OfficeIdSelectOne')
+      .flush('Lookup failed', { status: 403, statusText: 'Forbidden' });
+    http
+      .expectOne((request) => request.url === '/api/v1/runreports/currencyIdSelectAll')
+      .flush({ data: [{ row: ['USD', 'US Dollar'] }] });
   });
 
   it('sends every named report parameter without relying on positional arguments', () => {
@@ -145,17 +241,34 @@ describe('ReportExecutionService', () => {
     request.flush('Client ID,Display Name');
   });
 
-  it('fails closed when the parameter template is malformed', () => {
-    let message = '';
-    service.getReportParameters('Broken Report').subscribe({
-      error: (error: Error) => {
-        message = error.message;
+  it('skips malformed template rows without dropping valid parameters', () => {
+    service.getReportParameters('Tenant Report').subscribe({
+      next: (parameters) => {
+        expect(parameters).toHaveSize(1);
+        expect(parameters[0].queryParameter).toBe('R_startDate');
       },
+      error: fail,
     });
 
     http
-      .expectOne((request) => request.url === '/api/v1/runreports/FullParameterList')
-      .flush({ data: [{ row: ['missing-fields'] }] });
-    expect(message).toContain('invalid row');
+      .expectOne((request) => request.url === FULL_PARAMETER_LIST_URL)
+      .flush({
+        data: [
+          { row: ['missing-fields'] },
+          {
+            row: [
+              'startDateSelect',
+              'startDate',
+              'From Date',
+              'date',
+              'date',
+              'today',
+              null,
+              null,
+              null,
+            ],
+          },
+        ],
+      });
   });
 });

--- a/src/app/features/reporting/report-execution.service.spec.ts
+++ b/src/app/features/reporting/report-execution.service.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from '../../core/services/config.service';
+import { ReportExecutionService } from './report-execution.service';
+
+describe('ReportExecutionService', () => {
+  const REPORT_NAME = 'Client Listing';
+  const OUTPUT_TYPE = 'output-type';
+  let service: ReportExecutionService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ReportExecutionService,
+        { provide: ConfigService, useValue: { apiUrl: '/api/v1' } },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    service = TestBed.inject(ReportExecutionService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('discovers parameters and loads each select parameter from its own lookup', () => {
+    let discovered = false;
+    service.getReportParameters('Portfolio at Risk').subscribe((parameters) => {
+      discovered = true;
+      expect(parameters).toHaveSize(2);
+      expect(parameters[0].queryParameter).toBe('R_officeId');
+      expect(parameters[0].options).toEqual([
+        { id: 1, name: 'Head Office' },
+        { id: '-1', name: '', isAll: true },
+      ]);
+      expect(parameters[1].displayType).toBe('date');
+    });
+
+    const template = http.expectOne(
+      (request) => request.url === '/api/v1/runreports/FullParameterList',
+    );
+    expect(template.request.params.get('R_reportListing')).toBe('Portfolio at Risk');
+    expect(template.request.params.get('parameterType')).toBe('true');
+    template.flush({
+      data: [
+        {
+          row: [
+            'OfficeIdSelectAll',
+            'officeId',
+            'Office',
+            'select',
+            'number',
+            '0',
+            null,
+            'Y',
+            null,
+          ],
+        },
+        {
+          row: [
+            'startDateSelect',
+            'startDate',
+            'From Date',
+            'date',
+            'date',
+            'today',
+            null,
+            null,
+            null,
+          ],
+        },
+      ],
+    });
+
+    const lookup = http.expectOne(
+      (request) => request.url === '/api/v1/runreports/OfficeIdSelectAll',
+    );
+    expect(lookup.request.params.get('parameterType')).toBe('true');
+    lookup.flush({ data: [{ row: [1, 'Head Office'] }] });
+    expect(discovered).toBeTrue();
+  });
+
+  it('sends every named report parameter without relying on positional arguments', () => {
+    service
+      .runReport(REPORT_NAME, {
+        R_officeId: 1,
+        R_loanOfficerId: 42,
+        R_accountNo: '000123',
+      })
+      .subscribe();
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === '/api/v1/runreports/Client%20Listing',
+    );
+    expect(request.request.method).toBe('GET');
+    expect(request.request.params.keys().sort()).toEqual([
+      'R_accountNo',
+      'R_loanOfficerId',
+      'R_officeId',
+      'exportCSV',
+      OUTPUT_TYPE,
+    ]);
+    expect(request.request.params.get('R_officeId')).toBe('1');
+    expect(request.request.params.get('R_loanOfficerId')).toBe('42');
+    expect(request.request.params.get('R_accountNo')).toBe('000123');
+    expect(request.request.params.get('exportCSV')).toBe('false');
+    expect(request.request.params.get(OUTPUT_TYPE)).toBe('HTML');
+    request.flush({ columnHeaders: [], data: [] });
+  });
+
+  it('requests CSV output while preserving the same dynamic parameter map', () => {
+    service.downloadCsv(REPORT_NAME, { R_officeId: 2 }).subscribe((csv) => {
+      expect(csv).toContain('Client ID');
+    });
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === '/api/v1/runreports/Client%20Listing',
+    );
+    expect(request.request.responseType).toBe('text');
+    expect(request.request.params.get('R_officeId')).toBe('2');
+    expect(request.request.params.get('exportCSV')).toBe('true');
+    expect(request.request.params.get(OUTPUT_TYPE)).toBe('CSV');
+    request.flush('Client ID,Display Name');
+  });
+
+  it('fails closed when the parameter template is malformed', () => {
+    let message = '';
+    service.getReportParameters('Broken Report').subscribe({
+      error: (error: Error) => {
+        message = error.message;
+      },
+    });
+
+    http
+      .expectOne((request) => request.url === '/api/v1/runreports/FullParameterList')
+      .flush({ data: [{ row: ['missing-fields'] }] });
+    expect(message).toContain('invalid row');
+  });
+});

--- a/src/app/features/reporting/report-execution.service.ts
+++ b/src/app/features/reporting/report-execution.service.ts
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, forkJoin, map, of, switchMap } from 'rxjs';
+
+import { ConfigService } from '../../core/services/config.service';
+
+export interface ReportSelectOption {
+  readonly id: string | number;
+  readonly name: string;
+  readonly isAll?: boolean;
+}
+
+export interface ReportParameter {
+  readonly name: string;
+  readonly variable: string;
+  readonly label: string;
+  readonly displayType: string;
+  readonly formatType: string;
+  readonly defaultValue: unknown;
+  readonly selectOne: unknown;
+  readonly selectAll: unknown;
+  readonly parentParameterName: string | null;
+  readonly queryParameter: string;
+  readonly options: readonly ReportSelectOption[];
+}
+
+export interface ReportResult {
+  readonly columnHeaders?: readonly Record<string, unknown>[];
+  readonly data?: readonly Record<string, unknown>[];
+  readonly [key: string]: unknown;
+}
+
+interface GenericResultset {
+  readonly data?: readonly { readonly row?: unknown }[];
+}
+
+export type ReportParameterValues = Readonly<Record<string, string | number>>;
+
+/**
+ * The generated run-reports client exposes only a fixed positional subset of report parameters.
+ * Report definitions are dynamic, so this service deliberately uses a named query map instead.
+ */
+@Injectable({ providedIn: 'root' })
+export class ReportExecutionService {
+  private readonly http = inject(HttpClient);
+  private readonly config = inject(ConfigService);
+
+  getReportParameters(reportName: string): Observable<ReportParameter[]> {
+    const params = new HttpParams().set('R_reportListing', reportName).set('parameterType', 'true');
+
+    return this.http.get<GenericResultset>(this.reportUrl('FullParameterList'), { params }).pipe(
+      map((response) => (response.data ?? []).map((entry) => this.toReportParameter(entry.row))),
+      switchMap((parameters) => this.loadSelectOptions(parameters)),
+    );
+  }
+
+  runReport(reportName: string, values: ReportParameterValues): Observable<ReportResult> {
+    const params = this.buildRunParams(values, false, 'HTML');
+    return this.http.get<ReportResult>(this.reportUrl(reportName), { params });
+  }
+
+  downloadCsv(reportName: string, values: ReportParameterValues): Observable<string> {
+    const params = this.buildRunParams(values, true, 'CSV');
+    return this.http.get(this.reportUrl(reportName), { params, responseType: 'text' });
+  }
+
+  private loadSelectOptions(parameters: ReportParameter[]): Observable<ReportParameter[]> {
+    const requests = parameters.map((parameter) => {
+      if (parameter.displayType !== 'select') {
+        return of(parameter);
+      }
+
+      const params = new HttpParams().set('parameterType', 'true');
+      return this.http.get<GenericResultset>(this.reportUrl(parameter.name), { params }).pipe(
+        map((response) => {
+          const options = (response.data ?? []).map((entry) => this.toSelectOption(entry.row));
+          const offersAll = String(parameter.selectAll).toUpperCase() === 'Y';
+          const alreadyOffersAll = options.some((option) => String(option.id) === '-1');
+
+          return {
+            ...parameter,
+            options:
+              offersAll && !alreadyOffersAll
+                ? [...options, { id: '-1', name: '', isAll: true }]
+                : options,
+          };
+        }),
+      );
+    });
+
+    return requests.length > 0 ? forkJoin(requests) : of([]);
+  }
+
+  private toReportParameter(row: unknown): ReportParameter {
+    if (!Array.isArray(row) || row.length < 9) {
+      throw new Error('The report parameter template returned an invalid row.');
+    }
+
+    const [
+      name,
+      variable,
+      label,
+      displayType,
+      formatType,
+      defaultValue,
+      selectOne,
+      selectAll,
+      parent,
+    ] = row;
+    if (
+      typeof name !== 'string' ||
+      typeof variable !== 'string' ||
+      typeof displayType !== 'string'
+    ) {
+      throw new Error('The report parameter template omitted a required field.');
+    }
+
+    return {
+      name,
+      variable,
+      label: typeof label === 'string' && label ? label : variable,
+      displayType: displayType.toLowerCase(),
+      formatType: typeof formatType === 'string' ? formatType : '',
+      defaultValue,
+      selectOne,
+      selectAll,
+      parentParameterName: typeof parent === 'string' && parent ? parent : null,
+      queryParameter: `R_${variable}`,
+      options: [],
+    };
+  }
+
+  private toSelectOption(row: unknown): ReportSelectOption {
+    if (!Array.isArray(row) || row.length < 2) {
+      throw new Error('A report parameter lookup returned an invalid row.');
+    }
+    const [id, name] = row;
+    if ((typeof id !== 'string' && typeof id !== 'number') || typeof name !== 'string') {
+      throw new Error('A report parameter lookup omitted a required field.');
+    }
+    return { id, name };
+  }
+
+  private buildRunParams(
+    values: ReportParameterValues,
+    exportCsv: boolean,
+    outputType: 'CSV' | 'HTML',
+  ): HttpParams {
+    let params = new HttpParams()
+      .set('exportCSV', String(exportCsv))
+      .set('output-type', outputType);
+
+    for (const [key, value] of Object.entries(values)) {
+      params = params.set(key, String(value));
+    }
+    return params;
+  }
+
+  private reportUrl(reportName: string): string {
+    const apiUrl = this.config.apiUrl.replace(/\/$/, '');
+    return `${apiUrl}/runreports/${encodeURIComponent(reportName)}`;
+  }
+}

--- a/src/app/features/reporting/report-execution.service.ts
+++ b/src/app/features/reporting/report-execution.service.ts
@@ -19,7 +19,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { Observable, forkJoin, map, of, switchMap } from 'rxjs';
+import { Observable, catchError, forkJoin, map, of, switchMap } from 'rxjs';
 
 import { ConfigService } from '../../core/services/config.service';
 
@@ -68,7 +68,11 @@ export class ReportExecutionService {
     const params = new HttpParams().set('R_reportListing', reportName).set('parameterType', 'true');
 
     return this.http.get<GenericResultset>(this.reportUrl('FullParameterList'), { params }).pipe(
-      map((response) => (response.data ?? []).map((entry) => this.toReportParameter(entry.row))),
+      map((response) =>
+        (response.data ?? [])
+          .map((entry) => this.toReportParameter(entry.row))
+          .filter((parameter): parameter is ReportParameter => parameter !== null),
+      ),
       switchMap((parameters) => this.loadSelectOptions(parameters)),
     );
   }
@@ -85,7 +89,10 @@ export class ReportExecutionService {
 
   private loadSelectOptions(parameters: ReportParameter[]): Observable<ReportParameter[]> {
     const requests = parameters.map((parameter) => {
-      if (parameter.displayType !== 'select') {
+      // Parent-dependent options cannot be fetched until the parent has a value. Populating them
+      // after a parent selection is tracked in #301; for now they remain empty without preventing
+      // the rest of the parameter form from loading.
+      if (parameter.displayType !== 'select' || parameter.parentParameterName) {
         return of(parameter);
       }
 
@@ -104,15 +111,17 @@ export class ReportExecutionService {
                 : options,
           };
         }),
+        // A tenant-specific lookup failure should affect only that field, not the entire form.
+        catchError(() => of(parameter)),
       );
     });
 
     return requests.length > 0 ? forkJoin(requests) : of([]);
   }
 
-  private toReportParameter(row: unknown): ReportParameter {
+  private toReportParameter(row: unknown): ReportParameter | null {
     if (!Array.isArray(row) || row.length < 9) {
-      throw new Error('The report parameter template returned an invalid row.');
+      return null;
     }
 
     const [
@@ -131,7 +140,7 @@ export class ReportExecutionService {
       typeof variable !== 'string' ||
       typeof displayType !== 'string'
     ) {
-      throw new Error('The report parameter template omitted a required field.');
+      return null;
     }
 
     return {

--- a/src/app/features/reporting/run-report.component.spec.ts
+++ b/src/app/features/reporting/run-report.component.spec.ts
@@ -18,33 +18,65 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RunReportComponent } from './run-report.component';
-import { RunReportsService, OfficesService } from '../../api';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
-import { of } from 'rxjs';
-import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { NotificationService } from '../../core/services/notification.service';
+import { provideIonicTesting } from '../../testing/ionic-testing';
+import { ReportExecutionService, ReportParameter, ReportResult } from './report-execution.service';
+import { RunReportComponent } from './run-report.component';
 
 describe('RunReportComponent', () => {
   const REPORT_NAME = 'Active Clients';
   let component: RunReportComponent;
   let fixture: ComponentFixture<RunReportComponent>;
-  let runReportsServiceSpy: jasmine.SpyObj<RunReportsService>;
-  let officesServiceSpy: jasmine.SpyObj<OfficesService>;
+  let reportExecutionSpy: jasmine.SpyObj<ReportExecutionService>;
+
+  const parameter = (
+    variable: string,
+    label: string,
+    displayType: string,
+    options: ReportParameter['options'] = [],
+  ): ReportParameter => ({
+    name: `${variable}Parameter`,
+    variable,
+    label,
+    displayType,
+    formatType: displayType === 'date' ? 'date' : 'string',
+    defaultValue: displayType === 'none' ? 'hidden-value' : null,
+    selectOne: null,
+    selectAll: null,
+    parentParameterName: null,
+    queryParameter: `R_${variable}`,
+    options,
+  });
+
+  const office = parameter('officeId', 'Office', 'select', [{ id: 1, name: 'Head Office' }]);
+  const loanOfficer = parameter('loanOfficerId', 'Loan Officer', 'select', [
+    { id: 42, name: 'Ada Officer' },
+  ]);
+  const fromDate = parameter('fromDate', 'From Date', 'date');
+  const toDate = parameter('toDate', 'To Date', 'date');
+  const accountNumber = parameter('accountNo', 'Account Number', 'text');
 
   beforeEach(async () => {
-    runReportsServiceSpy = jasmine.createSpyObj('RunReportsService', ['getRunreportsReportName']);
-    officesServiceSpy = jasmine.createSpyObj('OfficesService', ['getOffices']);
-    officesServiceSpy.getOffices.and.returnValue(
-      of([]) as unknown as ReturnType<OfficesService['getOffices']>,
-    );
+    reportExecutionSpy = jasmine.createSpyObj('ReportExecutionService', [
+      'getReportParameters',
+      'runReport',
+      'downloadCsv',
+    ]);
 
     await TestBed.configureTestingModule({
       imports: [RunReportComponent, TranslateModule.forRoot()],
       providers: [
-        { provide: RunReportsService, useValue: runReportsServiceSpy },
-        { provide: OfficesService, useValue: officesServiceSpy },
+        { provide: ReportExecutionService, useValue: reportExecutionSpy },
         { provide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
+        {
+          provide: NotificationService,
+          useValue: jasmine.createSpyObj('NotificationService', ['error']),
+        },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -52,33 +84,99 @@ describe('RunReportComponent', () => {
             queryParamMap: of(convertToParamMap({ type: 'Table' })),
           },
         },
+        provideIonicTesting(),
         provideNoopAnimations(),
       ],
     }).compileComponents();
+  });
 
+  function create(parameters: ReportParameter[]): void {
+    reportExecutionSpy.getReportParameters.and.returnValue(of(parameters));
     fixture = TestBed.createComponent(RunReportComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }
 
   it('should create and read the report name from the route', () => {
+    create([office]);
+
     expect(component).toBeTruthy();
     expect(component.reportName()).toBe(REPORT_NAME);
+    expect(reportExecutionSpy.getReportParameters).toHaveBeenCalledOnceWith(REPORT_NAME);
   });
 
-  it('should run the report with positionally-correct arguments (no self-service flag)', () => {
-    runReportsServiceSpy.getRunreportsReportName.and.returnValue(
-      of({ columnHeaders: [], data: [] }) as unknown as ReturnType<
-        RunReportsService['getRunreportsReportName']
-      >,
-    );
+  it('renders all five declared visible parameters using their display types', () => {
+    create([office, loanOfficer, fromDate, toDate, accountNumber]);
 
+    const controls = fixture.nativeElement.querySelectorAll(
+      'ion-item[data-testid^="report-parameter-"]',
+    );
+    expect(controls).toHaveSize(5);
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="report-parameter-officeId"]'),
+    ).not.toBeNull();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="report-parameter-fromDate"]'),
+    ).not.toBeNull();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="report-parameter-accountNo"]'),
+    ).not.toBeNull();
+  });
+
+  it('renders only Office when it is the only declared parameter', () => {
+    create([office]);
+
+    expect(
+      fixture.nativeElement.querySelectorAll('[data-testid="report-parameter-officeId"]'),
+    ).toHaveSize(1);
+    expect(
+      fixture.nativeElement.querySelectorAll('ion-item[data-testid^="report-parameter-"]'),
+    ).toHaveSize(1);
+  });
+
+  it('passes hidden defaults without rendering a control', () => {
+    const hidden = parameter('tenantScope', 'Tenant Scope', 'none');
+    reportExecutionSpy.runReport.and.returnValue(of({ columnHeaders: [], data: [] }));
+    create([hidden]);
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="report-parameter-tenantScope"]'),
+    ).toBeNull();
+    expect(component.canRun()).toBeTrue();
+    component.onRun();
+    expect(reportExecutionSpy.runReport).toHaveBeenCalledOnceWith(REPORT_NAME, {
+      R_tenantScope: 'hidden-value',
+    });
+  });
+
+  it('passes the full collected value map to the report call', () => {
+    const result: ReportResult = { columnHeaders: [], data: [] };
+    reportExecutionSpy.runReport.and.returnValue(of(result));
+    create([office, loanOfficer, fromDate, toDate, accountNumber]);
+
+    component.setParameterValue(office, 1);
+    component.setParameterValue(loanOfficer, 42);
+    component.setParameterValue(fromDate, '2026-08-01T00:00:00.000Z');
+    component.setParameterValue(toDate, '2026-08-09T00:00:00.000Z');
+    component.setParameterValue(accountNumber, '000123');
     component.onRun();
 
-    expect(runReportsServiceSpy.getRunreportsReportName).toHaveBeenCalled();
-    const args = runReportsServiceSpy.getRunreportsReportName.calls.mostRecent().args;
-    // reportName, exportCSV, parameterType, outputType, ...
-    expect(args[0]).toBe(REPORT_NAME);
-    expect(args[3]).toBe('HTML'); // outputType lands in the right slot after the param fix
+    expect(reportExecutionSpy.runReport).toHaveBeenCalledOnceWith(REPORT_NAME, {
+      R_officeId: 1,
+      R_loanOfficerId: 42,
+      R_fromDate: '2026-08-01',
+      R_toDate: '2026-08-09',
+      R_accountNo: '000123',
+    });
+  });
+
+  it('blocks a report that declares an unsupported display type', () => {
+    create([parameter('customFilter', 'Custom Filter', 'range')]);
+
+    expect(component.canRun()).toBeFalse();
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="report-parameters-unsupported"]')
+        .textContent,
+    ).toContain('Custom Filter (range)');
   });
 });

--- a/src/app/features/reporting/run-report.component.ts
+++ b/src/app/features/reporting/run-report.component.ts
@@ -17,19 +17,11 @@
  * under the License.
  */
 
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
-
-import { ActivatedRoute, Router } from '@angular/router';
-import { FormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
-import { RunReportsService, OfficesService, GetOfficesResponse } from '../../api';
-import { HelpIconComponent } from '../../shared';
-import { NotificationService } from '../../core/services/notification.service';
 import { CdkTableModule } from '@angular/cdk/table';
-import { PaginatorComponent } from '../../shared/components/paginator/paginator.component';
-import { PageEvent } from '../../shared/models/table.model';
-import { toIsoDate } from '../../core/utils/date-formatter';
-import { DOWNLOAD } from '../../core/adapters';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   IonButton,
   IonCard,
@@ -39,12 +31,29 @@ import {
   IonDatetime,
   IonDatetimeButton,
   IonIcon,
+  IonInput,
   IonItem,
   IonLabel,
   IonModal,
+  IonNote,
   IonSelect,
   IonSelectOption,
+  IonSpinner,
 } from '@ionic/angular/standalone';
+
+import { DOWNLOAD } from '../../core/adapters';
+import { NotificationService } from '../../core/services/notification.service';
+import { toIsoDate } from '../../core/utils/date-formatter';
+import { HelpIconComponent } from '../../shared';
+import { PaginatorComponent } from '../../shared/components/paginator/paginator.component';
+import { PageEvent } from '../../shared/models/table.model';
+import {
+  ReportExecutionService,
+  ReportParameter,
+  ReportParameterValues,
+} from './report-execution.service';
+
+const SUPPORTED_DISPLAY_TYPES = new Set(['select', 'date', 'text', 'none']);
 
 @Component({
   selector: 'app-run-report',
@@ -67,7 +76,10 @@ import {
     IonSelect,
     IonDatetime,
     IonDatetimeButton,
+    IonInput,
     IonModal,
+    IonNote,
+    IonSpinner,
   ],
   template: `
     <div class="form-container">
@@ -80,62 +92,125 @@ import {
         </ion-card-header>
 
         <ion-card-content>
+          @if (isParametersLoading()) {
+            <div class="parameter-status" data-testid="report-parameters-loading">
+              <ion-spinner name="crescent"></ion-spinner>
+              <span>{{ 'REPORTS.PARAMETERS_LOADING' | translate }}</span>
+            </div>
+          } @else if (parameterLoadFailed()) {
+            <ion-note color="danger" data-testid="report-parameters-error">
+              {{ 'REPORTS.PARAMETERS_LOAD_FAILED' | translate }}
+            </ion-note>
+          } @else if (unsupportedParameters().length > 0) {
+            <ion-note color="danger" data-testid="report-parameters-unsupported">
+              {{ 'REPORTS.PARAMETERS_UNSUPPORTED' | translate }}:
+              {{ unsupportedParameterNames() }}
+            </ion-note>
+          }
+
           <div class="report-parameters form-grid">
-            <ion-item fill="outline">
-              <ion-label position="stacked">{{ 'COMMON.OFFICE' | translate }}</ion-label>
-              <ion-select
-                [attr.aria-label]="'COMMON.OFFICE' | translate"
-                interface="popover"
-                [(ngModel)]="officeId"
-              >
-                @for (office of offices(); track office.id) {
-                  <ion-select-option [value]="office.id">{{ office.name }}</ion-select-option>
+            @for (parameter of parameters(); track parameter.queryParameter; let index = $index) {
+              @switch (parameter.displayType) {
+                @case ('select') {
+                  <ion-item
+                    fill="outline"
+                    [attr.data-testid]="parameterTestId(parameter)"
+                    [id]="parameterControlId(parameter, index)"
+                  >
+                    <ion-label position="stacked">{{ parameter.label }}</ion-label>
+                    <ion-select
+                      [id]="parameterControlId(parameter, index) + '-select'"
+                      [attr.data-testid]="parameterTestId(parameter) + '-select'"
+                      [attr.aria-label]="parameter.label"
+                      interface="popover"
+                      [value]="parameterValue(parameter)"
+                      (ionChange)="onParameterChange(parameter, $event)"
+                    >
+                      @for (option of parameter.options; track option.id) {
+                        <ion-select-option [value]="option.id">
+                          {{ option.isAll ? ('COMMON.ALL' | translate) : option.name }}
+                        </ion-select-option>
+                      }
+                    </ion-select>
+                  </ion-item>
                 }
-              </ion-select>
-            </ion-item>
-
-            <ion-item fill="outline">
-              <ion-label position="stacked">{{ 'COMMON.FROM_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="fromDate-picker"></ion-datetime-button>
-              <ion-modal [keepContentsMounted]="true">
-                <ng-template>
-                  <ion-datetime
-                    id="fromDate-picker"
-                    data-testid="fromDate-picker"
-                    presentation="date"
-                    name="fromDate"
-                    [(ngModel)]="fromDate"
-                  ></ion-datetime>
-                </ng-template>
-              </ion-modal>
-            </ion-item>
-
-            <ion-item fill="outline">
-              <ion-label position="stacked">{{ 'COMMON.TO_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="toDate-picker"></ion-datetime-button>
-              <ion-modal [keepContentsMounted]="true">
-                <ng-template>
-                  <ion-datetime
-                    id="toDate-picker"
-                    data-testid="toDate-picker"
-                    presentation="date"
-                    name="toDate"
-                    [(ngModel)]="toDate"
-                  ></ion-datetime>
-                </ng-template>
-              </ion-modal>
-            </ion-item>
+                @case ('date') {
+                  <ion-item
+                    fill="outline"
+                    [attr.data-testid]="parameterTestId(parameter)"
+                    [id]="parameterControlId(parameter, index)"
+                  >
+                    <ion-label position="stacked">{{ parameter.label }}</ion-label>
+                    <ion-datetime-button
+                      [id]="parameterControlId(parameter, index) + '-button'"
+                      [attr.data-testid]="parameterTestId(parameter) + '-button'"
+                      [datetime]="parameterDatePickerId(parameter, index)"
+                    ></ion-datetime-button>
+                    <ion-modal [keepContentsMounted]="true">
+                      <ng-template>
+                        <ion-datetime
+                          presentation="date"
+                          [id]="parameterDatePickerId(parameter, index)"
+                          [attr.data-testid]="parameterDatePickerId(parameter, index)"
+                          [value]="parameterStringValue(parameter)"
+                          (ionChange)="onParameterChange(parameter, $event)"
+                        ></ion-datetime>
+                      </ng-template>
+                    </ion-modal>
+                  </ion-item>
+                }
+                @case ('text') {
+                  <ion-item
+                    fill="outline"
+                    [attr.data-testid]="parameterTestId(parameter)"
+                    [id]="parameterControlId(parameter, index)"
+                  >
+                    <ion-label position="stacked">{{ parameter.label }}</ion-label>
+                    <ion-input
+                      [id]="parameterControlId(parameter, index) + '-input'"
+                      [attr.data-testid]="parameterTestId(parameter) + '-input'"
+                      type="text"
+                      [attr.aria-label]="parameter.label"
+                      [value]="parameterStringValue(parameter)"
+                      (ionInput)="onParameterChange(parameter, $event)"
+                    ></ion-input>
+                  </ion-item>
+                }
+              }
+            }
           </div>
 
+          @if (parametersLoaded() && !parameterLoadFailed() && !canRun()) {
+            <ion-note data-testid="report-parameters-incomplete">
+              {{ 'REPORTS.PARAMETERS_INCOMPLETE' | translate }}
+            </ion-note>
+          }
+
           <div class="form-actions">
-            <ion-button fill="clear" (click)="onCancel()">{{
-              'COMMON.CANCEL' | translate
-            }}</ion-button>
-            <ion-button color="secondary" (click)="onDownloadCSV()" [disabled]="isLoading()">
+            <ion-button
+              id="cancel-report"
+              data-testid="cancel-report"
+              fill="clear"
+              (click)="onCancel()"
+              >{{ 'COMMON.CANCEL' | translate }}</ion-button
+            >
+            <ion-button
+              id="download-report-csv"
+              data-testid="download-report-csv"
+              color="secondary"
+              (click)="onDownloadCSV()"
+              [disabled]="!canRun() || isLoading()"
+            >
               <ion-icon name="download-outline"></ion-icon>
               {{ 'REPORTS.DOWNLOAD_CSV' | translate }}
             </ion-button>
-            <ion-button color="primary" (click)="onRun()" [disabled]="isLoading()">
+            <ion-button
+              id="run-report"
+              data-testid="run-report"
+              color="primary"
+              (click)="onRun()"
+              [disabled]="!canRun() || isLoading()"
+            >
               {{ isLoading() ? ('COMMON.LOADING' | translate) : ('REPORTS.RUN' | translate) }}
             </ion-button>
           </div>
@@ -145,7 +220,12 @@ import {
               <hr class="divider" />
               <div class="results-header">
                 <h3 class="mt-2">{{ 'REPORTS.RESULTS' | translate }}</h3>
-                <ion-button color="primary" (click)="downloadCSV()">
+                <ion-button
+                  id="download-report-results-csv"
+                  data-testid="download-report-results-csv"
+                  color="primary"
+                  (click)="downloadCSV()"
+                >
                   <ion-icon name="download-outline"></ion-icon>
                   {{ 'REPORTS.DOWNLOAD_RESULTS_CSV' | translate }}
                 </ion-button>
@@ -184,8 +264,18 @@ import {
       }
       .form-grid {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 16px;
+      }
+      .parameter-status {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+      ion-note {
+        display: block;
+        margin: 8px 0 16px;
       }
       .results-header {
         display: flex;
@@ -204,26 +294,49 @@ import {
       .mt-2 {
         margin-top: 1rem;
       }
+      @media (max-width: 900px) {
+        .form-grid {
+          grid-template-columns: 1fr;
+        }
+      }
     `,
   ],
 })
 export class RunReportComponent implements OnInit {
-  private readonly runReportsService = inject(RunReportsService);
+  private readonly reportExecution = inject(ReportExecutionService);
   private readonly download = inject(DOWNLOAD);
-  private readonly officesService = inject(OfficesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly notifications = inject(NotificationService);
+  private readonly translate = inject(TranslateService);
 
   readonly reportName = signal('');
   reportType = '';
   readonly isLoading = signal(false);
+  readonly isParametersLoading = signal(false);
+  readonly parametersLoaded = signal(false);
+  readonly parameterLoadFailed = signal(false);
+  readonly parameters = signal<ReportParameter[]>([]);
+  readonly parameterValues = signal<Record<string, string | number>>({});
 
-  officeId: number | undefined = undefined;
-  fromDate: string | null = null;
-  toDate: string | null = null;
+  readonly unsupportedParameters = computed(() =>
+    this.parameters().filter((parameter) => !SUPPORTED_DISPLAY_TYPES.has(parameter.displayType)),
+  );
+  readonly unsupportedParameterNames = computed(() =>
+    this.unsupportedParameters()
+      .map((parameter) => `${parameter.label} (${parameter.displayType})`)
+      .join(', '),
+  );
+  readonly canRun = computed(
+    () =>
+      this.parametersLoaded() &&
+      !this.parameterLoadFailed() &&
+      this.unsupportedParameters().length === 0 &&
+      this.parameters().every((parameter) =>
+        this.hasValue(this.parameterValues()[parameter.queryParameter]),
+      ),
+  );
 
-  readonly offices = signal<GetOfficesResponse[]>([]);
   readonly reportData = signal<Record<string, unknown> | null>(null);
   readonly displayedColumns = signal<string[]>([]);
   readonly dataRows = signal<Record<string, unknown>[]>([]);
@@ -237,97 +350,90 @@ export class RunReportComponent implements OnInit {
     return this.rows().slice(start, start + this.pageSize());
   });
 
+  ngOnInit(): void {
+    this.route.paramMap.subscribe((params) => {
+      const reportName = params.get('reportName') || '';
+      this.reportName.set(reportName);
+      this.loadParameters(reportName);
+    });
+    this.route.queryParamMap.subscribe((params) => {
+      this.reportType = params.get('type') || '';
+    });
+  }
+
   onPage(event: PageEvent): void {
     this.pageIndex.set(event.pageIndex);
     this.pageSize.set(event.pageSize);
   }
 
-  ngOnInit(): void {
-    this.route.paramMap.subscribe((params) => {
-      this.reportName.set(params.get('reportName') || '');
-    });
-    this.route.queryParamMap.subscribe((params) => {
-      this.reportType = params.get('type') || '';
-    });
-    this.loadMetadata();
+  onParameterChange(parameter: ReportParameter, event: Event): void {
+    const detailValue = (event as CustomEvent<{ value?: string | number | null }>).detail?.value;
+    const targetValue = (event.target as HTMLInputElement | null)?.value;
+    const value = detailValue ?? targetValue;
+    if (value !== undefined && value !== null) {
+      this.setParameterValue(parameter, value);
+    }
   }
 
-  private loadMetadata(): void {
-    this.officesService.getOffices(true).subscribe((data) => {
-      this.offices.set(data);
-    });
+  setParameterValue(parameter: ReportParameter, value: string | number): void {
+    this.parameterValues.update((current) => ({
+      ...current,
+      [parameter.queryParameter]: value,
+    }));
+  }
+
+  parameterValue(parameter: ReportParameter): string | number | undefined {
+    return this.parameterValues()[parameter.queryParameter];
+  }
+
+  parameterStringValue(parameter: ReportParameter): string | undefined {
+    const value = this.parameterValue(parameter);
+    return value === undefined ? undefined : String(value);
+  }
+
+  parameterControlId(parameter: ReportParameter, index: number): string {
+    return `report-parameter-${this.safeIdentifier(parameter.variable)}-${index}`;
+  }
+
+  parameterDatePickerId(parameter: ReportParameter, index: number): string {
+    return `${this.parameterControlId(parameter, index)}-picker`;
+  }
+
+  parameterTestId(parameter: ReportParameter): string {
+    return `report-parameter-${this.safeIdentifier(parameter.variable)}`;
   }
 
   onDownloadCSV(): void {
+    if (!this.canRun()) return;
     this.isLoading.set(true);
-    const formattedFrom = this.fromDate ? toIsoDate(this.fromDate) : undefined;
-    const formattedTo = this.toDate ? toIsoDate(this.toDate) : undefined;
 
-    this.runReportsService
-      .getRunreportsReportName(
-        this.reportName(),
-        true, // exportCSV
-        undefined, // parameterType
-        'CSV', // outputType
-        this.officeId?.toString(),
-        undefined, // rLoanOfficerId
-        formattedFrom,
-        formattedTo,
-        undefined,
-        undefined,
-        'body',
-        false,
-        { httpHeaderAccept: 'text/csv' },
-      )
-      .subscribe({
-        next: (data) => {
-          this.download.saveText(
-            data as unknown as string,
-            this.csvFilename(),
-            'text/csv;charset=utf-8;',
-          );
-          this.isLoading.set(false);
-        },
-        error: () => {
-          this.notifications.error('Operation failed. Please try again.');
-          this.isLoading.set(false);
-        },
-      });
+    this.reportExecution.downloadCsv(this.reportName(), this.collectedValues()).subscribe({
+      next: (data) => {
+        this.download.saveText(data, this.csvFilename(), 'text/csv;charset=utf-8;');
+        this.isLoading.set(false);
+      },
+      error: () => this.handleRunError(),
+    });
   }
 
   onRun(): void {
+    if (!this.canRun()) return;
     this.isLoading.set(true);
-    const formattedFrom = this.fromDate ? toIsoDate(this.fromDate) : undefined;
-    const formattedTo = this.toDate ? toIsoDate(this.toDate) : undefined;
 
-    this.runReportsService
-      .getRunreportsReportName(
-        this.reportName(),
-        false, // exportCSV
-        undefined, // parameterType
-        'HTML', // outputType
-        this.officeId?.toString(),
-        undefined, // rLoanOfficerId
-        formattedFrom,
-        formattedTo,
-      )
-      .subscribe({
-        next: (data) => {
-          const result = data as unknown as Record<string, unknown>;
-          this.reportData.set(result);
-          const columnHeaders = (result['columnHeaders'] as Record<string, unknown>[]) || [];
-          this.displayedColumns.set(columnHeaders.map((h) => h['columnName'] as string));
-          const dataRows = (result['data'] as Record<string, unknown>[]) || [];
-          this.dataRows.set(dataRows);
-          this.rows.set(dataRows);
-          this.pageIndex.set(0);
-          this.isLoading.set(false);
-        },
-        error: () => {
-          this.notifications.error('Operation failed. Please try again.');
-          this.isLoading.set(false);
-        },
-      });
+    this.reportExecution.runReport(this.reportName(), this.collectedValues()).subscribe({
+      next: (data) => {
+        const result = data as Record<string, unknown>;
+        this.reportData.set(result);
+        const columnHeaders = (result['columnHeaders'] as Record<string, unknown>[]) || [];
+        this.displayedColumns.set(columnHeaders.map((header) => header['columnName'] as string));
+        const dataRows = (result['data'] as Record<string, unknown>[]) || [];
+        this.dataRows.set(dataRows);
+        this.rows.set(dataRows);
+        this.pageIndex.set(0);
+        this.isLoading.set(false);
+      },
+      error: () => this.handleRunError(),
+    });
   }
 
   downloadCSV(): void {
@@ -356,11 +462,6 @@ export class RunReportComponent implements OnInit {
     );
   }
 
-  /** Filename shared by both CSV paths, so they cannot drift apart. */
-  private csvFilename(): string {
-    return `${this.reportName().replace(/\s+/g, '_')}_Report.csv`;
-  }
-
   onCancel(): void {
     this.router.navigate(['/reporting']);
   }
@@ -378,5 +479,64 @@ export class RunReportComponent implements OnInit {
       return String(val);
     }
     return '';
+  }
+
+  private loadParameters(reportName: string): void {
+    this.isParametersLoading.set(true);
+    this.parametersLoaded.set(false);
+    this.parameterLoadFailed.set(false);
+    this.parameters.set([]);
+    this.parameterValues.set({});
+
+    this.reportExecution.getReportParameters(reportName).subscribe({
+      next: (parameters) => {
+        this.parameters.set(parameters);
+        this.parameterValues.set(
+          Object.fromEntries(
+            parameters
+              .filter((parameter) => parameter.displayType === 'none')
+              .map((parameter) => [parameter.queryParameter, String(parameter.defaultValue ?? '')]),
+          ),
+        );
+        this.parametersLoaded.set(true);
+        this.isParametersLoading.set(false);
+      },
+      error: () => {
+        this.parameterLoadFailed.set(true);
+        this.isParametersLoading.set(false);
+        this.notifications.error(this.translate.instant('REPORTS.PARAMETERS_LOAD_FAILED'));
+      },
+    });
+  }
+
+  private collectedValues(): ReportParameterValues {
+    const current = this.parameterValues();
+    return Object.fromEntries(
+      this.parameters().map((parameter) => {
+        const value = current[parameter.queryParameter];
+        return [
+          parameter.queryParameter,
+          parameter.displayType === 'date' ? toIsoDate(String(value)) : value,
+        ];
+      }),
+    );
+  }
+
+  private hasValue(value: string | number | undefined): boolean {
+    return value !== undefined && String(value).trim().length > 0;
+  }
+
+  private handleRunError(): void {
+    this.notifications.error(this.translate.instant('COMMON.ERROR'));
+    this.isLoading.set(false);
+  }
+
+  private safeIdentifier(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+  }
+
+  /** Filename shared by both CSV paths, so they cannot drift apart. */
+  private csvFilename(): string {
+    return `${this.reportName().replace(/\s+/g, '_')}_Report.csv`;
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1065,7 +1065,11 @@
     "RUN_TITLE": "Run",
     "RESULTS": "Report Results",
     "DOWNLOAD_CSV": "Download CSV",
-    "DOWNLOAD_RESULTS_CSV": "Download Results as CSV"
+    "DOWNLOAD_RESULTS_CSV": "Download Results as CSV",
+    "PARAMETERS_LOADING": "Loading report parameters...",
+    "PARAMETERS_LOAD_FAILED": "This report cannot be run because its parameters could not be loaded.",
+    "PARAMETERS_UNSUPPORTED": "This report cannot be run because these parameters use unsupported control types",
+    "PARAMETERS_INCOMPLETE": "Complete every report parameter before running the report."
   },
   "SETTINGS": {
     "CONFIG_NAME": "Configuration Name",


### PR DESCRIPTION
## What and why

Report execution hardcoded Office and two dates even though Fineract defines each report parameter dynamically. This change discovers the selected report template, renders every supported control type, fails closed for unknown types, and sends the complete named R_* parameter map for both HTML and CSV execution.

Select lookups are isolated per field: parent-dependent lookups wait for cascading support in #301, one failed lookup does not cancel its siblings, and malformed template rows do not discard valid parameters.

Closes #300

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run i18n:check`
- `npm run check:icons`
- `npm run build`
- `./scripts/check-license.sh`
- `TZ=UTC npm test -- --watch=false --browsers=ChromeHeadless` - 853 tests passed
- `npx playwright test e2e/report-enhancements.spec.ts e2e/reporting.spec.ts e2e/functional-coverage.spec.ts --project=mocked --workers=2` - 45 tests passed
- `npx playwright test e2e/report-parameter-backend.spec.ts --project=backend --workers=1` - backend setup and regression tests passed against a real local Fineract stack
- The mocked flow verifies both `R_officeId` and `R_loanOfficerId` in the outgoing query
- The Client Listing backend flow proves that changing Office changes the returned row set
- The `Active Loans - Summary` backend flow proves cascading lookups no longer take down the parameter form

## Screenshots

A screenshot and short recording of the dynamic report parameters are attached in the evidence comment below.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code avoids direct browser globals and imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added unit, mocked e2e, and real-backend regression coverage.
- [x] UI workflow changes include suitable e2e coverage with both mocks and a real Fineract backend.
- [x] The commits are signed and include the Signed-off-by trailer.