### PR TITLE
fix(products): pass recurring deposit command

### DIFF
--- a/src/app/features/products/products.routes.ts
+++ b/src/app/features/products/products.routes.ts
@@ -526,7 +526,7 @@ export const PRODUCTS_ROUTES: Routes = [
       ),
   },
   {
-    path: 'recurring-deposits/:accountId/transactions/create',
+    path: 'recurring-deposits/:accountId/transactions/:command',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_RECURRINGDEPOSITACCOUNT' },
     title: 'RECURRING_DEPOSIT_TRANSACTIONS.CREATE',

--- a/src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.spec.ts
+++ b/src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.spec.ts
@@ -20,7 +20,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RecurringDepositTransactionFormComponent } from './recurring-deposit-transaction-form.component';
 import { RecurringDepositAccountTransactionsService } from '../../../api';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -30,8 +30,10 @@ describe('RecurringDepositTransactionFormComponent', () => {
   let fixture: ComponentFixture<RecurringDepositTransactionFormComponent>;
   let serviceSpy: jasmine.SpyObj<RecurringDepositAccountTransactionsService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let commandParam: 'deposit' | 'withdrawal';
 
   beforeEach(async () => {
+    commandParam = 'deposit';
     serviceSpy = jasmine.createSpyObj('RecurringDepositAccountTransactionsService', [
       'getRecurringdepositaccountsRecurringDepositAccountIdTransactionsTemplate',
       'postRecurringdepositaccountsRecurringDepositAccountIdTransactions',
@@ -50,18 +52,28 @@ describe('RecurringDepositTransactionFormComponent', () => {
         { provide: Router, useValue: routerSpy },
         {
           provide: ActivatedRoute,
-          useValue: { snapshot: { paramMap: convertToParamMap({ accountId: '1' }) } },
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: (key: string) => (key === 'accountId' ? '1' : commandParam),
+              },
+            },
+          },
         },
         provideNoopAnimations(),
       ],
     }).compileComponents();
+  });
 
+  function createComponent(): void {
     fixture = TestBed.createComponent(RecurringDepositTransactionFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }
 
   it('should load template payment-type options on init', () => {
+    createComponent();
+
     expect(component).toBeTruthy();
     expect(
       serviceSpy.getRecurringdepositaccountsRecurringDepositAccountIdTransactionsTemplate,
@@ -70,6 +82,7 @@ describe('RecurringDepositTransactionFormComponent', () => {
   });
 
   it('should post a deposit and navigate to the transactions list', () => {
+    createComponent();
     serviceSpy.postRecurringdepositaccountsRecurringDepositAccountIdTransactions.and.returnValue(
       of({}) as unknown as ReturnType<
         RecurringDepositAccountTransactionsService['postRecurringdepositaccountsRecurringDepositAccountIdTransactions']
@@ -80,11 +93,33 @@ describe('RecurringDepositTransactionFormComponent', () => {
     component.onSubmit();
     expect(
       serviceSpy.postRecurringdepositaccountsRecurringDepositAccountIdTransactions,
-    ).toHaveBeenCalled();
+    ).toHaveBeenCalledWith(
+      1,
+      jasmine.objectContaining({ transactionAmount: 500, paymentTypeId: 1 }),
+      'deposit',
+    );
     expect(routerSpy.navigate).toHaveBeenCalledWith([
       '/products/recurring-deposits',
       1,
       'transactions',
     ]);
+  });
+
+  it('should post a withdrawal command from the route', () => {
+    commandParam = 'withdrawal';
+    createComponent();
+    serviceSpy.postRecurringdepositaccountsRecurringDepositAccountIdTransactions.and.returnValue(
+      of({}) as unknown as ReturnType<
+        RecurringDepositAccountTransactionsService['postRecurringdepositaccountsRecurringDepositAccountIdTransactions']
+      >,
+    );
+    component.transactionAmount = 200;
+
+    component.onSubmit();
+
+    expect(component.command()).toBe('withdrawal');
+    expect(
+      serviceSpy.postRecurringdepositaccountsRecurringDepositAccountIdTransactions,
+    ).toHaveBeenCalledWith(1, jasmine.objectContaining({ transactionAmount: 200 }), 'withdrawal');
   });
 });

--- a/src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.ts
+++ b/src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.ts
@@ -49,9 +49,8 @@ import {
 } from '../../../core/utils/date-formatter';
 
 /**
- * Deposit form for a single recurring deposit account. The account id is read from the route.
- * Payment-type options come from the transaction template endpoint; the form posts a deposit
- * against the account's transaction collection.
+ * Transaction form for a single recurring deposit account. The account id and command are read
+ * from the route. Payment-type options come from the transaction template endpoint.
  */
 @Component({
   selector: 'app-recurring-deposit-transaction-form',
@@ -79,7 +78,12 @@ import {
       <ion-card>
         <ion-card-header>
           <ion-card-title>
-            {{ 'RECURRING_DEPOSIT_TRANSACTIONS.CREATE' | translate }}
+            {{
+              (command() === 'withdrawal'
+                ? 'SAVINGS.WITHDRAWAL'
+                : 'RECURRING_DEPOSIT_TRANSACTIONS.CREATE'
+              ) | translate
+            }}
           </ion-card-title>
         </ion-card-header>
 
@@ -176,6 +180,7 @@ export class RecurringDepositTransactionFormComponent implements OnInit {
   private readonly router = inject(Router);
 
   accountId!: number;
+  readonly command = signal<'deposit' | 'withdrawal'>('deposit');
   readonly isSaving = signal(false);
 
   transactionDate = toIsoDate(new Date());
@@ -185,6 +190,8 @@ export class RecurringDepositTransactionFormComponent implements OnInit {
 
   ngOnInit(): void {
     this.accountId = Number(this.route.snapshot.paramMap.get('accountId'));
+    const command = this.route.snapshot.paramMap.get('command');
+    this.command.set(command === 'withdrawal' ? 'withdrawal' : 'deposit');
     this.transactionsService
       .getRecurringdepositaccountsRecurringDepositAccountIdTransactionsTemplate(this.accountId)
       .subscribe((tpl) => {
@@ -203,7 +210,11 @@ export class RecurringDepositTransactionFormComponent implements OnInit {
     };
 
     this.transactionsService
-      .postRecurringdepositaccountsRecurringDepositAccountIdTransactions(this.accountId, request)
+      .postRecurringdepositaccountsRecurringDepositAccountIdTransactions(
+        this.accountId,
+        request,
+        this.command(),
+      )
       .subscribe({
         next: () =>
           this.router.navigate(['/products/recurring-deposits', this.accountId, 'transactions']),


### PR DESCRIPTION
## What and why

Read the recurring-deposit transaction command from the route and pass it as the generated API client's third argument. This lets the form submit both `deposit` and `withdrawal` instead of sending an unsupported null command.

The form defaults unknown commands to `deposit`, shows the withdrawal title when appropriate, and has focused coverage for both API calls.

Closes #278.

## Verification

- 3 focused tests passed
- 897 full tests passed
- lint, format, build, app TypeScript, icon, i18n, and license checks passed