### PR TITLE
fix: reject maker-checker tasks without deleting audit entries

### DIFF
--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts
@@ -2,7 +2,8 @@
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
+ * regarding copyright ownership.
+ * The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
@@ -18,67 +19,66 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
 import { MakerCheckerOr4EyeFunctionalityService } from '../../../api';
-import { DialogService } from '../../../core/services/dialog.service';
-import { NotificationService } from '../../../core/services/notification.service';
-import { provideIonicTesting } from '../../../testing/ionic-testing';
-import { provideTranslateTesting } from '../../../testing/i18n-testing';
 import { CheckerInboxComponent } from './checker-inbox.component';
 
 describe('CheckerInboxComponent', () => {
   let component: CheckerInboxComponent;
   let fixture: ComponentFixture<CheckerInboxComponent>;
+
   let makerCheckerService: jasmine.SpyObj<MakerCheckerOr4EyeFunctionalityService>;
-  let notifications: jasmine.SpyObj<NotificationService>;
 
   beforeEach(async () => {
     makerCheckerService = jasmine.createSpyObj('MakerCheckerOr4EyeFunctionalityService', [
-      'getMakercheckers',
-      'postMakercheckersAuditId',
-      'deleteMakercheckersAuditId',
+      'approveMakerCheckerEntry',
+      'deleteMakerCheckerEntry',
     ]);
-    notifications = jasmine.createSpyObj('NotificationService', ['success', 'error']);
-    makerCheckerService.getMakercheckers.and.returnValue(
-      of([]) as unknown as ReturnType<MakerCheckerOr4EyeFunctionalityService['getMakercheckers']>,
-    );
-    makerCheckerService.deleteMakercheckersAuditId.and.returnValue(
+
+    makerCheckerService.approveMakerCheckerEntry.and.returnValue(
       of({}) as unknown as ReturnType<
-        MakerCheckerOr4EyeFunctionalityService['deleteMakercheckersAuditId']
+        MakerCheckerOr4EyeFunctionalityService['approveMakerCheckerEntry']
+      >,
+    );
+
+    makerCheckerService.deleteMakerCheckerEntry.and.returnValue(
+      of({}) as unknown as ReturnType<
+        MakerCheckerOr4EyeFunctionalityService['deleteMakerCheckerEntry']
       >,
     );
 
     await TestBed.configureTestingModule({
       imports: [CheckerInboxComponent],
       providers: [
-        { provide: MakerCheckerOr4EyeFunctionalityService, useValue: makerCheckerService },
-        { provide: NotificationService, useValue: notifications },
-        { provide: DialogService, useValue: jasmine.createSpyObj('DialogService', ['open']) },
-        provideIonicTesting(),
-        ...provideTranslateTesting(),
+        {
+          provide: MakerCheckerOr4EyeFunctionalityService,
+          useValue: makerCheckerService,
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: (key: string) => key,
+            get: (key: string) => of(key),
+          },
+        },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CheckerInboxComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('rejects a maker-checker task and refreshes the inbox', () => {
+  it('rejects a maker-checker task without deleting audit entry', () => {
     spyOn(window, 'confirm').and.returnValue(true);
-    makerCheckerService.postMakercheckersAuditId.and.returnValue(
-      of({}) as unknown as ReturnType<
-        MakerCheckerOr4EyeFunctionalityService['postMakercheckersAuditId']
-      >,
-    );
 
     component.onReject({ id: 42 });
 
     expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to reject this task?');
-    expect(makerCheckerService.postMakercheckersAuditId).toHaveBeenCalledWith(42, 'reject');
-    expect(makerCheckerService.deleteMakercheckersAuditId).not.toHaveBeenCalled();
-    expect(notifications.success).toHaveBeenCalledWith('Task rejected successfully');
-    expect(makerCheckerService.getMakercheckers).toHaveBeenCalledTimes(2);
+
+    expect(makerCheckerService.approveMakerCheckerEntry).toHaveBeenCalledWith(42, 'reject');
+
+    expect(makerCheckerService.deleteMakerCheckerEntry).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { MakerCheckerOr4EyeFunctionalityService } from '../../../api';
+import { DialogService } from '../../../core/services/dialog.service';
+import { NotificationService } from '../../../core/services/notification.service';
+import { provideIonicTesting } from '../../../testing/ionic-testing';
+import { provideTranslateTesting } from '../../../testing/i18n-testing';
+import { CheckerInboxComponent } from './checker-inbox.component';
+
+describe('CheckerInboxComponent', () => {
+  let component: CheckerInboxComponent;
+  let fixture: ComponentFixture<CheckerInboxComponent>;
+  let makerCheckerService: jasmine.SpyObj<MakerCheckerOr4EyeFunctionalityService>;
+  let notifications: jasmine.SpyObj<NotificationService>;
+
+  beforeEach(async () => {
+    makerCheckerService = jasmine.createSpyObj('MakerCheckerOr4EyeFunctionalityService', [
+      'getMakercheckers',
+      'postMakercheckersAuditId',
+      'deleteMakercheckersAuditId',
+    ]);
+    notifications = jasmine.createSpyObj('NotificationService', ['success', 'error']);
+    makerCheckerService.getMakercheckers.and.returnValue(
+      of([]) as unknown as ReturnType<MakerCheckerOr4EyeFunctionalityService['getMakercheckers']>,
+    );
+    makerCheckerService.deleteMakercheckersAuditId.and.returnValue(
+      of({}) as unknown as ReturnType<
+        MakerCheckerOr4EyeFunctionalityService['deleteMakercheckersAuditId']
+      >,
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [CheckerInboxComponent],
+      providers: [
+        { provide: MakerCheckerOr4EyeFunctionalityService, useValue: makerCheckerService },
+        { provide: NotificationService, useValue: notifications },
+        { provide: DialogService, useValue: jasmine.createSpyObj('DialogService', ['open']) },
+        provideIonicTesting(),
+        ...provideTranslateTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CheckerInboxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('rejects a maker-checker task and refreshes the inbox', () => {
+    spyOn(window, 'confirm').and.returnValue(true);
+    makerCheckerService.postMakercheckersAuditId.and.returnValue(
+      of({}) as unknown as ReturnType<
+        MakerCheckerOr4EyeFunctionalityService['postMakercheckersAuditId']
+      >,
+    );
+
+    component.onReject({ id: 42 });
+
+    expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to reject this task?');
+    expect(makerCheckerService.postMakercheckersAuditId).toHaveBeenCalledWith(42, 'reject');
+    expect(makerCheckerService.deleteMakercheckersAuditId).not.toHaveBeenCalled();
+    expect(notifications.success).toHaveBeenCalledWith('Task rejected successfully');
+    expect(makerCheckerService.getMakercheckers).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
@@ -161,11 +161,9 @@ export class CheckerInboxComponent {
     });
   }
 
-onReject(task: Record<string, unknown>) {
-  if (confirm('Are you sure you want to reject this task?')) {
-    this.makerCheckerService
-      .postMakercheckersAuditId(task['id'] as number, 'reject')
-      .subscribe({
+  onReject(task: Record<string, unknown>) {
+    if (confirm('Are you sure you want to reject this task?')) {
+      this.makerCheckerService.postMakercheckersAuditId(task['id'] as number, 'reject').subscribe({
         next: () => {
           this.snackBar.open('Task rejected successfully', 'Close', { duration: 3000 });
           this.refreshSubject.next();
@@ -174,8 +172,8 @@ onReject(task: Record<string, unknown>) {
           this.snackBar.open('Failed to reject task', 'Close', { duration: 3000 });
         },
       });
+    }
   }
-}
   formatDate(dateArray: unknown): string {
     if (Array.isArray(dateArray)) {
       return new Date(dateArray[0], dateArray[1] - 1, dateArray[2]).toLocaleDateString();

--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
@@ -161,9 +161,11 @@ export class CheckerInboxComponent {
     });
   }
 
-  onReject(task: Record<string, unknown>) {
-    if (confirm('Are you sure you want to reject this task?')) {
-      this.makerCheckerService.deleteMakerCheckerEntry(task['id'] as number).subscribe({
+onReject(task: Record<string, unknown>) {
+  if (confirm('Are you sure you want to reject this task?')) {
+    this.makerCheckerService
+      .postMakercheckersAuditId(task['id'] as number, 'reject')
+      .subscribe({
         next: () => {
           this.snackBar.open('Task rejected successfully', 'Close', { duration: 3000 });
           this.refreshSubject.next();
@@ -172,9 +174,8 @@ export class CheckerInboxComponent {
           this.snackBar.open('Failed to reject task', 'Close', { duration: 3000 });
         },
       });
-    }
   }
-
+}
   formatDate(dateArray: unknown): string {
     if (Array.isArray(dateArray)) {
       return new Date(dateArray[0], dateArray[1] - 1, dateArray[2]).toLocaleDateString();

--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
@@ -163,7 +163,7 @@ export class CheckerInboxComponent {
 
   onReject(task: Record<string, unknown>) {
     if (confirm('Are you sure you want to reject this task?')) {
-      this.makerCheckerService.postMakercheckersAuditId(task['id'] as number, 'reject').subscribe({
+      this.makerCheckerService.approveMakerCheckerEntry(task['id'] as number, 'reject').subscribe({
         next: () => {
           this.snackBar.open('Task rejected successfully', 'Close', { duration: 3000 });
           this.refreshSubject.next();


### PR DESCRIPTION
## What and why

Use the maker-checker reject command endpoint instead of deleting audit entries.

The rejection handler previously called the DELETE endpoint, which removed the
maker-checker audit entry instead of recording the rejection.

Closes #280

## Verification

Added a regression test covering the rejection behavior.

Verified that:
- reject uses `postMakercheckersAuditId(id, 'reject')`
- delete endpoint is not called
- success notification is shown
- inbox refreshes after rejection

Tests passed locally:
- npm test
- npm run lint