### PR TITLE
refactor(transfers): use formatArrayDate helper

### DIFF
--- a/src/app/features/transfers/standing-instruction-form.component.spec.ts
+++ b/src/app/features/transfers/standing-instruction-form.component.spec.ts
@@ -198,6 +198,7 @@ describe('StandingInstructionFormComponent', () => {
         instructionsServiceSpy.getStandinginstructionsStandingInstructionId,
       ).toHaveBeenCalledWith(99);
       expect(component.request.name).toBe('Existing SI');
+      expect(component.validFrom).toBe('2026-06-16');
 
       component.onSubmit();
       expect(

--- a/src/app/features/transfers/standing-instruction-form.component.ts
+++ b/src/app/features/transfers/standing-instruction-form.component.ts
@@ -49,6 +49,7 @@ import {
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
+  formatArrayDate,
   toIsoDate,
 } from '../../core/utils/date-formatter';
 
@@ -549,8 +550,7 @@ export class StandingInstructionFormComponent implements OnInit {
 
   private populateDates(data: GetStandingInstructionsStandingInstructionIdResponse): void {
     if (data.validFrom) {
-      const vf = data.validFrom as unknown as number[];
-      this.validFrom = toIsoDate(new Date(vf[0], vf[1] - 1, vf[2]));
+      this.validFrom = formatArrayDate(data.validFrom);
     }
     const rawData = data as unknown as Record<string, unknown>;
     if (rawData['validTill']) {


### PR DESCRIPTION
## What and why

Replace the manual Fineract array-date conversion in the standing instruction form with the existing `formatArrayDate` helper. This covers the `transfers` feature-directory portion of #257 and leaves the existing `validTill` handling unchanged.

Closes #257

## Verification

- `npm test -- --watch=false --include=src/app/features/transfers/standing-instruction-form.component.spec.ts` (5 tests)
- `npm test -- --watch=false` (896 tests)
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run check:icons`
- `npm run i18n:check`
- `./scripts/check-license.sh`
- `./scripts/verify-signed-commits.sh --base-ref fork/main --head-ref HEAD --strict`

## Screenshots

Not applicable; this is a behavior-preserving date-formatting refactor.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. No new component or service code was added.
- [x] User-facing strings use translation keys. No user-facing strings changed.
- [x] I added or updated tests appropriate to this change.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. No UI workflow changed.
- [x] Commits are signed - see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.