### PR TITLE
fix(a11y): give icon-only buttons an accessible name

### DIFF
--- a/src/app/features/accounting/accounting-closures-list.component.ts
+++ b/src/app/features/accounting/accounting-closures-list.component.ts
@@ -71,6 +71,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
           color="danger"
           [title]="'ACCOUNTING_CLOSURES.REOPEN' | appTranslate"
           (click)="onDeleteClosure(closure)"
+          [attr.aria-label]="'ACCOUNTING_CLOSURES.REOPEN' | translate"
         >
           <ion-icon name="lock-open-outline"></ion-icon>
         </ion-button>

--- a/src/app/features/accounting/accounting-rules-list.component.ts
+++ b/src/app/features/accounting/accounting-rules-list.component.ts
@@ -20,6 +20,7 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 
 import { Router } from '@angular/router';
+import { TranslatePipe } from '../../core/adapters';
 import { AccountingRulesService } from '../../api/api/accountingRules.service';
 import { AccountingRuleData } from '../../api/model/models';
 import {
@@ -32,7 +33,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-accounting-rules-list',
   standalone: true,
-  imports: [DataTableComponent, CellTemplateDirective, IonIcon, IonButton],
+  imports: [DataTableComponent, CellTemplateDirective, TranslatePipe, IonIcon, IonButton],
   template: `
     <div class="container">
       <app-data-table
@@ -50,10 +51,20 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
           {{ row.creditAccounts?.[0]?.name || '' }}
         </ng-template>
         <ng-template appCellTemplate="actions" let-row>
-          <ion-button fill="clear" color="primary" (click)="onEdit(row)">
+          <ion-button
+            fill="clear"
+            color="primary"
+            (click)="onEdit(row)"
+            [attr.aria-label]="'COMMON.EDIT' | appTranslate"
+          >
             <ion-icon name="create-outline"></ion-icon>
           </ion-button>
-          <ion-button fill="clear" color="danger" (click)="onDelete(row)">
+          <ion-button
+            fill="clear"
+            color="danger"
+            (click)="onDelete(row)"
+            [attr.aria-label]="'COMMON.DELETE' | appTranslate"
+          >
             <ion-icon name="trash-outline"></ion-icon>
           </ion-button>
         </ng-template>

--- a/src/app/features/accounting/chart-of-accounts.component.ts
+++ b/src/app/features/accounting/chart-of-accounts.component.ts
@@ -64,6 +64,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
           color="primary"
           [title]="'ACCOUNTING.EDIT_ACCOUNT' | appTranslate"
           (click)="onEditAccount(account)"
+          [attr.aria-label]="'ACCOUNTING.EDIT_ACCOUNT' | translate"
         >
           <ion-icon name="create-outline"></ion-icon>
         </ion-button>

--- a/src/app/features/accounting/financial-activity-mappings-list.component.ts
+++ b/src/app/features/accounting/financial-activity-mappings-list.component.ts
@@ -20,6 +20,7 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 
 import { Router } from '@angular/router';
+import { TranslatePipe } from '../../core/adapters';
 import { MappingFinancialActivitiesToAccountsService } from '../../api/api/mappingFinancialActivitiesToAccounts.service';
 import { GetFinancialActivityAccountsResponse } from '../../api/model/models';
 import {
@@ -32,7 +33,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-financial-activity-mappings-list',
   standalone: true,
-  imports: [DataTableComponent, CellTemplateDirective, IonIcon, IonButton],
+  imports: [DataTableComponent, CellTemplateDirective, TranslatePipe, IonIcon, IonButton],
   template: `
     <div class="container">
       <app-data-table
@@ -53,10 +54,20 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
           {{ row.glAccountData?.glCode || '' }}
         </ng-template>
         <ng-template appCellTemplate="actions" let-row>
-          <ion-button fill="clear" color="primary" (click)="onEdit(row)">
+          <ion-button
+            fill="clear"
+            color="primary"
+            (click)="onEdit(row)"
+            [attr.aria-label]="'COMMON.EDIT' | appTranslate"
+          >
             <ion-icon name="create-outline"></ion-icon>
           </ion-button>
-          <ion-button fill="clear" color="danger" (click)="onDelete(row)">
+          <ion-button
+            fill="clear"
+            color="danger"
+            (click)="onDelete(row)"
+            [attr.aria-label]="'COMMON.DELETE' | appTranslate"
+          >
             <ion-icon name="trash-outline"></ion-icon>
           </ion-button>
         </ng-template>

--- a/src/app/features/accounting/journal-entry-form.component.ts
+++ b/src/app/features/accounting/journal-entry-form.component.ts
@@ -196,6 +196,7 @@ import { toIsoDate } from '../../core/utils/date-formatter';
                     type="button"
                     (click)="removeDebit($index)"
                     [disabled]="debits.length === 1"
+                    [attr.aria-label]="'JOURNAL_ENTRIES.REMOVE_DEBIT' | translate"
                   >
                     <ion-icon name="trash-outline"></ion-icon>
                   </ion-button>
@@ -242,6 +243,7 @@ import { toIsoDate } from '../../core/utils/date-formatter';
                     type="button"
                     (click)="removeCredit($index)"
                     [disabled]="credits.length === 1"
+                    [attr.aria-label]="'JOURNAL_ENTRIES.REMOVE_CREDIT' | translate"
                   >
                     <ion-icon name="trash-outline"></ion-icon>
                   </ion-button>

--- a/src/app/features/campaigns/email-campaigns/email-campaigns-list.component.ts
+++ b/src/app/features/campaigns/email-campaigns/email-campaigns-list.component.ts
@@ -117,6 +117,7 @@ interface EmailCampaign {
                     color="primary"
                     [title]="'EMAIL_CAMPAIGNS.EDIT' | translate"
                     (click)="navigateToEdit(campaign.id)"
+                    [attr.aria-label]="'EMAIL_CAMPAIGNS.EDIT' | translate"
                   >
                     <ion-icon name="create-outline"></ion-icon>
                   </ion-button>
@@ -125,6 +126,7 @@ interface EmailCampaign {
                     color="secondary"
                     [title]="'EMAIL_CAMPAIGNS.ACTIVATE' | translate"
                     (click)="activate(campaign.id)"
+                    [attr.aria-label]="'EMAIL_CAMPAIGNS.ACTIVATE' | translate"
                   >
                     <ion-icon name="play-outline"></ion-icon>
                   </ion-button>
@@ -133,6 +135,7 @@ interface EmailCampaign {
                     color="danger"
                     [title]="'EMAIL_CAMPAIGNS.DEACTIVATE' | translate"
                     (click)="deactivate(campaign.id)"
+                    [attr.aria-label]="'EMAIL_CAMPAIGNS.DEACTIVATE' | translate"
                   >
                     <ion-icon name="pause-outline"></ion-icon>
                   </ion-button>
@@ -141,6 +144,7 @@ interface EmailCampaign {
                     color="danger"
                     [title]="'EMAIL_CAMPAIGNS.DELETE' | translate"
                     (click)="delete(campaign.id)"
+                    [attr.aria-label]="'EMAIL_CAMPAIGNS.DELETE' | translate"
                   >
                     <ion-icon name="trash-outline"></ion-icon>
                   </ion-button>

--- a/src/app/features/campaigns/sms-campaigns/sms-campaigns-list.component.ts
+++ b/src/app/features/campaigns/sms-campaigns/sms-campaigns-list.component.ts
@@ -104,14 +104,19 @@ interface SmsCampaign {
               <ng-container cdkColumnDef="actions">
                 <th cdk-header-cell *cdkHeaderCellDef>{{ 'SMS_CAMPAIGNS.ACTIONS' | translate }}</th>
                 <td cdk-cell *cdkCellDef="let row">
-                  <ion-button fill="clear" color="primary" (click)="edit(row.id)" title="Edit">
+                  <ion-button
+                    fill="clear"
+                    color="primary"
+                    (click)="edit(row.id)"
+                    [attr.aria-label]="'SMS_CAMPAIGNS.EDIT' | translate"
+                  >
                     <ion-icon name="create-outline"></ion-icon>
                   </ion-button>
                   <ion-button
                     fill="clear"
                     color="secondary"
                     (click)="activate(row.id)"
-                    title="{{ 'SMS_CAMPAIGNS.ACTIVATE' | translate }}"
+                    [attr.aria-label]="'SMS_CAMPAIGNS.ACTIVATE' | translate"
                   >
                     <ion-icon name="play-outline"></ion-icon>
                   </ion-button>
@@ -119,7 +124,7 @@ interface SmsCampaign {
                     fill="clear"
                     color="danger"
                     (click)="deactivate(row.id)"
-                    title="{{ 'SMS_CAMPAIGNS.DEACTIVATE' | translate }}"
+                    [attr.aria-label]="'SMS_CAMPAIGNS.DEACTIVATE' | translate"
                   >
                     <ion-icon name="pause-outline"></ion-icon>
                   </ion-button>
@@ -127,7 +132,7 @@ interface SmsCampaign {
                     fill="clear"
                     color="danger"
                     (click)="delete(row.id)"
-                    title="{{ 'SMS_CAMPAIGNS.DELETE' | translate }}"
+                    [attr.aria-label]="'SMS_CAMPAIGNS.DELETE' | translate"
                   >
                     <ion-icon name="trash-outline"></ion-icon>
                   </ion-button>

--- a/src/app/features/clients/client-search-v2.component.ts
+++ b/src/app/features/clients/client-search-v2.component.ts
@@ -115,6 +115,7 @@ import {
                   fill="clear"
                   (click)="viewClient(row.id)"
                   [title]="'CLIENT_SEARCH_V2.VIEW' | translate"
+                  [attr.aria-label]="'CLIENT_SEARCH_V2.VIEW' | translate"
                 >
                   <ion-icon name="eye-outline"></ion-icon>
                 </ion-button>

--- a/src/app/features/fintech/asset-owners-list.component.ts
+++ b/src/app/features/fintech/asset-owners-list.component.ts
@@ -62,8 +62,8 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
         <ion-button
           fill="clear"
           color="primary"
-          title="View Details"
           (click)="onViewDetails(transfer)"
+          [attr.aria-label]="'COMMON.VIEW_DETAILS' | translate"
         >
           <ion-icon name="eye-outline"></ion-icon>
         </ion-button>

--- a/src/app/features/loans/loan-notes-tab.component.ts
+++ b/src/app/features/loans/loan-notes-tab.component.ts
@@ -82,6 +82,7 @@ import { IonButton, IonIcon, IonItem, IonLabel, IonTextarea } from '@ionic/angul
               color="danger"
               class="delete-btn"
               (click)="onDeleteNote(note.id!)"
+              [attr.aria-label]="'LOANS.DELETE_NOTE' | translate"
             >
               <ion-icon name="trash-outline"></ion-icon>
             </ion-button>

--- a/src/app/features/organization/office-transactions/office-transactions-list.component.ts
+++ b/src/app/features/organization/office-transactions/office-transactions-list.component.ts
@@ -115,7 +115,12 @@ interface OfficeTransaction {
             <ng-container cdkColumnDef="actions">
               <th cdk-header-cell *cdkHeaderCellDef>{{ 'COMMON.ACTIONS' | translate }}</th>
               <td cdk-cell *cdkCellDef="let row">
-                <ion-button fill="clear" color="danger" (click)="onDelete(row)">
+                <ion-button
+                  fill="clear"
+                  color="danger"
+                  (click)="onDelete(row)"
+                  [attr.aria-label]="'OFFICE_TRANSACTIONS.DELETE' | translate"
+                >
                   <ion-icon name="trash-outline"></ion-icon>
                 </ion-button>
               </td>

--- a/src/app/features/products/payment-credit-allocation-editor.component.ts
+++ b/src/app/features/products/payment-credit-allocation-editor.component.ts
@@ -113,6 +113,7 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                     type="button"
                     [disabled]="orderIndex === 0"
                     (click)="moveOrderEntry(rule.paymentAllocationOrder!, orderIndex, -1)"
+                    [attr.aria-label]="'COMMON.MOVE_UP' | translate"
                   >
                     <ion-icon name="arrow-up-outline" slot="icon-only"></ion-icon>
                   </ion-button>
@@ -121,6 +122,7 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                     type="button"
                     [disabled]="orderIndex === rule.paymentAllocationOrder!.length - 1"
                     (click)="moveOrderEntry(rule.paymentAllocationOrder!, orderIndex, 1)"
+                    [attr.aria-label]="'COMMON.MOVE_DOWN' | translate"
                   >
                     <ion-icon name="arrow-down-outline" slot="icon-only"></ion-icon>
                   </ion-button>
@@ -201,6 +203,7 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                     type="button"
                     [disabled]="orderIndex === 0"
                     (click)="moveOrderEntry(rule.creditAllocationOrder!, orderIndex, -1)"
+                    [attr.aria-label]="'COMMON.MOVE_UP' | translate"
                   >
                     <ion-icon name="arrow-up-outline" slot="icon-only"></ion-icon>
                   </ion-button>
@@ -209,6 +212,7 @@ import { TooltipDirective } from '../../shared/directives/tooltip.directive';
                     type="button"
                     [disabled]="orderIndex === rule.creditAllocationOrder!.length - 1"
                     (click)="moveOrderEntry(rule.creditAllocationOrder!, orderIndex, 1)"
+                    [attr.aria-label]="'COMMON.MOVE_DOWN' | translate"
                   >
                     <ion-icon name="arrow-down-outline" slot="icon-only"></ion-icon>
                   </ion-button>

--- a/src/app/features/products/shares/share-account-form.component.ts
+++ b/src/app/features/products/shares/share-account-form.component.ts
@@ -134,6 +134,7 @@ interface ShareAccountTemplateResponse {
                       color="primary"
                       type="button"
                       (click)="onCreateClient()"
+                      [attr.aria-label]="'SHARE_ACCOUNTS.CREATE_CLIENT' | translate"
                     >
                       <ion-icon name="add-circle-outline" slot="icon-only"></ion-icon>
                     </ion-button>
@@ -171,6 +172,7 @@ interface ShareAccountTemplateResponse {
                       type="button"
                       (click)="onCreateProduct()"
                       [disabled]="isEditMode()"
+                      [attr.aria-label]="'SHARE_ACCOUNTS.CREATE_PRODUCT' | translate"
                     >
                       <ion-icon name="add-circle-outline" slot="icon-only"></ion-icon>
                     </ion-button>

--- a/src/app/features/system/business-steps/business-steps.component.spec.ts
+++ b/src/app/features/system/business-steps/business-steps.component.spec.ts
@@ -83,4 +83,20 @@ describe('BusinessStepsComponent', () => {
     component.onSave();
     expect(serviceSpy.putJobsJobNameSteps).toHaveBeenCalled();
   });
+
+  it('gives the reorder buttons an accessible name', () => {
+    component.selectedJob = 'LOAN_CLOSE_OF_BUSINESS';
+    component.loadSteps();
+    fixture.detectChanges();
+
+    // The buttons are icon-only, so the icon is all a sighted user gets and an
+    // accessible name is all a screen reader gets. Without one, a row of these
+    // announces as "button, button".
+    const labels = Array.from(
+      fixture.nativeElement.querySelectorAll('ion-button') as NodeListOf<HTMLElement>,
+    ).map((button) => button.getAttribute('aria-label'));
+
+    expect(labels).toContain('COMMON.MOVE_UP');
+    expect(labels).toContain('COMMON.MOVE_DOWN');
+  });
 });

--- a/src/app/features/system/business-steps/business-steps.component.ts
+++ b/src/app/features/system/business-steps/business-steps.component.ts
@@ -87,7 +87,13 @@ import {
                 <ion-item>
                   <span>{{ step.stepName }}</span>
                   <span matListItemMeta>
-                    <ion-button fill="clear" type="button" [disabled]="i === 0" (click)="moveUp(i)">
+                    <ion-button
+                      fill="clear"
+                      type="button"
+                      [disabled]="i === 0"
+                      (click)="moveUp(i)"
+                      [attr.aria-label]="'COMMON.MOVE_UP' | translate"
+                    >
                       <ion-icon name="arrow-up-outline"></ion-icon>
                     </ion-button>
                     <ion-button
@@ -95,6 +101,7 @@ import {
                       type="button"
                       [disabled]="i === steps().length - 1"
                       (click)="moveDown(i)"
+                      [attr.aria-label]="'COMMON.MOVE_DOWN' | translate"
                     >
                       <ion-icon name="arrow-down-outline"></ion-icon>
                     </ion-button>

--- a/src/app/features/system/data-tables/datatables-form.component.ts
+++ b/src/app/features/system/data-tables/datatables-form.component.ts
@@ -204,7 +204,13 @@ import {
                   </div>
 
                   @if (!isEditMode) {
-                    <ion-button fill="clear" color="danger" type="button" (click)="removeColumn(i)">
+                    <ion-button
+                      fill="clear"
+                      color="danger"
+                      type="button"
+                      (click)="removeColumn(i)"
+                      [attr.aria-label]="'SYSTEM.REMOVE_COLUMN' | translate"
+                    >
                       <ion-icon name="trash-outline"></ion-icon>
                     </ion-button>
                   }

--- a/src/app/features/system/templates/templates-list.component.ts
+++ b/src/app/features/system/templates/templates-list.component.ts
@@ -74,10 +74,20 @@ import {
           <ng-container cdkColumnDef="actions">
             <th cdk-header-cell *cdkHeaderCellDef></th>
             <td cdk-cell *cdkCellDef="let row">
-              <ion-button fill="clear" color="primary" (click)="onEdit(row)">
+              <ion-button
+                fill="clear"
+                color="primary"
+                (click)="onEdit(row)"
+                [attr.aria-label]="'COMMON.EDIT' | translate"
+              >
                 <ion-icon name="create-outline"></ion-icon>
               </ion-button>
-              <ion-button fill="clear" color="danger" (click)="onDelete(row)">
+              <ion-button
+                fill="clear"
+                color="danger"
+                (click)="onDelete(row)"
+                [attr.aria-label]="'COMMON.DELETE' | translate"
+              >
                 <ion-icon name="trash-outline"></ion-icon>
               </ion-button>
             </td>

--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
@@ -53,15 +53,25 @@ import { DialogService } from '../../../core/services/dialog.service';
           <ion-button
             fill="clear"
             color="primary"
-            title="View Payload"
             (click)="onViewPayload(task)"
+            [attr.aria-label]="'CHECKER_INBOX.VIEW_PAYLOAD' | translate"
           >
             <ion-icon name="eye-outline"></ion-icon>
           </ion-button>
-          <ion-button fill="clear" class="approve-btn" title="Approve" (click)="onApprove(task)">
+          <ion-button
+            fill="clear"
+            class="approve-btn"
+            (click)="onApprove(task)"
+            [attr.aria-label]="'ACTIONS.APPROVE' | translate"
+          >
             <ion-icon name="checkmark-circle-outline"></ion-icon>
           </ion-button>
-          <ion-button fill="clear" color="danger" title="Reject" (click)="onReject(task)">
+          <ion-button
+            fill="clear"
+            color="danger"
+            (click)="onReject(task)"
+            [attr.aria-label]="'ACTIONS.REJECT' | translate"
+          >
             <ion-icon name="close-circle-outline"></ion-icon>
           </ion-button>
         </div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -217,6 +217,8 @@
     "MATURITY_AMOUNT": "Maturity Amount",
     "MOBILE_NO": "Mobile No",
     "MONTHS": "Months",
+    "MOVE_DOWN": "Move down",
+    "MOVE_UP": "Move up",
     "NAME": "Name",
     "NEXT_PAGE": "Next page",
     "NO": "No",
@@ -586,6 +588,7 @@
     "UNRECOGNIZED_AMOUNT": "Unrecognized Amount",
     "NOTES": "Notes",
     "ADD_NOTE": "Add a note",
+    "DELETE_NOTE": "Delete note",
     "NO_NOTES": "No notes recorded for this loan yet.",
     "CONFIRM_DELETE_NOTE": "Are you sure you want to delete this note? This action cannot be undone.",
     "DOCUMENTS": "Documents",
@@ -881,6 +884,7 @@
     "MULTI_ROW": "Multi Row",
     "COLUMNS": "Columns",
     "ADD_COLUMN": "Add Column",
+    "REMOVE_COLUMN": "Remove column",
     "LENGTH": "Length",
     "CODE": "Code",
     "MANDATORY": "Mandatory",
@@ -1146,7 +1150,9 @@
   "JOURNAL_ENTRIES": {
     "CREATE": "Add Journal Entry",
     "DEBITS": "Debits",
+    "REMOVE_DEBIT": "Remove debit line",
     "CREDITS": "Credits",
+    "REMOVE_CREDIT": "Remove credit line",
     "TRANSACTION_DATE": "Transaction Date",
     "REFERENCE_NUMBER": "Reference Number",
     "OFFICE": "Office",
@@ -1252,6 +1258,8 @@
     "APPLICATION_DATE": "Application Date",
     "APPLY_SHARES": "Apply for more shares",
     "CREATE": "Create Share Account",
+    "CREATE_CLIENT": "Create client",
+    "CREATE_PRODUCT": "Create share product",
     "DIVIDENDS": "Dividends",
     "EDIT": "Edit Share Account",
     "LINKED_SAVINGS": "Linked savings account",
@@ -1831,6 +1839,9 @@
     "TITLE": "Business Step Configuration",
     "JOB": "Job",
     "NO_STEPS": "No steps configured for this job."
+  },
+  "CHECKER_INBOX": {
+    "VIEW_PAYLOAD": "View payload"
   },
   "BUSINESS_DATES": {
     "TITLE": "Business Date Management",


### PR DESCRIPTION
## What and why

34 icon-only `ion-button`s across 19 files had no accessible name, so a screen reader announced each one as just "button". On a row of icon buttons the icon is the only thing separating edit from delete, and several of these actions are destructive: deleting an accounting rule, removing a datatable column, re-opening a closed accounting period.

Each button now carries `[attr.aria-label]` bound to a translation key, which is the pattern the 100 already-labelled buttons in the app use. Existing keys are reused wherever one fits (`COMMON.EDIT`, `COMMON.DELETE`, `ACTIONS.APPROVE`, `ACCOUNTING_CLOSURES.REOPEN` and so on). 9 new keys are added for actions that had none.

Two smaller things came with it:

* Eight buttons carried a native `title` (five hardcoded English, three translated). Those are removed. As `tooltip.directive.ts` documents in its own header, the native `title` does not surface from an Ionic component's shadow host, so it was neither naming the button nor reliably showing help text.
* `accounting-rules-list` and `financial-activity-mappings-list` had no translation pipe at all. They now use the I18N adapter's `appTranslate` pipe per `DOCS/adr/0003-adapter-boundary.md`, rather than adding two new direct `@ngx-translate/core` imports.

Closes #233

## One thing worth flagging before review

The issue says the 246 `appTooltip` uses are what give those buttons their accessible name. That does not appear to be the case, and it changes what "done" means here.

`TooltipDirective` sets `aria-describedby`, and only while the tooltip is visible (`src/app/shared/directives/tooltip.directive.ts`, `show()` and `hide()`). `aria-describedby` supplies a description, not a name, so a button whose only annotation is `appTooltip` still has no accessible name and still fails WCAG 4.1.2.

Measured across `src/app`, counting `ion-button`s whose only content is an `ion-icon`:

| | count |
|---|---|
| icon-only buttons total | 187 |
| with `aria-label` (real accessible name) | 109 |
| without | 78 |

This PR fixes 34 of those 78. The other 44 have an `appTooltip` and no `aria-label`, and the detection script in the issue skips them for exactly that reason. Happy to follow up with a second PR covering those 44 if you agree with the reading, or to fold them into this one if you would rather have it in a single change.

Two smaller notes on counting. The issue says 38 in 19 files; I get 34 strictly icon-only in 19 files. The other 4 (`journal-entry-form` "Add Debit" and "Add Credit", `clients-list`, `asset-owner-view`) do have visible text, so they already have an accessible name. Their text is hardcoded English rather than a translation key, which is a real bug but an i18n one, so I left them out of an accessibility fix. Say the word and I will raise it separately.

## Verification

All run against this branch in a clean container (node 22.23.2):

* `npm run lint:prune` passes, and `eslint-suppressions.json` is unchanged, so no suppressed violation was disturbed.
* `npm run format:check`, `npx eslint "src/**/*.html"`, `npm run i18n:check`, `npm run check:icons`, `./scripts/check-license.sh` all pass.
* `npm run build` passes. It was the build that caught the two components missing a translation pipe, which lint alone did not.
* `npm test` passes: 897 of 897, up from 896.
* `./scripts/verify-signed-commits.sh` reports 0 unsigned commits.

On the added test, I checked it is not vacuous: stripping the two `aria-label`s back out of `business-steps.component.ts` turns it red (1 FAILED, 896 SUCCESS), and restoring them turns it green again.

I also confirmed the mechanism rather than assuming it. `@ionic/core`'s button calls `inheritAriaAttributes(this.el)` and spreads the result onto the inner `button.button-native`, so an `aria-label` on the `<ion-button>` host does reach the native button and does become its accessible name.

## Screenshots

No visual change. `aria-label` renders nothing on screen, and the elements are unchanged in size and position.

The one user-visible difference is that the eight buttons that had a native `title` no longer show a browser tooltip on hover. For five of them that tooltip was untranslated English. If you want hover help preserved on any of these, the house pattern is `appTooltip`, and I am glad to add it alongside the label.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. No workflow changes here: this adds an attribute and removes a `title`, with no change to what any button does. Existing e2e specs select on `data-testid` and `id`, neither of which moved.
- [x] Commits are signed.
