### PR TITLE
refactor(products): use formatArrayDate helper

### DIFF
--- a/src/app/features/products/savings-account-form.component.ts
+++ b/src/app/features/products/savings-account-form.component.ts
@@ -50,6 +50,7 @@ import {
   SavingsAccountData,
 } from '../../api';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -295,9 +296,7 @@ export class SavingsAccountFormComponent implements OnInit {
       next: (data: SavingsAccountData) => {
         const dateArray = data.timeline?.submittedOnDate as unknown as number[];
         if (dateArray) {
-          this.submittedOnDate.set(
-            toIsoDate(new Date(dateArray[0], dateArray[1] - 1, dateArray[2])),
-          );
+          this.submittedOnDate.set(formatArrayDate(dateArray));
         }
         this.account.set({
           clientId: data.clientId,


### PR DESCRIPTION
## What and why

Replace the manual Fineract array-date -> JavaScript `Date` -> ISO round trip in the `products` feature directory with the existing `formatArrayDate` helper.

This keeps the change scoped to `products/`, as requested by #257, and removes the repeated month-offset conversion from `savings-account-form.component.ts`.

Part of #257.

## Verification

- PASS: `prettier --check src/app/features/products/savings-account-form.component.ts`
- PASS: `npm run lint`
- PASS: `npm test -- --watch=false`
- PASS: `npm run build`
- PASS: `npm run check:icons`
- PASS: `npm run i18n:check`
- PASS: `git diff --check`

## Scope

- `src/app/features/products/savings-account-form.component.ts`
- No changes to `toLocaleDateString()` sites
- No changes outside the `products/` feature directory