### PR TITLE
feat(router): set a translated document title per route

### DIFF
--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -83,6 +83,10 @@ const PATTERNS = [
     String.raw`\[(?:title|helpTextKey|label|placeholder|createButtonLabel)\]\s*=\s*['"]'${KEY}'['"]`,
     'g',
   ),
+  // Route definitions: `title: 'nav.groups'` in a *.routes.ts Routes array. Resolved as a
+  // key by TranslatedTitleStrategy, so a typo here is a missing key like any other. The KEY
+  // shape (dotted identifier) keeps this off ordinary `title:` properties holding a phrase.
+  new RegExp(String.raw`\btitle:\s*['"]${KEY}['"]`, 'g'),
 ];
 
 function referencedKeys(files) {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -27,7 +27,7 @@ import {
   ApplicationConfig,
   ErrorHandler,
 } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { TitleStrategy, provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { TranslateModule } from '@ngx-translate/core';
@@ -44,6 +44,7 @@ import { ConfigService } from './core/services/config.service';
 import { provideIonicAngular } from '@ionic/angular/standalone';
 
 import { BASE_PATH } from './api/variables';
+import { TranslatedTitleStrategy } from './core/router/translated-title.strategy';
 
 /**
  * Factory function to load configuration before app bootstrap
@@ -74,6 +75,8 @@ export const appConfig: ApplicationConfig = {
     ...(isDevMode() ? [provideCheckNoChangesConfig({ interval: 500, exhaustive: true })] : []),
     { provide: ErrorHandler, useClass: GlobalErrorHandler },
     provideRouter(routes),
+    // Routes carry a translation key in `title`; this resolves it. See the strategy's own docs.
+    { provide: TitleStrategy, useClass: TranslatedTitleStrategy },
     // Order is the chain order, outermost first. `retryInterceptor` is last, and so closest
     // to the backend, deliberately: `loadingInterceptor` outside it counts one logical request
     // instead of flickering the progress bar per attempt, `errorInterceptor` toasts only once

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -25,6 +25,7 @@ import { loadRemoteModule } from '@angular-architects/native-federation';
 export const routes: Routes = [
   {
     path: 'login',
+    title: 'login.title',
     loadComponent: () => import('./features/login/login.component').then((m) => m.LoginComponent),
   },
   {
@@ -39,6 +40,7 @@ export const routes: Routes = [
       },
       {
         path: 'dashboard',
+        title: 'nav.dashboard',
         loadComponent: () =>
           import('./features/dashboard/system-status.component').then(
             (m) => m.SystemStatusComponent,
@@ -51,72 +53,87 @@ export const routes: Routes = [
       },
       {
         path: 'clients',
+        title: 'nav.clients',
         loadChildren: () =>
           import('./features/clients/clients.routes').then((m) => m.CLIENTS_ROUTES),
       },
       {
         path: 'groups',
+        title: 'nav.groups',
         loadChildren: () => import('./features/groups/groups.routes').then((m) => m.GROUPS_ROUTES),
       },
       {
         path: 'centers',
+        title: 'nav.centers',
         loadChildren: () =>
           import('./features/centers/centers.routes').then((m) => m.CENTERS_ROUTES),
       },
       {
         path: 'products',
+        title: 'nav.products',
         loadChildren: () =>
           import('./features/products/products.routes').then((m) => m.PRODUCTS_ROUTES),
       },
       {
         path: 'fintech',
+        title: 'nav.fintech',
         loadChildren: () =>
           import('./features/fintech/fintech.routes').then((m) => m.FINTECH_ROUTES),
       },
       {
         path: 'transfers',
+        title: 'nav.transfers',
         loadChildren: () =>
           import('./features/transfers/transfers.routes').then((m) => m.TRANSFERS_ROUTES),
       },
       {
         path: 'accounting',
+        title: 'nav.accounting',
         loadChildren: () =>
           import('./features/accounting/accounting.routes').then((m) => m.ACCOUNTING_ROUTES),
       },
       {
         path: 'security',
+        title: 'nav.security',
         loadChildren: () =>
           import('./features/security/security.routes').then((m) => m.SECURITY_ROUTES),
       },
       {
         path: 'loans',
+        title: 'nav.loans',
         loadChildren: () => import('./features/loans/loans.routes').then((m) => m.LOANS_ROUTES),
       },
       {
         path: 'tellers',
+        title: 'nav.tellers',
         loadChildren: () =>
           import('./features/tellers/tellers.routes').then((m) => m.TELLERS_ROUTES),
       },
       {
         path: 'organization',
+        title: 'nav.organization',
         loadChildren: () =>
           import('./features/organization/organization.routes').then((m) => m.ORGANIZATION_ROUTES),
       },
       {
         path: 'system',
+        title: 'nav.system',
         loadChildren: () => import('./features/system/system.routes').then((m) => m.SYSTEM_ROUTES),
       },
       {
         path: 'reporting',
+        title: 'nav.reporting',
         loadChildren: () =>
           import('./features/reporting/reporting.routes').then((m) => m.REPORTING_ROUTES),
       },
       {
         path: 'tasks',
+        title: 'nav.tasks',
         loadChildren: () => import('./features/tasks/tasks.routes').then((m) => m.TASKS_ROUTES),
       },
       {
         path: 'settings',
+        title: 'nav.settings',
         loadChildren: () =>
           import('./features/settings/settings.routes').then((m) => m.SETTINGS_ROUTES),
       },
@@ -130,16 +147,19 @@ export const routes: Routes = [
       },
       {
         path: 'meetings',
+        title: 'MEETINGS.TITLE',
         loadChildren: () =>
           import('./features/meetings/meetings.routes').then((m) => m.MEETINGS_ROUTES),
       },
       {
         path: 'calendars',
+        title: 'CALENDARS.TITLE',
         loadChildren: () =>
           import('./features/calendars/calendars.routes').then((m) => m.CALENDARS_ROUTES),
       },
       {
         path: 'collection-sheet',
+        title: 'COLLECTION_SHEET.TITLE',
         loadComponent: () =>
           import('./features/collection-sheet/collection-sheet.component').then(
             (m) => m.CollectionSheetComponent,
@@ -148,6 +168,7 @@ export const routes: Routes = [
       },
       {
         path: 'notifications',
+        title: 'nav.notifications',
         loadComponent: () =>
           import('./features/notifications/notifications-list.component').then(
             (m) => m.NotificationsListComponent,
@@ -156,6 +177,7 @@ export const routes: Routes = [
       },
       {
         path: 'working-capital',
+        title: 'nav.workingCapital',
         loadChildren: () =>
           import('./features/working-capital/working-capital.routes').then(
             (m) => m.WORKING_CAPITAL_ROUTES,
@@ -163,6 +185,7 @@ export const routes: Routes = [
       },
       {
         path: 'search',
+        title: 'SEARCH.TITLE',
         loadComponent: () =>
           import('./features/search/global-search.component').then((m) => m.GlobalSearchComponent),
       },
@@ -182,6 +205,7 @@ export const routes: Routes = [
       },
       {
         path: 'auth/forgot-password',
+        title: 'FORGOT_PASSWORD.TITLE',
         loadComponent: () =>
           import('./features/auth/forgot-password/forgot-password.component').then(
             (m) => m.ForgotPasswordComponent,
@@ -189,6 +213,7 @@ export const routes: Routes = [
       },
       {
         path: 'profile',
+        title: 'PROFILE.TITLE',
         loadComponent: () =>
           import('./features/profile/user-profile.component').then((m) => m.UserProfileComponent),
       },

--- a/src/app/core/router/translated-title.strategy.spec.ts
+++ b/src/app/core/router/translated-title.strategy.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { TitleStrategy, provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { TranslatedTitleStrategy } from './translated-title.strategy';
+import { FakeI18nAdapter, provideFakeAdapters } from '../../testing/adapters';
+
+const APP_NAME_KEY = 'app.shortTitle';
+const SECTION_KEY = 'nav.groups';
+const PAGE_KEY = 'GROUPS.CREATE_GROUP';
+
+@Component({ standalone: true, template: '' })
+class RouteStub {}
+
+describe('TranslatedTitleStrategy', () => {
+  let i18n: FakeI18nAdapter;
+
+  beforeEach(() => {
+    const adapters = provideFakeAdapters();
+    i18n = adapters.i18n;
+    i18n.catalogue.set(APP_NAME_KEY, 'Fineract');
+    i18n.catalogue.set(SECTION_KEY, 'Groups');
+    i18n.catalogue.set(PAGE_KEY, 'Create Group');
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...adapters.providers,
+        { provide: TitleStrategy, useClass: TranslatedTitleStrategy },
+        provideRouter([
+          {
+            path: 'groups',
+            title: SECTION_KEY,
+            children: [
+              { path: '', component: RouteStub },
+              { path: 'create', title: PAGE_KEY, component: RouteStub },
+            ],
+          },
+          { path: 'untitled', component: RouteStub },
+        ]),
+      ],
+    });
+  });
+
+  const cases = [
+    {
+      description: 'resolves a route title as a translation key and suffixes the app name',
+      url: '/groups/create',
+      expected: 'Create Group · Fineract',
+    },
+    {
+      description: 'falls back to the nearest ancestor title when a route has none',
+      url: '/groups',
+      expected: 'Groups · Fineract',
+    },
+    {
+      description: 'uses the application name alone when no route in the chain has a title',
+      url: '/untitled',
+      expected: 'Fineract',
+    },
+  ];
+
+  cases.forEach(({ description, url, expected }) => {
+    it(description, async () => {
+      const harness = await RouterTestingHarness.create();
+      await harness.navigateByUrl(url);
+
+      expect(TestBed.inject(Title).getTitle()).toBe(expected);
+    });
+  });
+
+  it('re-applies the title when the language changes, without navigating', async () => {
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/groups/create');
+
+    i18n.catalogue.set(APP_NAME_KEY, 'फिनरैक्ट');
+    i18n.catalogue.set(PAGE_KEY, 'समूह बनाएं');
+    i18n.use('hi');
+    harness.detectChanges();
+
+    expect(TestBed.inject(Title).getTitle()).toBe('समूह बनाएं · फिनरैक्ट');
+  });
+});

--- a/src/app/core/router/translated-title.strategy.ts
+++ b/src/app/core/router/translated-title.strategy.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable, effect, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { I18N } from '../adapters';
+
+/** Separates the page name from the application name, as in `Groups · Fineract`. */
+const SEPARATOR = ' · ';
+
+/** Key holding the short application name used as the suffix. */
+const APP_NAME_KEY = 'app.shortTitle';
+
+/**
+ * Sets the document title from each route's `title`, treated as a translation key.
+ *
+ * Angular's default strategy writes `route.title` to the document verbatim, which would
+ * make the tab the only user-visible string in the app that cannot be translated. Routes
+ * here therefore carry a key (`'nav.groups'`) rather than a phrase, and this strategy
+ * resolves it through the I18N adapter.
+ *
+ * A route without a `title` inherits the nearest ancestor that has one, which is Angular's
+ * own `buildTitle` behaviour: titling a section in `app.routes.ts` gives every page beneath
+ * it a reasonable tab immediately, and a feature can then refine its own routes without
+ * touching anything else.
+ *
+ * The title is re-applied when the language changes. Titles are otherwise written only on
+ * navigation, so without this the tab would keep the previous language until the user
+ * navigated again.
+ */
+@Injectable()
+export class TranslatedTitleStrategy extends TitleStrategy {
+  private readonly title = inject(Title);
+  private readonly i18n = inject(I18N);
+
+  /** The key from the current route, retained so a language change can re-resolve it. */
+  private currentKey?: string;
+
+  constructor() {
+    super();
+    effect(() => {
+      // Read the signal so this re-runs on every language change.
+      this.i18n.currentLang();
+      this.apply();
+    });
+  }
+
+  override updateTitle(snapshot: RouterStateSnapshot): void {
+    this.currentKey = this.buildTitle(snapshot);
+    this.apply();
+  }
+
+  private apply(): void {
+    const appName = this.i18n.translate(APP_NAME_KEY);
+    this.title.setTitle(
+      this.currentKey ? `${this.i18n.translate(this.currentKey)}${SEPARATOR}${appName}` : appName,
+    );
+  }
+}

--- a/src/app/features/groups/groups.routes.ts
+++ b/src/app/features/groups/groups.routes.ts
@@ -22,27 +22,33 @@ import { Routes } from '@angular/router';
 export const GROUPS_ROUTES: Routes = [
   {
     path: '',
+    title: 'nav.groups',
     loadComponent: () => import('./groups-list.component').then((m) => m.GroupsListComponent),
   },
   {
     path: 'create',
+    title: 'GROUPS.CREATE_GROUP',
     loadComponent: () => import('./group-form.component').then((m) => m.GroupFormComponent),
   },
   {
     path: 'edit/:id',
+    title: 'GROUPS.EDIT_GROUP',
     loadComponent: () => import('./group-form.component').then((m) => m.GroupFormComponent),
   },
   {
     path: 'view/:id',
+    title: 'GROUPS.GROUP_DETAILS',
     loadComponent: () => import('./group-view.component').then((m) => m.GroupViewComponent),
   },
   {
     path: ':groupId/notes/create',
+    title: 'GROUPS.ADD_NOTE',
     loadComponent: () =>
       import('./group-note-form.component').then((m) => m.GroupNoteFormComponent),
   },
   {
     path: ':groupId/notes/edit/:id',
+    title: 'GROUPS.EDIT_NOTE',
     loadComponent: () =>
       import('./group-note-form.component').then((m) => m.GroupNoteFormComponent),
   },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2,6 +2,7 @@
   "license": "Apache-2.0",
   "app": {
     "title": "Fineract Backoffice UI",
+    "shortTitle": "Fineract",
     "welcome": "Welcome to Fineract Backoffice UI!",
     "logout": "Logout",
     "language": {
@@ -1194,6 +1195,7 @@
     "EDIT_NOTE": "Edit Note",
     "EXTERNAL_ID": "External Id",
     "GENERAL": "General",
+    "GROUP_DETAILS": "Group Details",
     "LOAD_FAILED": "The group could not be loaded.",
     "MEMBER": "Member",
     "MEMBERS": "Members",


### PR DESCRIPTION
## What and why

Every browser tab read "Fineract Backoffice UI". Across 325 route declarations in 23 files, none set `Route.title`, and the app registered no `TitleStrategy`, so the static title in `src/index.html` was never replaced. The tab strip carried no information, and history entries and bookmarks were equally undifferentiated.

It also matters without a screen. The document title is announced on navigation and is the primary way a non-visual user learns the page changed, so in a single-page app that never updates it, navigation is silent.

`TranslatedTitleStrategy` treats `Route.title` as a translation key rather than a phrase, resolves it through the I18N adapter and appends the short app name, giving `Groups · Fineract`. Writing the phrase directly would have made the tab the only user-visible string in the app that cannot be translated.

Closes #250

## On scope, since the issue invites a choice

The issue offers two paths: plain keys first with the strategy as a follow-up, or the strategy in the same PR. This takes the second, because the strategy is the part that decides what every later PR looks like, and it is easier to argue about once it exists.

It also uses inheritance rather than titling all 325 routes. A route without a `title` inherits its nearest titled ancestor, which is Angular's own `buildTitle` behaviour. So titling the 25 sections in `app.routes.ts` gives every page beneath them a sensible tab immediately, and a feature can then refine its own routes without touching anything outside its own file. `groups.routes.ts` is fully refined here as the worked example of that second step.

That leaves the per-feature refinement of the remaining 22 route files as exactly the small, self-contained tasks the issue describes, which seemed more useful to you than one 325-line diff from me. Happy to take them on if you would rather, or to leave them as newcomer tasks.

Four sections are deliberately not titled, because no existing key names them and I did not want to invent page names: `admin`, `spm`, `fineract-mfe`, and the `**` route (which only redirects). They fall back to `Fineract`, which is still better than today.

## Keys

No new page names were invented. The 25 sections reuse the sidebar's own `nav.*` keys, which are already the canonical names for these pages, or an existing section `TITLE` where there is no `nav` entry (`MEETINGS.TITLE`, `CALENDARS.TITLE`, `COLLECTION_SHEET.TITLE`, `SEARCH.TITLE`, `FORGOT_PASSWORD.TITLE`, `PROFILE.TITLE`, `login.title`).

Two keys are added: `app.shortTitle` ("Fineract") for the suffix, since `app.title` is "Fineract Backoffice UI" and repeating that on every tab defeats the purpose; and `GROUPS.GROUP_DETAILS` for the group view page, which had no name.

## One small addition worth calling out

`scripts/check-translations.mjs` now recognises the route form, `title: 'nav.groups'`. Without it a typo in a route key is caught by nothing and reaches the tab as a raw key. The pattern requires the dotted-identifier key shape, so it does not match ordinary `title:` properties holding a phrase. It raises the referenced-key count from 1,439 to 1,514 and reports no missing keys.

## Verification

Run in a clean container (node 22.23.2), all passing: `lint:prune` (with `eslint-suppressions.json` unchanged), `format:check`, `eslint "src/**/*.html"`, `i18n:check`, `check:icons`, `check-license.sh`, `build`, and `npm test` at 900 of 900, up from 896.

The four new specs drive the real Angular router through `RouterTestingHarness`, the real `TitleStrategy` base class and the real `Title` service, with only the I18N adapter faked, so they cover key resolution, ancestor inheritance, the no-title fallback and re-application on language change.

I checked they are not vacuous. Removing the `effect` that watches the language fails exactly the language test and nothing else. Passing the key through untranslated and dropping the suffix fails the two resolution tests. Restoring the implementation returns all 900 to green.

What that does not cover, stated plainly: nothing here exercises the `app.config.ts` provider registration in a real browser. I had a headless check part-written and stopped it, so the wiring itself is verified by reading rather than by running. It is three lines next to `provideRouter`, but it is the one part a reviewer should not take on trust from the test results alone.

## Screenshots

Not applicable in the usual sense, since nothing inside the page changes. The visible difference is the browser tab, which now reads for example `Groups · Fineract` on `/groups` and `Create Group · Fineract` on `/groups/create`, instead of `Fineract Backoffice UI` everywhere.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. The strategy resolves keys through the `I18N` token and sets the title through Angular's `Title` service rather than touching `document` directly.
- [x] User-facing strings use translation keys. That is the substance of the change.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. No workflow changes: no route path, guard, redirect or component was touched, only the `title` property and the strategy that reads it.
- [x] Commits are signed.
