### PR TITLE
refactor(loans): use formatArrayDate helper

### DIFF
--- a/src/app/features/loans/guarantors/guarantor-form.component.ts
+++ b/src/app/features/loans/guarantors/guarantor-form.component.ts
@@ -25,6 +25,7 @@ import { GuarantorsService, GuarantorsRequest, EnumOptionData } from '../../../a
 import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
+  formatArrayDate,
   formatDateToFineract,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
@@ -277,9 +278,7 @@ export class GuarantorFormComponent implements OnInit {
         if (data.dob) {
           const dob = data.dob as unknown as number[];
           this.dobDate.set(
-            Array.isArray(dob)
-              ? toIsoDate(new Date(dob[0], dob[1] - 1, dob[2]))
-              : toIsoDate(new Date(data.dob)),
+            Array.isArray(dob) ? formatArrayDate(dob) : toIsoDate(new Date(data.dob)),
           );
         }
       });

--- a/src/app/features/loans/loan-form.component.ts
+++ b/src/app/features/loans/loan-form.component.ts
@@ -62,6 +62,7 @@ import {
   IonSpinner,
 } from '@ionic/angular/standalone';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -603,15 +604,11 @@ export class LoanFormComponent implements OnInit {
       next: (data: GetLoansLoanIdResponse) => {
         const subDateArray = data.timeline?.submittedOnDate as unknown as number[];
         if (subDateArray) {
-          this.submittedOnDate.set(
-            toIsoDate(new Date(subDateArray[0], subDateArray[1] - 1, subDateArray[2])),
-          );
+          this.submittedOnDate.set(formatArrayDate(subDateArray));
         }
         const expDisbDateArray = data.timeline?.expectedDisbursementDate as unknown as number[];
         if (expDisbDateArray) {
-          this.expectedDisbursementDate.set(
-            toIsoDate(new Date(expDisbDateArray[0], expDisbDateArray[1] - 1, expDisbDateArray[2])),
-          );
+          this.expectedDisbursementDate.set(formatArrayDate(expDisbDateArray));
         }
 
         this.loan.set({

--- a/src/app/features/loans/transaction-detail-dialog.component.ts
+++ b/src/app/features/loans/transaction-detail-dialog.component.ts
@@ -38,7 +38,7 @@ import {
   IonTextarea,
   ModalController,
 } from '@ionic/angular/standalone';
-import { toIsoDate } from '../../core/utils/date-formatter';
+import { formatArrayDate, toIsoDate } from '../../core/utils/date-formatter';
 
 export interface TransactionDetailDialogData {
   loanId: number;
@@ -260,7 +260,7 @@ export class TransactionDetailDialogComponent implements OnInit {
           this.adjustAmount.set(data.amount ?? 0);
           const dateArray = data.date as unknown as number[];
           if (Array.isArray(dateArray)) {
-            this.adjustDate.set(toIsoDate(new Date(dateArray[0], dateArray[1] - 1, dateArray[2])));
+            this.adjustDate.set(formatArrayDate(dateArray));
           }
         },
         error: (err) => console.error('Failed to load transaction detail', err),


### PR DESCRIPTION
## What and why

Replace the four manual array-to-Date round trips in the `loans` feature directory with the existing `formatArrayDate` helper. Existing missing-date guards remain in place, and the guarantor fallback for non-array dates is unchanged.

Part of #257.

## Verification

- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` (930 tests)
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run i18n:check`
- `npm run check:icons`
- `bash scripts/check-license.sh`
- `npm audit --audit-level=high --omit=dev`
- `git diff --check`

`npm run api:surface` still reports the 16 manifest omissions already present on current `main`; none is in the three files changed here.

## Screenshots

Not applicable; this is a behavior-preserving date-formatting refactor.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary for generated API interaction. (No new component or service code.)
- [x] User-facing strings use translation keys. (No user-facing strings changed.)
- [x] I added or updated tests appropriate to the change. (Existing date formatter coverage plus the full 930-test suite; no new behavior.)
- [x] UI workflow changes include suitable e2e coverage. (No UI workflow changed.)
- [x] Commits are signed.
