### PR TITLE
ci: add signed commit verification check

### DIFF
--- a/.github/workflows/signed-commit.yml
+++ b/.github/workflows/signed-commit.yml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Fineract Signed Commits Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-signatures:
+    name: Verify Commit Signatures
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF"
+
+      - name: Verify signatures
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          ./scripts/verify-signed-commits.sh \
+            --base-ref "origin/$BASE_REF" \
+            --head-ref "$HEAD_SHA" \
+            --strict

--- a/scripts/verify-signed-commits.sh
+++ b/scripts/verify-signed-commits.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Usage: ./scripts/verify-signed-commits.sh [--base-ref <ref>] [--head-ref <ref>] [--strict] [--help]
+set -e
+
+BASE_REF="origin/main"
+HEAD_REF="HEAD"
+STRICT_MODE=false
+
+show_help() {
+    cat << 'EOF'
+Usage: ./scripts/verify-signed-commits.sh [OPTIONS]
+
+Options:
+  --base-ref <ref>   Base reference (default: origin/main)
+  --head-ref <ref>   Head reference (default: HEAD)
+  --strict           Exit with error if unsigned commits found
+  --help             Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --base-ref) BASE_REF="$2"; shift 2 ;;
+        --head-ref) HEAD_REF="$2"; shift 2 ;;
+        --strict) STRICT_MODE=true; shift ;;
+        --help) show_help; exit 0 ;;
+        *) echo "Unknown option: $1"; show_help; exit 1 ;;
+    esac
+done
+
+MERGE_BASE=$(git merge-base "$BASE_REF" "$HEAD_REF" 2>/dev/null || echo "")
+if [ -z "$MERGE_BASE" ]; then
+    COMMIT_RANGE="$HEAD_REF~10..$HEAD_REF"
+else
+    COMMIT_RANGE="$MERGE_BASE..$HEAD_REF"
+fi
+
+echo "Verifying commit signatures in range: $COMMIT_RANGE"
+
+COMMITS=$(git log --format="%H%x1f%G?%x1f%an%x1f%s" "$COMMIT_RANGE" 2>/dev/null || echo "")
+if [ -z "$COMMITS" ]; then
+    echo "No commits to verify."
+    exit 0
+fi
+
+UNSIGNED_COUNT=0
+
+# ponytail: only %G? == N (no signature) fails. A runner has no contributor public
+# keys, so E/U/B would flag every signed commit as broken — GitHub's own
+# verification covers key validity.
+while IFS=$'\x1f' read -r HASH SIG_STATUS AUTHOR SUBJECT; do
+    [ -z "$HASH" ] && continue
+    SHORT_HASH="${HASH:0:7}"
+
+    case "$SIG_STATUS" in
+        N)
+            UNSIGNED_COUNT=$((UNSIGNED_COUNT + 1))
+            if [ -n "$GITHUB_ACTIONS" ]; then
+                echo "::error title=Unsigned Commit::Commit $SHORT_HASH by $AUTHOR is not signed."
+            else
+                echo "❌ Unsigned: $SHORT_HASH - $SUBJECT ($AUTHOR)"
+            fi
+            ;;
+        *)
+            echo "✅ Signed: $SHORT_HASH - $SUBJECT"
+            ;;
+    esac
+done <<< "$COMMITS"
+
+echo ""
+echo "Summary: $UNSIGNED_COUNT unsigned commit(s) found."
+
+if [ "$STRICT_MODE" = true ] && [ "$UNSIGNED_COUNT" -gt 0 ]; then
+    if [ -n "$GITHUB_ACTIONS" ]; then
+        echo "::error::$UNSIGNED_COUNT unsigned commit(s). See CONTRIBUTING.md#commit-signing"
+    else
+        echo "❌ $UNSIGNED_COUNT unsigned commit(s). See CONTRIBUTING.md#commit-signing"
+    fi
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Closes #336

Picking this one up — initial commit, happy to take feedback before I go further.

Ports the signed-commit check from `apache/fineract` (`verify-commits.yml` + `scripts/verify-signed-commits.sh`) so contributor expectations match between the two repos.

**What's here**
- `.github/workflows/signed-commit.yml` — runs on `pull_request` (opened/synchronize/reopened), checks out with full history, verifies the PR commit range in `--strict` mode so unsigned commits fail the job.
- `scripts/verify-signed-commits.sh` — walks `merge-base..head`, prints a per-commit signed/unsigned line, and emits `::error title=Unsigned Commit::` annotations so the offending commits are called out directly in the job log.

**Notes**
- Only `%G?` == `N` (no signature) fails. A runner has no contributor public keys, so `E`/`U` would flag every *signed* commit as broken — GitHub's own verification covers key validity. Same behaviour as the fineract script.
- Default `--base-ref` is `origin/main` (fineract's is `origin/develop`).
- Pinned `actions/checkout` to the same SHA already used by `zizmor.yml`, with `persist-credentials: false`.
- The docs half of the acceptance criteria already exists — [CONTRIBUTING.md#commit-signing](https://github.com/apache/fineract-backoffice-ui/blob/main/CONTRIBUTING.md#commit-signing) covers `user.signingkey` / `commit.gpgsign` and retroactive signing, so the script points there instead of duplicating it. Lemme know if you'd rather have a separate `docs/ci.md`.

Verified locally against a range containing a known unsigned commit — it's correctly identified and `--strict` exits 1.

cc @Aman-Mittal
