### PR TITLE
refactor(clients): use formatArrayDate helper

### DIFF
--- a/src/app/features/clients/client-action-dialog.component.spec.ts
+++ b/src/app/features/clients/client-action-dialog.component.spec.ts
@@ -100,6 +100,17 @@ describe('ClientActionDialogComponent', () => {
       component.actionDate.set(null as unknown as string);
       expect(component.isValid).toBeFalse();
     });
+
+    it('should use the business date for the action date and maximum', () => {
+      businessDateServiceSpy.getBusinessdate.and.returnValue(
+        of([{ type: 'BUSINESS_DATE', date: [2026, 1, 5] }]) as unknown as Observable<never>,
+      );
+
+      component.ngOnInit();
+
+      expect(component.actionDate()).toBe('2026-01-05');
+      expect(component.maxDate()).toBe('2026-01-05');
+    });
   });
 
   describe('with Reject command (requiring reasons)', () => {

--- a/src/app/features/clients/client-action-dialog.component.ts
+++ b/src/app/features/clients/client-action-dialog.component.ts
@@ -32,7 +32,7 @@ import {
   IonTextarea,
   ModalController,
 } from '@ionic/angular/standalone';
-import { toIsoDate } from '../../core/utils/date-formatter';
+import { formatArrayDate, toIsoDate } from '../../core/utils/date-formatter';
 import {
   CodesService,
   CodeValuesService,
@@ -162,9 +162,8 @@ export class ClientActionDialogComponent implements OnInit {
       next: (dates) => {
         const bd = dates.find((d) => d.type === 'BUSINESS_DATE');
         if (bd && bd.date) {
-          const d = bd.date as unknown as number[];
           // ion-datetime works in ISO strings, including its max bound.
-          const bDate = toIsoDate(new Date(d[0], d[1] - 1, d[2]));
+          const bDate = formatArrayDate(bd.date);
           this.actionDate.set(bDate);
           this.maxDate.set(bDate);
         }

--- a/src/app/features/clients/client-form.component.spec.ts
+++ b/src/app/features/clients/client-form.component.spec.ts
@@ -60,6 +60,7 @@ describe('ClientFormComponent', () => {
         legalFormId: 1,
         submittedOnDate: [2026, 6, 16] as unknown as number[],
         activationDate: [2026, 6, 17] as unknown as number[],
+        dateOfBirth: [1990, 1, 5] as unknown as number[],
         active: true,
       }) as unknown as Observable<never>,
     );
@@ -184,6 +185,9 @@ describe('ClientFormComponent', () => {
       expect(component.isEditMode()).toBeTrue();
       expect(component.clientId).toBe(10);
       expect(clientServiceSpy.getClientsClientId).toHaveBeenCalledWith(10);
+      expect(component.submittedOnDate()).toBe('2026-06-16');
+      expect(component.activationDate()).toBe('2026-06-17');
+      expect(component.dateOfBirth()).toBe('1990-01-05');
 
       clientServiceSpy.putClientsClientId.and.returnValue(of({}) as unknown as Observable<never>);
       component.onSubmit();

--- a/src/app/features/clients/client-form.component.ts
+++ b/src/app/features/clients/client-form.component.ts
@@ -52,6 +52,7 @@ import {
   GetOfficesResponse,
 } from '../../api';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -438,25 +439,19 @@ export class ClientFormComponent implements OnInit {
       const clientData = data as any;
       const actDateArray = clientData.activationDate as unknown as number[];
       if (actDateArray) {
-        this.activationDate.set(
-          toIsoDate(new Date(actDateArray[0], actDateArray[1] - 1, actDateArray[2])),
-        );
+        this.activationDate.set(formatArrayDate(actDateArray));
       }
 
       const subDateArray = clientData.submittedOnDate as unknown as number[];
       if (subDateArray) {
-        this.submittedOnDate.set(
-          toIsoDate(new Date(subDateArray[0], subDateArray[1] - 1, subDateArray[2])),
-        );
+        this.submittedOnDate.set(formatArrayDate(subDateArray));
       } else if (actDateArray) {
-        this.submittedOnDate.set(
-          toIsoDate(new Date(actDateArray[0], actDateArray[1] - 1, actDateArray[2])),
-        );
+        this.submittedOnDate.set(formatArrayDate(actDateArray));
       }
 
       const dobArray = clientData.dateOfBirth as unknown as number[];
       if (dobArray) {
-        this.dateOfBirth.set(toIsoDate(new Date(dobArray[0], dobArray[1] - 1, dobArray[2])));
+        this.dateOfBirth.set(formatArrayDate(dobArray));
       }
 
       this.originalActive.set(!!clientData.active);


### PR DESCRIPTION
## What and why

Replace the five manual Fineract array-date conversions in the `clients` feature with the existing `formatArrayDate` helper. This removes repeated month-offset arithmetic while preserving the guards around optional dates and the ISO strings expected by Ionic date controls.

This covers the `clients` feature-directory portion of #257.

## Verification

- `npm test -- --watch=false --include='src/app/features/clients/client-form.component.spec.ts' --include='src/app/features/clients/client-action-dialog.component.spec.ts'` (14 tests)
- `npm test -- --watch=false` (894 tests)
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run check:icons`
- `npm run i18n:check`
- `./scripts/check-license.sh`
- UI exercised through mocked component tests; no real Fineract backend was required for this refactor.

## Screenshots

Not applicable; this is a behavior-preserving date-formatting refactor.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. (No new component or service code.)
- [x] User-facing strings use translation keys. (No user-facing strings changed.)
- [x] I added or updated tests appropriate to this change.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. (No UI workflow changed; component regression tests cover the date values.)
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.
