### PR TITLE
feat: support unique and indexed datatable columns

### DIFF
--- a/src/app/features/system/data-tables/datatables-form.component.spec.ts
+++ b/src/app/features/system/data-tables/datatables-form.component.spec.ts
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { CodesService, DataTablesService, PostDataTablesRequest } from '../../../api';
+import { provideIonicTesting } from '../../../testing/ionic-testing';
+import { provideTranslateTesting } from '../../../testing/i18n-testing';
+import { DatatablesFormComponent } from './datatables-form.component';
+
+describe('DatatablesFormComponent', () => {
+  let fixture: ComponentFixture<DatatablesFormComponent>;
+  let component: DatatablesFormComponent;
+  let datatablesServiceSpy: jasmine.SpyObj<DataTablesService>;
+  let codesServiceSpy: jasmine.SpyObj<CodesService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  async function configure(name: string | null = null): Promise<void> {
+    datatablesServiceSpy = jasmine.createSpyObj('DataTablesService', [
+      'getDatatablesDatatable',
+      'postDatatables',
+      'putDatatablesDatatableName',
+    ]);
+    codesServiceSpy = jasmine.createSpyObj('CodesService', ['getCodes']);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    codesServiceSpy.getCodes.and.returnValue(of([]) as unknown as Observable<never>);
+
+    await TestBed.configureTestingModule({
+      imports: [DatatablesFormComponent],
+      providers: [
+        provideIonicTesting(),
+        ...provideTranslateTesting(),
+        { provide: DataTablesService, useValue: datatablesServiceSpy },
+        { provide: CodesService, useValue: codesServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: { get: () => name },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatatablesFormComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('includes unique and indexed values in the create request', async () => {
+    await configure();
+    datatablesServiceSpy.postDatatables.and.returnValue(of({}) as unknown as Observable<never>);
+    fixture.detectChanges();
+
+    expect(component.datatable().columns[0]).toEqual(
+      jasmine.objectContaining({ unique: false, indexed: false }),
+    );
+
+    component.datatable.set({
+      datatableName: 'client_identifiers',
+      apptableName: 'm_client',
+      multiRow: false,
+      columns: [
+        {
+          name: 'external_reference',
+          type: 'String',
+          length: 64,
+          mandatory: true,
+          unique: true,
+          indexed: true,
+        },
+      ],
+    });
+
+    component.onSubmit();
+
+    const request = datatablesServiceSpy.postDatatables.calls.mostRecent()
+      .args[0] as PostDataTablesRequest;
+    expect(request.columns[0]).toEqual(jasmine.objectContaining({ unique: true, indexed: true }));
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/system/data-tables']);
+  });
+
+  it('maps unique and indexed values from an existing datatable', async () => {
+    await configure('client_identifiers');
+    datatablesServiceSpy.getDatatablesDatatable.and.returnValue(
+      of({
+        registeredTableName: 'client_identifiers',
+        applicationTableName: 'm_client',
+        columnHeaderData: [
+          {
+            columnName: 'external_reference',
+            columnDisplayType: 'STRING',
+            isColumnNullable: false,
+            isColumnUnique: true,
+            isColumnIndexed: true,
+            columnLength: 64,
+          },
+        ],
+      }) as unknown as Observable<never>,
+    );
+    fixture.detectChanges();
+
+    expect(component.isEditMode).toBeTrue();
+    expect(component.datatable().columns[0]).toEqual(
+      jasmine.objectContaining({
+        name: 'external_reference',
+        mandatory: true,
+        unique: true,
+        indexed: true,
+      }),
+    );
+  });
+});

--- a/src/app/features/system/data-tables/datatables-form.component.ts
+++ b/src/app/features/system/data-tables/datatables-form.component.ts
@@ -187,6 +187,20 @@ import {
                     >
                       {{ 'SYSTEM.MANDATORY' | translate }}
                     </ion-checkbox>
+                    <ion-checkbox
+                      [name]="'colUnique' + i"
+                      [(ngModel)]="column.unique"
+                      [disabled]="isEditMode"
+                    >
+                      {{ 'SYSTEM.UNIQUE' | translate }}
+                    </ion-checkbox>
+                    <ion-checkbox
+                      [name]="'colIndexed' + i"
+                      [(ngModel)]="column.indexed"
+                      [disabled]="isEditMode"
+                    >
+                      {{ 'SYSTEM.INDEXED' | translate }}
+                    </ion-checkbox>
                   </div>
 
                   @if (!isEditMode) {
@@ -253,7 +267,7 @@ import {
       }
       .column-row {
         display: grid;
-        grid-template-columns: 2fr 1.5fr 1.5fr 1fr auto;
+        grid-template-columns: 2fr 1.5fr 1.5fr 2fr auto;
         gap: 12px;
         align-items: center;
         margin-bottom: 8px;
@@ -261,6 +275,8 @@ import {
       .column-checkboxes {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
         height: 100%;
       }
       .add-col-btn {
@@ -331,6 +347,8 @@ export class DatatablesFormComponent implements OnInit {
           name: col.columnName!,
           type: col.columnDisplayType!,
           mandatory: !col.isColumnNullable,
+          unique: col.isColumnUnique,
+          indexed: col.isColumnIndexed,
           length: col.columnLength,
           code: col.columnCode,
         })),
@@ -343,6 +361,8 @@ export class DatatablesFormComponent implements OnInit {
       name: '',
       type: 'String',
       mandatory: false,
+      unique: false,
+      indexed: false,
       length: 10,
     });
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -884,6 +884,8 @@
     "LENGTH": "Length",
     "CODE": "Code",
     "MANDATORY": "Mandatory",
+    "UNIQUE": "Unique",
+    "INDEXED": "Indexed",
     "CUSTOM_FIELDS": "Custom Fields",
     "ADD_ENTRY": "Add Entry",
     "NO_DATA_TABLES_REGISTERED": "No data tables registered for this entity.",


### PR DESCRIPTION
## What and why

Adds Unique and Indexed controls to datatable column definitions so users can configure the constraints supported by the Fineract API. Existing datatables also map the server's constraint flags back into the edit form.

Closes #281

## Verification

- `npm test -- --watch=false` (896 tests passed)
- `npm run lint`
- `npm run lint:prune`
- `npm run format:check`
- `npm run i18n:check`
- `npm run check:icons`
- `./scripts/check-license.sh`
- `npm run build`
- UI behavior covered with component tests; no live Fineract backend was used.

## Screenshots

Not included; the change adds two checkboxes to the existing datatable column row.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. Component tests cover create payload and edit response mapping; no e2e test or live backend was used.
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.
