### PR TITLE
fix(accounting): use translation keys for list screen titles and tooltips

### DIFF
--- a/src/app/features/accounting/accounting-closures-list.component.ts
+++ b/src/app/features/accounting/accounting-closures-list.component.ts
@@ -23,6 +23,7 @@ import { Router } from '@angular/router';
 import { DatePipe, NgClass } from '@angular/common';
 import { DataTableComponent, ColumnDef, CellTemplateDirective } from '../../shared';
 import { AccountingClosureService, GetGlClosureResponse } from '../../api';
+import { TranslatePipe } from '../../core/adapters';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 
 /**
@@ -37,6 +38,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
     TranslateModule,
     DataTableComponent,
     CellTemplateDirective,
+    TranslatePipe,
     DatePipe,
     NgClass,
     IonIcon,
@@ -44,9 +46,9 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
   ],
   template: `
     <app-data-table
-      title="Accounting Closures"
+      title="nav.accountingClosures"
       helpTextKey="HELP.ACCOUNTING_CLOSURES_DESC"
-      createButtonLabel="Close Period"
+      createButtonLabel="ACCOUNTING_CLOSURES.CREATE"
       [columns]="columns"
       [data]="closures()"
       [localLogic]="true"
@@ -67,7 +69,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
         <ion-button
           fill="clear"
           color="danger"
-          title="Re-open Period"
+          [title]="'ACCOUNTING_CLOSURES.REOPEN' | appTranslate"
           (click)="onDeleteClosure(closure)"
         >
           <ion-icon name="lock-open-outline"></ion-icon>

--- a/src/app/features/accounting/charges/charges-list.component.ts
+++ b/src/app/features/accounting/charges/charges-list.component.ts
@@ -24,6 +24,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { CurrencyPipe, DecimalPipe } from '@angular/common';
 import { DataTableComponent, ColumnDef, CellTemplateDirective } from '../../../shared';
 import { ChargesService, ChargeData } from '../../../api';
+import { TranslatePipe } from '../../../core/adapters';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 
 /**
@@ -38,6 +39,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
     TranslateModule,
     DataTableComponent,
     CellTemplateDirective,
+    TranslatePipe,
     DecimalPipe,
     CurrencyPipe,
     IonIcon,
@@ -79,7 +81,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
           fill="clear"
           color="primary"
           [attr.aria-label]="'COMMON.EDIT' | translate"
-          title="Edit Charge"
+          [title]="'CHARGES.EDIT' | appTranslate"
           (click)="onEditCharge(charge)"
         >
           <ion-icon name="create-outline"></ion-icon>

--- a/src/app/features/accounting/chart-of-accounts.component.ts
+++ b/src/app/features/accounting/chart-of-accounts.component.ts
@@ -25,6 +25,7 @@ import { of } from 'rxjs';
 import { catchError, startWith, tap } from 'rxjs/operators';
 import { DataTableComponent, CellTemplateDirective, ColumnDef } from '../../shared';
 import { GeneralLedgerAccountService, GetGLAccountsResponse } from '../../api';
+import { TranslatePipe } from '../../core/adapters';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 
 @Component({
@@ -34,6 +35,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
     TranslateModule,
     DataTableComponent,
     CellTemplateDirective,
+    TranslatePipe,
     NgClass,
     IonIcon,
     IonButton,
@@ -42,9 +44,9 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
     <app-data-table
       [hasError]="hasError()"
       (retry)="onRetry()"
-      title="Chart of Accounts"
+      title="nav.chartOfAccounts"
       helpTextKey="HELP.CHART_OF_ACCOUNTS_DESC"
-      createButtonLabel="Add Ledger Account"
+      createButtonLabel="ACCOUNTING.ADD_LEDGER_ACCOUNT"
       [columns]="columns"
       [data]="accounts()"
       [localLogic]="true"
@@ -60,7 +62,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
         <ion-button
           fill="clear"
           color="primary"
-          title="Edit Account"
+          [title]="'ACCOUNTING.EDIT_ACCOUNT' | appTranslate"
           (click)="onEditAccount(account)"
         >
           <ion-icon name="create-outline"></ion-icon>

--- a/src/app/features/accounting/financial-activity-mappings-list.component.ts
+++ b/src/app/features/accounting/financial-activity-mappings-list.component.ts
@@ -36,11 +36,11 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
   template: `
     <div class="container">
       <app-data-table
-        title="Financial Activity Mappings"
+        title="nav.financialActivityMappings"
         [data]="mappings()"
         [columns]="columns"
         [localLogic]="true"
-        createButtonLabel="Define Mapping"
+        createButtonLabel="ACCOUNTING.DEFINE_MAPPING"
         (create)="onCreate()"
       >
         <ng-template appCellTemplate="financialActivity" let-row>

--- a/src/app/features/accounting/journal-entries-list.component.ts
+++ b/src/app/features/accounting/journal-entries-list.component.ts
@@ -47,9 +47,9 @@ import { PageEvent, SortEvent } from '../../shared/models/table.model';
     <app-data-table
       [hasError]="hasError()"
       (retry)="onRetry()"
-      title="Journal Entries"
+      title="nav.journalEntries"
       helpTextKey="HELP.JOURNAL_ENTRIES_DESC"
-      createButtonLabel="Add Journal Entry"
+      createButtonLabel="JOURNAL_ENTRIES.CREATE"
       [columns]="columns"
       [data]="entries()"
       [totalRecords]="totalRecords"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1137,6 +1137,7 @@
   },
   "ACCOUNTING_CLOSURES": {
     "CREATE": "Close Period",
+    "REOPEN": "Re-open Period",
     "CLOSING_DATE": "Closing Date",
     "IS_CLOSED": "Is Closed"
   },
@@ -1226,6 +1227,9 @@
   "ACCOUNTING": {
     "CREATE_GL_ACCOUNT": "Create GL Account",
     "EDIT_GL_ACCOUNT": "Edit GL Account",
+    "ADD_LEDGER_ACCOUNT": "Add Ledger Account",
+    "EDIT_ACCOUNT": "Edit Account",
+    "DEFINE_MAPPING": "Define Mapping",
     "GL_CODE": "GL Code",
     "ACCOUNT_TYPE": "Account Type",
     "ACCOUNT_USAGE": "Account Usage",


### PR DESCRIPTION
## What and why

The five accounting list screens passed English literals to `app-data-table`'s `title` / `createButtonLabel` inputs and to `ion-button` `title` tooltips, so those strings stayed in English whichever language was selected. As #251 notes, this is worse than an ordinary missing translation: a missing key renders as a visible key and diagnoses itself, whereas a hardcoded string looks correct in every locale.

This replaces all **11 sites in `src/app/features/accounting`** with translation keys. #251 says one PR per feature directory; accounting is the largest at 11 sites.

Part of #251.

## The 11 replacements

| File | Was | Now | Key |
| --- | --- | --- | --- |
| `accounting-closures-list` | `title="Accounting Closures"` | `nav.accountingClosures` | existing |
| `accounting-closures-list` | `createButtonLabel="Close Period"` | `ACCOUNTING_CLOSURES.CREATE` | existing |
| `accounting-closures-list` | `title="Re-open Period"` | `ACCOUNTING_CLOSURES.REOPEN` | **new** |
| `chart-of-accounts` | `title="Chart of Accounts"` | `nav.chartOfAccounts` | existing |
| `chart-of-accounts` | `createButtonLabel="Add Ledger Account"` | `ACCOUNTING.ADD_LEDGER_ACCOUNT` | **new** |
| `chart-of-accounts` | `title="Edit Account"` | `ACCOUNTING.EDIT_ACCOUNT` | **new** |
| `journal-entries-list` | `title="Journal Entries"` | `nav.journalEntries` | existing |
| `journal-entries-list` | `createButtonLabel="Add Journal Entry"` | `JOURNAL_ENTRIES.CREATE` | existing |
| `financial-activity-mappings-list` | `title="Financial Activity Mappings"` | `nav.financialActivityMappings` | existing |
| `financial-activity-mappings-list` | `createButtonLabel="Define Mapping"` | `ACCOUNTING.DEFINE_MAPPING` | **new** |
| `charges-list` | `title="Edit Charge"` | `CHARGES.EDIT` | existing |

**No visible English text changes.** Every key resolves to the exact string it replaced, so in English this is a no-op and only the other locales change.

## Two decisions worth a reviewer's eye

**1. List screen titles reuse `nav.*` rather than new `ACCOUNTING.*` keys.** #251 sketched `title="ACCOUNTING.CHART_OF_ACCOUNTS"`, but 45 existing list screens already pass their `nav.*` entry as the data-table title (`nav.groups`, `nav.users`, `nav.loanProducts`, …), and `nav.chartOfAccounts` / `nav.journalEntries` / `nav.accountingClosures` / `nav.financialActivityMappings` already exist with byte-identical English. Reusing them follows both the issue's "reuse beats a near-duplicate" guidance and the dominant convention. Happy to switch to a new namespace if you prefer.

**2. `ADD_LEDGER_ACCOUNT` / `EDIT_ACCOUNT` are new even though `CREATE_GL_ACCOUNT` / `EDIT_GL_ACCOUNT` exist.** Those read "Create GL Account" / "Edit GL Account" and title the `gl-account-form` dialog these buttons open, so collapsing into them looked like the tighter catalogue. It would have broken a test: `e2e/functional-coverage.spec.ts:839` drives this screen with `getByRole('button', { name: /Add Ledger Account/i })`. Keeping the English byte-identical is what makes this change safe. If you do want the wording unified, the e2e selector has to change in the same PR.

## Verification

Run on a fork of this repository at the same commit — **all 18 jobs green**:

- **CI (12/12)**: Dependency Integrity, TS/ESLint, HTML Lint, Format Check, Unit Tests, Production Build, Translation Check, License Compliance, Apache RAT Scan, Security Audit, API Client Drift Check, Build Summary.
- **E2E (6/6)**: all four mocked shards, the mocked report, and **E2E (real Fineract)** against the docker-compose backend.

Additional checks made while preparing this:

- `node scripts/check-translations.mjs` → `Checked 1485 referenced keys against 2014 keys in en.json. ✓ No missing keys.` This is a real gate here, not a formality: the checker's patterns match the `title="KEY"` / `createButtonLabel="KEY"` attribute forms, so every key introduced above is statically validated.
- The grep in #251 drops from 31 sites to 20 repo-wide, and to **0** under `src/app/features/accounting`.
- Every existing assertion that touches these strings was checked before changing them. The e2e suite drives all five screens by their English text (`feature-coverage.spec.ts:414` asserts the card title; `functional-coverage.spec.ts:785/816/839` click the create buttons by name) and each still matches because the keys resolve to the identical string. No unit spec under `src/app` asserts these literals.
- The three converted `title=` → `[title]=` bindings use `| appTranslate` with `TranslatePipe` from `src/app/core/adapters`, per `DOCS/ADAPTERS.md`, and their attribute order matches existing prettier-stable elements of the same shape (`groups-list` L85-90, `email-campaigns-list` L115-119). `Format Check` passing confirms `prettier` is a no-op on this diff.

## Screenshots

Not applicable — no visual change in English. The change is only observable by switching the language, where these strings now translate instead of staying English.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed — there is no new behaviour and no visible string change, so the existing e2e specs that drive these screens by their English text are the regression test, and `check-translations` covers the new keys.
- [x] UI workflow changes include suitable e2e coverage — not applicable, no workflow change.
- [ ] **Commits are signed.** The commit *is* SSH-signed, but the public key is not yet registered as a signing key on my GitHub account, so it currently displays as `Unverified` (`GET /commits/:sha` reports `reason: "unknown_key"`, i.e. GitHub sees a valid signature it cannot attribute). Registering the key makes it verify retroactively with no rewrite of this branch, and I will do that shortly. Flagging it rather than ticking the box.
