### PR TITLE
refactor(organization): use formatArrayDate helper

### DIFF
--- a/src/app/features/organization/offices/office-form.component.spec.ts
+++ b/src/app/features/organization/offices/office-form.component.spec.ts
@@ -36,6 +36,7 @@ describe('OfficeFormComponent', () => {
   const OFFICES_PATH = '/organization/offices';
   const NEW_OFFICE = 'New Office';
   const TEST_OFFICE = 'Test Office';
+  const TEST_OPENING_DATE = '2026-06-16';
 
   beforeEach(async () => {
     officesServiceSpy = jasmine.createSpyObj('OfficesService', [
@@ -197,16 +198,17 @@ describe('OfficeFormComponent', () => {
       expect(component.officeId).toBe(12);
       expect(officesServiceSpy.getOfficesOfficeId).toHaveBeenCalledWith(12);
       expect(component.office().name).toBe(TEST_OFFICE);
+      expect(component.openingDate()).toBe(TEST_OPENING_DATE);
 
       officesServiceSpy.putOfficesOfficeId.and.returnValue(of({}) as unknown as Observable<never>);
-      component.openingDate.set('2026-06-16');
+      component.openingDate.set(TEST_OPENING_DATE);
       component.onSubmit();
 
       expect(officesServiceSpy.putOfficesOfficeId).toHaveBeenCalledWith(
         12,
         jasmine.objectContaining({
           name: TEST_OFFICE,
-          openingDate: '2026-06-16',
+          openingDate: TEST_OPENING_DATE,
         }),
       );
     });

--- a/src/app/features/organization/offices/office-form.component.ts
+++ b/src/app/features/organization/offices/office-form.component.ts
@@ -38,7 +38,7 @@ import {
   IonSelectOption,
   IonSpinner,
 } from '@ionic/angular/standalone';
-import { toIsoDate } from '../../../core/utils/date-formatter';
+import { formatArrayDate, toIsoDate } from '../../../core/utils/date-formatter';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 import {
   OfficesService,
@@ -217,9 +217,8 @@ export class OfficeFormComponent implements OnInit {
   loadOfficeData() {
     if (!this.officeId) return;
     this.officesService.getOfficesOfficeId(this.officeId).subscribe((data) => {
-      const dateArray = data.openingDate as unknown as number[];
-      if (dateArray) {
-        this.openingDate.set(toIsoDate(new Date(dateArray[0], dateArray[1] - 1, dateArray[2])));
+      if (data.openingDate) {
+        this.openingDate.set(formatArrayDate(data.openingDate));
       }
       this.office.set({
         name: data.name,

--- a/src/app/features/organization/staff/staff-form.component.spec.ts
+++ b/src/app/features/organization/staff/staff-form.component.spec.ts
@@ -74,6 +74,18 @@ describe('StaffFormComponent', () => {
     expect(officesServiceSpy.getOffices).toHaveBeenCalled();
   });
 
+  it('should format the joining date returned by the API', () => {
+    staffServiceSpy.getStaffStaffId.and.returnValue(
+      of({ joiningDate: [2026, 1, 5] }) as unknown as ReturnType<StaffService['getStaffStaffId']>,
+    );
+    component.staffId = 7;
+
+    component.loadStaffData();
+
+    expect(staffServiceSpy.getStaffStaffId).toHaveBeenCalledWith(7);
+    expect(component.joiningDate()).toBe('2026-01-05');
+  });
+
   it('should create staff with a StaffCreateRequest payload on submit', () => {
     staffServiceSpy.postStaff.and.returnValue(
       of({}) as unknown as ReturnType<StaffService['postStaff']>,

--- a/src/app/features/organization/staff/staff-form.component.ts
+++ b/src/app/features/organization/staff/staff-form.component.ts
@@ -46,6 +46,7 @@ import {
   GetOfficesResponse,
 } from '../../../api';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -301,8 +302,7 @@ export class StaffFormComponent implements OnInit {
         emailAddress: (data as Record<string, unknown>)['emailAddress'] as string | undefined,
       });
       if (data.joiningDate) {
-        const jd = data.joiningDate as unknown as number[];
-        this.joiningDate.set(toIsoDate(new Date(jd[0], jd[1] - 1, jd[2])));
+        this.joiningDate.set(formatArrayDate(data.joiningDate));
       }
     });
   }


### PR DESCRIPTION
## What and why

Replace the manual array-to-`Date` round trip in the Organization office and staff forms with the existing `formatArrayDate` helper. Existing missing-date guards remain in place, and the component specs cover the formatted office opening and staff joining dates.

Part of #257.

## Verification

- 11 focused tests passed
- 897 full tests passed
- lint, format, build, app TypeScript, icon, i18n, and license checks passed