### PR TITLE
feat(centers): give a center a detail view, so it can be operated

### DIFF
--- a/e2e/center-servicing.spec.ts
+++ b/e2e/center-servicing.spec.ts
@@ -40,7 +40,7 @@
 import { expect, test } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { ionSelect } from './utils/ionic-locators';
-import { createApiContext, seedCenter, seedGroup } from './utils/seed-api';
+import { createApiContext, seedCenter, seedGroup, seedStaff } from './utils/seed-api';
 
 test.describe('Center servicing', () => {
   test('a center is activated, staffed and given a group', async ({ page }) => {
@@ -50,6 +50,9 @@ test.describe('Center servicing', () => {
     const suffix = uniqueSuffix();
     const center = await seedCenter(api, `E2ECenter ${suffix}`);
     const group = await seedGroup(api, `E2ECenterGroup ${suffix}`);
+    // Seeded rather than assumed: a fresh instance has no staff at all, so the picker — which is
+    // scoped to the office because the platform refuses staff from another one — would be empty.
+    const staff = await seedStaff(api, 'E2ECenterStaff');
     await api.dispose();
 
     await login(page);
@@ -73,11 +76,19 @@ test.describe('Center servicing', () => {
     // platform answers validation.msg.center.name.cannot.be.blank, which reads like a form bug.
     await page.getByTestId('center-actions').click();
     await page.getByTestId('center-action-assign-staff').click();
+    // Not `selectOption`: it waits for every overlay to close first, and this page keeps a
+    // declarative <ion-popover trigger="…"> mounted for the actions menu, so that never holds.
+    // The radio is addressed by name instead — the actions popover has none.
     await ionSelect(page, 'Staff').click();
-    await page.locator('ion-alert, ion-popover').getByRole('radio').first().click();
+    await page
+      .locator('ion-alert, ion-popover, ion-action-sheet')
+      .getByRole('radio', { name: staff.staffName, exact: true })
+      .click();
     await page.getByTestId('center-staff-confirm').click();
 
-    await expect(page.getByTestId('center-staff-name')).not.toHaveText('Unassigned', {
+    // Asserted by name, not merely by "not Unassigned": that proves the chosen officer is the one
+    // the update carried, which is the whole point of scoping the picker to the office.
+    await expect(page.getByTestId('center-staff-name')).toHaveText(staff.staffName, {
       timeout: 20000,
     });
 

--- a/e2e/center-servicing.spec.ts
+++ b/e2e/center-servicing.spec.ts
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The center detail view, end to end against a real Fineract.
+ *
+ * A center could be created and renamed and nothing else: `centers.routes.ts` declared list,
+ * create and edit, so its groups could not be seen, staff could not be assigned, and it could not
+ * be activated. For centre-based lending the center is the unit of daily work.
+ *
+ * Three things here are specific to centers and are why this is its own suite:
+ *
+ * - The read must name the association. `associations=all` returns *nothing* extra on a center,
+ *   so the groups tab would be empty by construction under the parameter that sounds right.
+ * - Staff assignment is a `PUT` carrying the unchanged `name`, not a command — the platform
+ *   exposes no `assignStaff` for a center, and rejects the update without a name.
+ * - Unassignment is reachable only through the *groups* resource, because a center is a group at
+ *   a higher level. The center endpoint has no such command, `staffId: null` is ignored and
+ *   `staffId: -1` is refused for not being greater than zero.
+ *
+ *   npx playwright test e2e/center-servicing.spec.ts --project=backend --workers=1
+ */
+
+import { expect, test } from './fixtures';
+import { login, uniqueSuffix } from './utils/fineract-login';
+import { ionSelect } from './utils/ionic-locators';
+import { createApiContext, seedCenter, seedGroup } from './utils/seed-api';
+
+test.describe('Center servicing', () => {
+  test('a center is activated, staffed and given a group', async ({ page }) => {
+    test.setTimeout(240000);
+
+    const api = await createApiContext();
+    const suffix = uniqueSuffix();
+    const center = await seedCenter(api, `E2ECenter ${suffix}`);
+    const group = await seedGroup(api, `E2ECenterGroup ${suffix}`);
+    await api.dispose();
+
+    await login(page);
+    await page.goto(`/centers/view/${center.centerId}`);
+
+    await expect(page.getByTestId('center-name')).toContainText(center.centerName, {
+      timeout: 20000,
+    });
+    await expect(page.getByTestId('center-status')).toContainText(/pending/i);
+    await expect(page.getByTestId('center-group-count')).toHaveText('0');
+
+    // --- Activate ------------------------------------------------------------------------------
+    await page.getByTestId('center-actions').click();
+    await page.getByTestId('center-action-activate').click();
+    await page.getByTestId('center-action-confirm').click();
+    await expect(page.getByTestId('center-status')).toContainText(/active/i, { timeout: 20000 });
+
+    // --- Assign staff --------------------------------------------------------------------------
+    //
+    // The assignment goes out as a PUT carrying the center's unchanged name. Without it the
+    // platform answers validation.msg.center.name.cannot.be.blank, which reads like a form bug.
+    await page.getByTestId('center-actions').click();
+    await page.getByTestId('center-action-assign-staff').click();
+    await ionSelect(page, 'Staff').click();
+    await page.locator('ion-alert, ion-popover').getByRole('radio').first().click();
+    await page.getByTestId('center-staff-confirm').click();
+
+    await expect(page.getByTestId('center-staff-name')).not.toHaveText('Unassigned', {
+      timeout: 20000,
+    });
+
+    // --- Attach a group ------------------------------------------------------------------------
+    //
+    // Candidates come from `orphansOnly=true`, the platform's own filter for groups that do not
+    // already belong to a center — a group has at most one parent.
+    await page.getByTestId('center-actions').click();
+    await page.getByTestId('center-action-attach-groups').click();
+    await page.getByTestId(`center-group-${group.groupId}`).click();
+    await page.getByTestId('center-groups-confirm').click();
+
+    await expect(page.getByTestId('center-group-count')).toHaveText('1', { timeout: 20000 });
+    await expect(page.getByTestId('center-groups-table')).toContainText(group.groupName);
+
+    // The group links to its own detail view, which is the point of listing it here.
+    await expect(page.getByTestId('center-group-link').first()).toHaveAttribute(
+      'href',
+      new RegExp(`/groups/view/${group.groupId}$`),
+    );
+
+    // --- Unassign staff, through the groups resource --------------------------------------------
+    await page.getByTestId('center-actions').click();
+    await page.getByTestId('center-action-unassign-staff').click();
+    await page.getByRole('button', { name: /^(confirm|yes|ok)$/i }).click();
+    await expect(page.getByTestId('center-staff-name')).toHaveText('Unassigned', {
+      timeout: 20000,
+    });
+
+    // --- Detach the group ----------------------------------------------------------------------
+    await page.getByTestId('center-actions').click();
+    await page.getByTestId('center-action-detach-groups').click();
+    await page.getByTestId(`center-group-${group.groupId}`).click();
+    await page.getByTestId('center-groups-confirm').click();
+    await expect(page.getByTestId('center-group-count')).toHaveText('0', { timeout: 20000 });
+
+    // --- Schedule the meeting -------------------------------------------------------------------
+    //
+    // Only offered on an active center: a meeting that starts before the activation date is
+    // refused with validation.msg.calendar.cannot.be.before.centers.activation.date.
+    await expect(page.getByTestId('center-meeting')).toHaveText('—');
+    await page.getByTestId('center-actions').click();
+    await page.getByTestId('center-action-meeting').click();
+    // Fill the native input Ionic renders, which is what carries the `name` and what the
+    // ngModel binding listens to; filling the ion-input host does not update the model.
+    await page.locator('input[name="title"]').fill('Weekly collection');
+    await page.getByTestId('center-meeting-confirm').click();
+
+    await expect(page.getByTestId('center-meeting')).toContainText('Weekly collection', {
+      timeout: 20000,
+    });
+  });
+
+  /**
+   * Notes are read and written through the groups resource: `/centers/{id}/notes` answers 404
+   * "Note does not support resource centers", while `/groups/{centerId}/notes` stores one.
+   */
+  test('notes are recorded against the center', async ({ page }) => {
+    test.setTimeout(180000);
+
+    const api = await createApiContext();
+    const center = await seedCenter(api, `E2ECenterNotes ${uniqueSuffix()}`);
+    await api.dispose();
+
+    await login(page);
+    await page.goto(`/centers/view/${center.centerId}`);
+    await expect(page.getByTestId('center-name')).toContainText(center.centerName, {
+      timeout: 20000,
+    });
+
+    await page.getByTestId('center-tab-notes').click();
+    await expect(page.getByTestId('center-notes')).toBeVisible({ timeout: 20000 });
+
+    await page.getByTestId('group-add-note').click();
+    // The form is the group one, reused because the endpoint is the group one — but it must come
+    // back to the center rather than to a group view that would not exist.
+    await expect(page).toHaveURL(new RegExp(`/centers/${center.centerId}/notes/create$`), {
+      timeout: 20000,
+    });
+    await page.locator('textarea[name="note"]').fill('Recorded from the center view');
+    await page.getByRole('button', { name: /^save$/i }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/centers/view/${center.centerId}$`), {
+      timeout: 20000,
+    });
+    await page.getByTestId('center-tab-notes').click();
+    await expect(page.getByTestId('center-notes')).toContainText('Recorded from the center view', {
+      timeout: 20000,
+    });
+  });
+});

--- a/e2e/utils/seed-api.ts
+++ b/e2e/utils/seed-api.ts
@@ -767,3 +767,33 @@ export async function seedGroup(
   });
   return { groupId: resourceId, groupName };
 }
+
+export interface SeededStaff {
+  staffId: number;
+  staffName: string;
+}
+
+/**
+ * A member of staff in the head office.
+ *
+ * Seeded rather than assumed: a fresh Fineract has none, and a staff picker scoped to the office
+ * — as every one of them is, because the platform refuses staff from another office — then has
+ * nothing to offer. `displayName` comes back as "lastname, firstname", which is what the pickers
+ * show.
+ */
+export async function seedStaff(
+  api: APIRequestContext,
+  namePrefix = 'E2EStaff',
+): Promise<SeededStaff> {
+  const lastname = `${namePrefix}${seedSuffix()}`;
+  const { resourceId } = await post<{ resourceId: number }>(api, '/staff', {
+    officeId: 1,
+    firstname: 'Field',
+    lastname,
+    isLoanOfficer: true,
+    joiningDate: fineractDate(new Date(2020, 0, 1)),
+    locale: LOCALE,
+    dateFormat: DATE_FORMAT,
+  });
+  return { staffId: resourceId, staffName: `${lastname}, Field` };
+}

--- a/e2e/utils/seed-api.ts
+++ b/e2e/utils/seed-api.ts
@@ -720,3 +720,50 @@ export async function seedChartReport(
   });
   return { reportId: resourceId, reportName };
 }
+
+export interface SeededCenter {
+  centerId: number;
+  centerName: string;
+}
+
+/** A pending center, which is where the lifecycle actions on the detail view start. */
+export async function seedCenter(
+  api: APIRequestContext,
+  namePrefix = 'E2ECenter',
+): Promise<SeededCenter> {
+  const centerName = `${namePrefix} ${seedSuffix()}`;
+  const { resourceId } = await post<{ resourceId: number }>(api, '/centers', {
+    name: centerName,
+    officeId: 1,
+    active: false,
+    locale: LOCALE,
+    dateFormat: DATE_FORMAT,
+  });
+  return { centerId: resourceId, centerName };
+}
+
+export interface SeededGroup {
+  groupId: number;
+  groupName: string;
+}
+
+/**
+ * A group with no parent center, so it is a candidate for attaching to one.
+ *
+ * `GET /groups?orphansOnly=true` is what the attach dialog offers, and a group already held by a
+ * center is excluded from it — a group has at most one parent.
+ */
+export async function seedGroup(
+  api: APIRequestContext,
+  namePrefix = 'E2EGroup',
+): Promise<SeededGroup> {
+  const groupName = `${namePrefix} ${seedSuffix()}`;
+  const { resourceId } = await post<{ resourceId: number }>(api, '/groups', {
+    name: groupName,
+    officeId: 1,
+    active: false,
+    locale: LOCALE,
+    dateFormat: DATE_FORMAT,
+  });
+  return { groupId: resourceId, groupName };
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,7 @@ import { defineConfig, devices } from '@playwright/test';
  * A spec belongs here if it contains no page.route() mocks.
  */
 const BACKEND_SPECS = [
+  'center-servicing.spec.ts',
   'client-transfer.spec.ts',
   'deposit-account-servicing.spec.ts',
   'deposit-product-configuration.spec.ts',

--- a/src/app/features/centers/center-action-dialog.component.ts
+++ b/src/app/features/centers/center-action-dialog.component.ts
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  IonButton,
+  IonDatetime,
+  IonDatetimeButton,
+  IonItem,
+  IonLabel,
+  IonModal,
+  IonSelect,
+  IonSelectOption,
+} from '@ionic/angular/standalone';
+
+import { CentersService } from '../../api';
+import { OVERLAY, TranslatePipe } from '../../core/adapters';
+
+export interface CenterActionDialogData {
+  command: 'activate' | 'close';
+}
+
+export interface CenterActionResult {
+  date: string;
+  closureReasonId?: number;
+}
+
+/**
+ * Collects the date, and for a closure the reason, that `activate` and `close` require.
+ *
+ * Closure reasons come from `GET /centers/template?command=close` rather than from the plain
+ * template, which carries only office and staff options. They are code values of
+ * `CenterClosureReason`, and that code ships with no values: an institution that has not populated
+ * it cannot close a center at all, because the platform rejects the request for a missing
+ * `closureReasonId`. An empty list is therefore explained on screen rather than left as a select
+ * that appears broken.
+ */
+@Component({
+  selector: 'app-center-action-dialog',
+  standalone: true,
+  imports: [
+    FormsModule,
+    TranslatePipe,
+    IonItem,
+    IonLabel,
+    IonSelect,
+    IonSelectOption,
+    IonButton,
+    IonDatetime,
+    IonDatetimeButton,
+    IonModal,
+  ],
+  template: `
+    <h2 class="dialog-title">
+      {{ (data().command === 'activate' ? 'CENTERS.ACTIVATE' : 'CENTERS.CLOSE') | appTranslate }}
+    </h2>
+    <div class="dialog-content">
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">
+          {{
+            (data().command === 'activate' ? 'CENTERS.ACTIVATION_DATE' : 'CENTERS.CLOSURE_DATE')
+              | appTranslate
+          }}
+        </ion-label>
+        <ion-datetime-button
+          data-testid="center-action-date-button"
+          datetime="center-action-date"
+        ></ion-datetime-button>
+        <ion-modal [keepContentsMounted]="true">
+          <ng-template>
+            <ion-datetime
+              id="center-action-date"
+              data-testid="center-action-date"
+              presentation="date"
+              [value]="date"
+              (ionChange)="onDateChange($event)"
+            ></ion-datetime>
+          </ng-template>
+        </ion-modal>
+      </ion-item>
+
+      @if (data().command === 'close') {
+        <ion-item fill="outline" class="full-width">
+          <ion-label position="stacked">{{ 'CENTERS.CLOSURE_REASON' | appTranslate }}</ion-label>
+          <ion-select
+            [attr.aria-label]="'CENTERS.CLOSURE_REASON' | appTranslate"
+            interface="popover"
+            data-testid="center-closure-reason"
+            name="closureReasonId"
+            [(ngModel)]="closureReasonId"
+          >
+            @for (reason of closureReasons(); track reason.id) {
+              <ion-select-option [value]="reason.id">{{ reason.name }}</ion-select-option>
+            }
+          </ion-select>
+        </ion-item>
+
+        @if (!closureReasons().length) {
+          <p class="field-note" data-testid="center-closure-reason-none">
+            {{ 'CENTERS.NO_CLOSURE_REASONS' | appTranslate }}
+          </p>
+        }
+      }
+    </div>
+    <div class="dialog-actions">
+      <ion-button fill="clear" color="medium" (click)="onCancel()">
+        {{ 'COMMON.CANCEL' | appTranslate }}
+      </ion-button>
+      <ion-button
+        color="primary"
+        data-testid="center-action-confirm"
+        [disabled]="!canConfirm()"
+        (click)="onConfirm()"
+      >
+        {{ 'COMMON.CONFIRM' | appTranslate }}
+      </ion-button>
+    </div>
+  `,
+  styles: [
+    `
+      .dialog-content {
+        min-width: 340px;
+      }
+      .full-width {
+        width: 100%;
+      }
+      .field-note {
+        margin: 8px 0 0;
+        font-size: 12px;
+        color: var(--text-muted, #6b7280);
+      }
+    `,
+  ],
+})
+export class CenterActionDialogComponent implements OnInit {
+  private readonly overlay = inject(OVERLAY);
+  private readonly centersService = inject(CentersService);
+
+  readonly data = input.required<CenterActionDialogData>();
+
+  readonly closureReasons = signal<{ id?: number; name?: string }[]>([]);
+  date = new Date().toISOString();
+  closureReasonId?: number;
+
+  ngOnInit(): void {
+    if (this.data().command === 'close') {
+      this.loadClosureReasons();
+    }
+  }
+
+  onDateChange(event: Event): void {
+    const value = (event as CustomEvent<{ value?: string }>).detail?.value;
+    if (value) this.date = value;
+  }
+
+  canConfirm(): boolean {
+    if (this.data().command === 'close' && !this.closureReasonId) return false;
+    return Boolean(this.date);
+  }
+
+  onCancel(): void {
+    void this.overlay.dismissModal();
+  }
+
+  onConfirm(): void {
+    if (!this.canConfirm()) return;
+    void this.overlay.dismissModal<CenterActionResult>({
+      date: this.date,
+      closureReasonId: this.closureReasonId,
+    });
+  }
+
+  private loadClosureReasons(): void {
+    // Signature: command, officeId, staffInSelectedOfficeOnly.
+    this.centersService.getCentersTemplate('close').subscribe({
+      next: (template) => {
+        const reasons = (
+          template as unknown as { closureReasons?: { id?: number; name?: string }[] }
+        ).closureReasons;
+        this.closureReasons.set(reasons ?? []);
+      },
+      error: () => this.closureReasons.set([]),
+    });
+  }
+}

--- a/src/app/features/centers/center-detail.model.ts
+++ b/src/app/features/centers/center-detail.model.ts
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * What `GET /centers/{id}` actually returns, and how a center differs from a group.
+ *
+ * A center *is* a group in the platform's data model — one at a higher `groupLevel` — and several
+ * operations are only reachable through the groups resource even for a center. Each of those is
+ * noted where it is used; they are not interchangeable in general, so the distinction is kept
+ * explicit rather than hidden behind a shared service.
+ *
+ * The generated `GetCentersCenterIdResponse` omits `status`, `active`, `staffId`, `staffName` and
+ * `groupMembers`, all of which this screen shows or gates an action on. Declaring the shape here
+ * keeps that guesswork in one reviewable place — see the same note on `group-detail.model.ts`.
+ */
+
+import { FineractDate, GroupStatus } from '../groups/group-detail.model';
+
+export type { FineractDate, GroupStatus };
+
+/** A group belonging to a center, as returned under `associations=groupMembers`. */
+export interface CenterGroupMember {
+  id?: number;
+  accountNo?: string;
+  name?: string;
+  status?: GroupStatus;
+  active?: boolean;
+  officeName?: string;
+  hierarchy?: string;
+}
+
+export interface CenterTimeline {
+  submittedOnDate?: FineractDate;
+  submittedByUsername?: string;
+  activatedOnDate?: FineractDate;
+  closedOnDate?: FineractDate;
+}
+
+export interface CenterDetail {
+  id?: number;
+  accountNo?: string;
+  name?: string;
+  externalId?: string;
+  status?: GroupStatus;
+  active?: boolean;
+  activationDate?: FineractDate;
+  officeId?: number;
+  officeName?: string;
+  staffId?: number;
+  staffName?: string;
+  hierarchy?: string;
+  /**
+   * Present only when the read asked for it by name.
+   *
+   * `associations=all` returns *nothing* extra on a center — not even the group members that
+   * `associations=groupMembers` returns — so the association has to be requested explicitly.
+   * Verified against a live instance; it is not what the parameter's name suggests.
+   */
+  groupMembers?: CenterGroupMember[];
+  timeline?: CenterTimeline;
+}
+
+/**
+ * The center's meeting, from `GET /centers/{id}/calendars`.
+ *
+ * `startDate` is a `yyyy-MM-dd` string here, not the `[year, month, day]` array the rest of the
+ * platform returns — the one place in this feature where a date needs no conversion.
+ */
+export interface CenterMeeting {
+  id?: number;
+  title?: string;
+  startDate?: string;
+  interval?: number;
+  repeating?: boolean;
+  recurrence?: string;
+  frequency?: { id?: number; value?: string };
+  type?: { id?: number; value?: string };
+}
+
+/**
+ * Center status ids. Shared with groups and clients: the codes come back as
+ * `groupingStatusType.pending` and the ids match {@link GROUP_STATUS}.
+ *
+ * Gated on the id rather than on `value`, which is the platform's English label and moves with
+ * the server's locale.
+ */
+export const CENTER_STATUS = {
+  PENDING: 100,
+  ACTIVE: 300,
+  CLOSED: 600,
+} as const;
+
+/** The commands `POST /centers/{id}` accepts, as reported by the platform itself. */
+export const CENTER_COMMANDS = {
+  ACTIVATE: 'activate',
+  CLOSE: 'close',
+  ASSOCIATE_GROUPS: 'associateGroups',
+  DISASSOCIATE_GROUPS: 'disassociateGroups',
+} as const;
+
+export function isCenterActive(center: CenterDetail | null): boolean {
+  return center?.status?.id === CENTER_STATUS.ACTIVE;
+}
+
+export function isCenterPending(center: CenterDetail | null): boolean {
+  return center?.status?.id === CENTER_STATUS.PENDING;
+}
+
+export function isCenterClosed(center: CenterDetail | null): boolean {
+  return center?.status?.id === CENTER_STATUS.CLOSED;
+}

--- a/src/app/features/centers/center-groups-dialog.component.ts
+++ b/src/app/features/centers/center-groups-dialog.component.ts
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Subject, debounceTime, distinctUntilChanged, of, switchMap } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { IonButton, IonCheckbox, IonItem, IonList, IonSearchbar } from '@ionic/angular/standalone';
+
+import { GroupsService } from '../../api';
+import { OVERLAY, TranslatePipe } from '../../core/adapters';
+import { CenterGroupMember } from './center-detail.model';
+
+export interface CenterGroupsDialogData {
+  /** `add` searches the office for candidates; `remove` lists the center's current groups. */
+  mode: 'add' | 'remove';
+  /** Scopes the candidate search. A center may only hold groups from its own office. */
+  officeId?: number;
+  /** The center's current groups — the candidate list in `remove` mode. */
+  members: CenterGroupMember[];
+}
+
+export interface CenterGroupsResult {
+  groupMembers: number[];
+}
+
+/**
+ * Chooses the groups to attach to, or detach from, a center.
+ *
+ * **Adding** searches `GET /groups?orphansOnly=true`, which is the platform's own filter for
+ * groups that do not already belong to a center. That is the right question to ask: a group has at
+ * most one parent, so a group listed under another center is not a candidate, and offering it
+ * produces a refusal the operator cannot act on. Filtering client-side against this center's own
+ * members would not catch groups held by a *different* centre.
+ *
+ * The search is scoped to the center's office because the platform refuses a group from anywhere
+ * else, and is seeded with a blank term so the dialog opens with a page of candidates rather than
+ * an empty panel that only fills once the operator guesses a name.
+ */
+@Component({
+  selector: 'app-center-groups-dialog',
+  standalone: true,
+  imports: [FormsModule, TranslatePipe, IonButton, IonCheckbox, IonItem, IonList, IonSearchbar],
+  template: `
+    <h2 class="dialog-title">
+      {{
+        (data().mode === 'add' ? 'CENTERS.ATTACH_GROUPS' : 'CENTERS.DETACH_GROUPS') | appTranslate
+      }}
+    </h2>
+    <div class="dialog-content">
+      @if (data().mode === 'add') {
+        <ion-searchbar
+          data-testid="center-group-search"
+          [attr.aria-label]="'CENTERS.SEARCH_GROUPS' | appTranslate"
+          [placeholder]="'CENTERS.SEARCH_GROUPS' | appTranslate"
+          [debounce]="0"
+          (ionInput)="onSearch($any($event).detail.value)"
+        ></ion-searchbar>
+      }
+
+      <ion-list class="candidate-list">
+        @for (candidate of candidates(); track candidate.id) {
+          <ion-item>
+            <ion-checkbox
+              justify="start"
+              labelPlacement="end"
+              [attr.data-testid]="'center-group-' + candidate.id"
+              [checked]="selected().has(candidate.id!)"
+              (ionChange)="toggle(candidate.id!)"
+            >
+              {{ candidate.name }}
+              @if (candidate.accountNo) {
+                <span class="account-no">({{ candidate.accountNo }})</span>
+              }
+            </ion-checkbox>
+          </ion-item>
+        } @empty {
+          <p class="field-note" data-testid="center-group-none">
+            {{ emptyMessage() | appTranslate }}
+          </p>
+        }
+      </ion-list>
+    </div>
+    <div class="dialog-actions">
+      <ion-button fill="clear" color="medium" (click)="onCancel()">
+        {{ 'COMMON.CANCEL' | appTranslate }}
+      </ion-button>
+      <ion-button
+        color="primary"
+        data-testid="center-groups-confirm"
+        [disabled]="!selected().size"
+        (click)="onConfirm()"
+      >
+        {{ 'COMMON.CONFIRM' | appTranslate }}
+      </ion-button>
+    </div>
+  `,
+  styles: [
+    `
+      .dialog-content {
+        min-width: 360px;
+      }
+      .candidate-list {
+        max-height: 320px;
+        overflow-y: auto;
+      }
+      .account-no {
+        margin-left: 6px;
+        color: var(--text-muted, #6b7280);
+        font-size: 12px;
+      }
+      .field-note {
+        margin: 8px 0 0;
+        font-size: 12px;
+        color: var(--text-muted, #6b7280);
+      }
+    `,
+  ],
+})
+export class CenterGroupsDialogComponent implements OnInit {
+  private readonly overlay = inject(OVERLAY);
+  private readonly groupsService = inject(GroupsService);
+
+  readonly data = input.required<CenterGroupsDialogData>();
+
+  readonly candidates = signal<CenterGroupMember[]>([]);
+  /** Replaced rather than mutated: under the OnPush default a mutated Set notifies nothing. */
+  readonly selected = signal<ReadonlySet<number>>(new Set());
+
+  private readonly searchTerm = new Subject<string>();
+
+  ngOnInit(): void {
+    if (this.data().mode === 'remove') {
+      this.candidates.set(this.data().members);
+      return;
+    }
+
+    this.searchTerm
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((term) =>
+          this.groupsService
+            // Signature: officeId, staffId, externalId, name, underHierarchy, paged, offset,
+            // limit, orderBy, sortOrder, orphansOnly.
+            .getGroups(
+              this.data().officeId,
+              undefined,
+              undefined,
+              term || undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              true,
+            )
+            .pipe(catchError(() => of(null))),
+        ),
+      )
+      .subscribe((response) => {
+        const rows = response as unknown as
+          CenterGroupMember[] | { pageItems?: CenterGroupMember[] } | null;
+        // `GET /groups` answers with a bare array unless `paged` is set, and with a page object
+        // when it is. Both shapes are handled so this does not depend on that flag staying unset.
+        const items = Array.isArray(rows) ? rows : (rows?.pageItems ?? []);
+        this.candidates.set(Array.from(items));
+      });
+
+    this.searchTerm.next('');
+  }
+
+  emptyMessage(): string {
+    return this.data().mode === 'add' ? 'CENTERS.NO_GROUPS_FOUND' : 'CENTERS.NO_GROUPS';
+  }
+
+  onSearch(term: string | null | undefined): void {
+    this.searchTerm.next(term ?? '');
+  }
+
+  toggle(groupId: number): void {
+    const next = new Set(this.selected());
+    if (!next.delete(groupId)) next.add(groupId);
+    this.selected.set(next);
+  }
+
+  onCancel(): void {
+    void this.overlay.dismissModal();
+  }
+
+  onConfirm(): void {
+    if (!this.selected().size) return;
+    void this.overlay.dismissModal<CenterGroupsResult>({ groupMembers: [...this.selected()] });
+  }
+}

--- a/src/app/features/centers/center-meeting-dialog.component.ts
+++ b/src/app/features/centers/center-meeting-dialog.component.ts
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { Component, OnInit, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  IonButton,
+  IonDatetime,
+  IonDatetimeButton,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonModal,
+  IonSelect,
+  IonSelectOption,
+} from '@ionic/angular/standalone';
+
+import { BASE_PATH } from '../../api';
+import { OVERLAY, TranslatePipe } from '../../core/adapters';
+import { CenterMeeting } from './center-detail.model';
+
+export interface CenterMeetingDialogData {
+  centerId: number;
+  /** The meeting being changed, when there is one. Absent means a new meeting. */
+  meeting?: CenterMeeting;
+}
+
+export interface CenterMeetingResult {
+  title: string;
+  startDate: string;
+  frequency: number;
+  interval: number;
+  typeId: number;
+  /** Only meaningful, and only sent, for a weekly meeting. */
+  repeatsOnDay?: number;
+}
+
+/** `frequencyOptions` id for WEEKLY, the one frequency that needs a day of the week. */
+const WEEKLY_FREQUENCY = 2;
+
+interface CodeOption {
+  id?: number;
+  value?: string;
+}
+
+/**
+ * Schedules, or reschedules, the meeting a center's groups attend.
+ *
+ * The options come from `GET /centers/{id}/calendars/template`, whose frequency list is under
+ * `frequencyOptions` — not the `calendarFrequencyTypeOptions` its code names suggest.
+ *
+ * A meeting cannot start before the center was activated: the platform answers
+ * `validation.msg.calendar.cannot.be.before.centers.activation.date`, so the action is offered
+ * only on an active center.
+ *
+ * A **weekly** meeting additionally requires `repeatsOnDay` — a weekly schedule with no day is
+ * refused with `validation.msg.calendar.repeatsOnDay.cannot.be.blank`. Weekly is the ordinary
+ * cadence for centre-based lending, so the day selector appears with it rather than being an
+ * advanced option, and is withheld for the other frequencies, which reject it as unsupported.
+ */
+@Component({
+  selector: 'app-center-meeting-dialog',
+  standalone: true,
+  imports: [
+    FormsModule,
+    TranslatePipe,
+    IonItem,
+    IonLabel,
+    IonInput,
+    IonSelect,
+    IonSelectOption,
+    IonButton,
+    IonDatetime,
+    IonDatetimeButton,
+    IonModal,
+  ],
+  template: `
+    <h2 class="dialog-title">
+      {{ (data().meeting ? 'CENTERS.EDIT_MEETING' : 'CENTERS.ATTACH_MEETING') | appTranslate }}
+    </h2>
+    <div class="dialog-content">
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'CENTERS.MEETING_TITLE' | appTranslate }}</ion-label>
+        <ion-input
+          data-testid="center-meeting-title"
+          name="title"
+          [attr.aria-label]="'CENTERS.MEETING_TITLE' | appTranslate"
+          [(ngModel)]="title"
+        ></ion-input>
+      </ion-item>
+
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'CENTERS.MEETING_START' | appTranslate }}</ion-label>
+        <ion-datetime-button
+          data-testid="center-meeting-date-button"
+          datetime="center-meeting-date"
+        ></ion-datetime-button>
+        <ion-modal [keepContentsMounted]="true">
+          <ng-template>
+            <ion-datetime
+              id="center-meeting-date"
+              data-testid="center-meeting-date"
+              presentation="date"
+              [value]="startDate"
+              (ionChange)="onDateChange($event)"
+            ></ion-datetime>
+          </ng-template>
+        </ion-modal>
+      </ion-item>
+
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'CENTERS.MEETING_FREQUENCY' | appTranslate }}</ion-label>
+        <ion-select
+          [attr.aria-label]="'CENTERS.MEETING_FREQUENCY' | appTranslate"
+          interface="popover"
+          data-testid="center-meeting-frequency"
+          name="frequency"
+          [(ngModel)]="frequency"
+        >
+          @for (option of frequencyOptions(); track option.id) {
+            <ion-select-option [value]="option.id">{{ option.value }}</ion-select-option>
+          }
+        </ion-select>
+      </ion-item>
+
+      @if (isWeekly()) {
+        <ion-item fill="outline" class="full-width">
+          <ion-label position="stacked">{{ 'CENTERS.MEETING_DAY' | appTranslate }}</ion-label>
+          <ion-select
+            [attr.aria-label]="'CENTERS.MEETING_DAY' | appTranslate"
+            interface="popover"
+            data-testid="center-meeting-day"
+            name="repeatsOnDay"
+            [(ngModel)]="repeatsOnDay"
+          >
+            @for (option of dayOptions(); track option.id) {
+              <ion-select-option [value]="option.id">{{ option.value }}</ion-select-option>
+            }
+          </ion-select>
+        </ion-item>
+      }
+
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'CENTERS.MEETING_INTERVAL' | appTranslate }}</ion-label>
+        <ion-input
+          data-testid="center-meeting-interval"
+          type="number"
+          min="1"
+          name="interval"
+          [attr.aria-label]="'CENTERS.MEETING_INTERVAL' | appTranslate"
+          [(ngModel)]="interval"
+        ></ion-input>
+      </ion-item>
+
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'CENTERS.MEETING_TYPE' | appTranslate }}</ion-label>
+        <ion-select
+          [attr.aria-label]="'CENTERS.MEETING_TYPE' | appTranslate"
+          interface="popover"
+          data-testid="center-meeting-type"
+          name="typeId"
+          [(ngModel)]="typeId"
+        >
+          @for (option of typeOptions(); track option.id) {
+            <ion-select-option [value]="option.id">{{ option.value }}</ion-select-option>
+          }
+        </ion-select>
+      </ion-item>
+    </div>
+    <div class="dialog-actions">
+      <ion-button fill="clear" color="medium" (click)="onCancel()">
+        {{ 'COMMON.CANCEL' | appTranslate }}
+      </ion-button>
+      <ion-button
+        color="primary"
+        data-testid="center-meeting-confirm"
+        [disabled]="!canConfirm()"
+        (click)="onConfirm()"
+      >
+        {{ 'COMMON.CONFIRM' | appTranslate }}
+      </ion-button>
+    </div>
+  `,
+  styles: [
+    `
+      .dialog-content {
+        min-width: 360px;
+      }
+      .full-width {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class CenterMeetingDialogComponent implements OnInit {
+  private readonly overlay = inject(OVERLAY);
+  private readonly httpClient = inject(HttpClient);
+  private readonly basePath = inject(BASE_PATH);
+
+  readonly data = input.required<CenterMeetingDialogData>();
+
+  readonly frequencyOptions = signal<CodeOption[]>([]);
+  readonly typeOptions = signal<CodeOption[]>([]);
+  readonly dayOptions = signal<CodeOption[]>([]);
+
+  title = '';
+  startDate = new Date().toISOString();
+  frequency = 2;
+  interval = 1;
+  typeId = 1;
+  repeatsOnDay = 1;
+
+  ngOnInit(): void {
+    const meeting = this.data().meeting;
+    if (meeting) {
+      this.title = meeting.title ?? '';
+      // The calendar read returns `startDate` as `yyyy-MM-dd`, not as the `[y, m, d]` array the
+      // rest of the platform uses, so it needs no conversion to seed the picker.
+      if (meeting.startDate) this.startDate = meeting.startDate;
+      if (meeting.frequency?.id) this.frequency = meeting.frequency.id;
+      if (meeting.type?.id) this.typeId = meeting.type.id;
+      // `interval` comes back as -1 for a non-repeating frequency; that is not a usable default.
+      if (meeting.interval && meeting.interval > 0) this.interval = meeting.interval;
+    }
+
+    this.httpClient
+      .get<Record<string, CodeOption[]>>(
+        `${this.basePath}/v1/centers/${this.data().centerId}/calendars/template`,
+      )
+      .subscribe({
+        next: (template) => {
+          this.frequencyOptions.set(template['frequencyOptions'] ?? []);
+          this.typeOptions.set(template['calendarTypeOptions'] ?? []);
+          this.dayOptions.set(template['repeatsOnDayOptions'] ?? []);
+        },
+        error: () => {
+          this.frequencyOptions.set([]);
+          this.typeOptions.set([]);
+          this.dayOptions.set([]);
+        },
+      });
+  }
+
+  isWeekly(): boolean {
+    return Number(this.frequency) === WEEKLY_FREQUENCY;
+  }
+
+  onDateChange(event: Event): void {
+    const value = (event as CustomEvent<{ value?: string }>).detail?.value;
+    if (value) this.startDate = value;
+  }
+
+  canConfirm(): boolean {
+    return Boolean(this.title.trim()) && Boolean(this.startDate) && this.interval > 0;
+  }
+
+  onCancel(): void {
+    void this.overlay.dismissModal();
+  }
+
+  onConfirm(): void {
+    if (!this.canConfirm()) return;
+    void this.overlay.dismissModal<CenterMeetingResult>({
+      title: this.title.trim(),
+      startDate: this.startDate,
+      frequency: this.frequency,
+      interval: this.interval,
+      typeId: this.typeId,
+      // Withheld unless weekly: the other frequencies reject it.
+      repeatsOnDay: this.isWeekly() ? this.repeatsOnDay : undefined,
+    });
+  }
+}

--- a/src/app/features/centers/center-staff-dialog.component.ts
+++ b/src/app/features/centers/center-staff-dialog.component.ts
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit, inject, input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  IonButton,
+  IonItem,
+  IonLabel,
+  IonSelect,
+  IonSelectOption,
+} from '@ionic/angular/standalone';
+
+import { CentersService } from '../../api';
+import { OVERLAY, TranslatePipe } from '../../core/adapters';
+
+export interface CenterStaffDialogData {
+  /** The center's office. Fineract only accepts staff who belong to it. */
+  officeId?: number;
+  /** Currently assigned staff, pre-selected so reassignment starts from the truth. */
+  staffId?: number;
+}
+
+export interface CenterStaffResult {
+  staffId: number;
+}
+
+/**
+ * Picks the member of staff a center is assigned to.
+ *
+ * Options come from `GET /centers/template?officeId=…&staffInSelectedOfficeOnly=true`. Scoping to
+ * the office matters because the platform rejects staff from another office and names the staff id
+ * rather than the office in the refusal, which reads like the feature is broken.
+ */
+@Component({
+  selector: 'app-center-staff-dialog',
+  standalone: true,
+  imports: [FormsModule, TranslatePipe, IonItem, IonLabel, IonSelect, IonSelectOption, IonButton],
+  template: `
+    <h2 class="dialog-title">{{ 'CENTERS.ASSIGN_STAFF' | appTranslate }}</h2>
+    <div class="dialog-content">
+      <ion-item fill="outline" class="full-width">
+        <ion-label position="stacked">{{ 'COMMON.STAFF' | appTranslate }}</ion-label>
+        <ion-select
+          [attr.aria-label]="'COMMON.STAFF' | appTranslate"
+          interface="popover"
+          data-testid="center-staff-select"
+          name="staffId"
+          [(ngModel)]="staffId"
+        >
+          @for (member of staff(); track member.id) {
+            <ion-select-option [value]="member.id">{{ member.displayName }}</ion-select-option>
+          }
+        </ion-select>
+      </ion-item>
+
+      @if (!staff().length) {
+        <p class="field-note" data-testid="center-staff-none">
+          {{ 'CENTERS.NO_STAFF_IN_OFFICE' | appTranslate }}
+        </p>
+      }
+    </div>
+    <div class="dialog-actions">
+      <ion-button fill="clear" color="medium" (click)="onCancel()">
+        {{ 'COMMON.CANCEL' | appTranslate }}
+      </ion-button>
+      <ion-button
+        color="primary"
+        data-testid="center-staff-confirm"
+        [disabled]="staffId === undefined"
+        (click)="onConfirm()"
+      >
+        {{ 'COMMON.CONFIRM' | appTranslate }}
+      </ion-button>
+    </div>
+  `,
+  styles: [
+    `
+      .dialog-content {
+        min-width: 340px;
+      }
+      .full-width {
+        width: 100%;
+      }
+      .field-note {
+        margin: 8px 0 0;
+        font-size: 12px;
+        color: var(--text-muted, #6b7280);
+      }
+    `,
+  ],
+})
+export class CenterStaffDialogComponent implements OnInit {
+  private readonly overlay = inject(OVERLAY);
+  private readonly centersService = inject(CentersService);
+
+  readonly data = input.required<CenterStaffDialogData>();
+
+  readonly staff = signal<{ id?: number; displayName?: string }[]>([]);
+  staffId?: number;
+
+  ngOnInit(): void {
+    this.staffId = this.data().staffId;
+
+    // Signature: command, officeId, staffInSelectedOfficeOnly.
+    this.centersService.getCentersTemplate(undefined, this.data().officeId, true).subscribe({
+      next: (template) => {
+        const options = (
+          template as unknown as { staffOptions?: { id?: number; displayName?: string }[] }
+        ).staffOptions;
+        this.staff.set(options ? Array.from(options) : []);
+      },
+      error: () => this.staff.set([]),
+    });
+  }
+
+  onCancel(): void {
+    void this.overlay.dismissModal();
+  }
+
+  onConfirm(): void {
+    if (this.staffId === undefined) return;
+    void this.overlay.dismissModal<CenterStaffResult>({ staffId: this.staffId });
+  }
+}

--- a/src/app/features/centers/center-view.component.spec.ts
+++ b/src/app/features/centers/center-view.component.spec.ts
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { BASE_PATH } from '../../api';
+import { DialogService } from '../../core/services/dialog.service';
+import { provideFakeAdapters } from '../../testing/adapters';
+import { provideTranslateTesting } from '../../testing/i18n-testing';
+import { CenterDetail } from './center-detail.model';
+import { CenterViewComponent } from './center-view.component';
+
+/** As `app.config.ts` computes it: the API url with the trailing `/v1` removed. */
+const API = '/api';
+const HEAD_OFFICE = 'Head Office';
+const CENTER_NAME = 'Kibera Center';
+const CENTER_URL = `${API}/v1/centers/4`;
+const FINERACT_LOCALE = 'en';
+const FINERACT_DATE_FORMAT = 'dd MMMM yyyy';
+const WEEKLY_COLLECTION = 'Weekly collection';
+
+const ACTIVE_CENTER: CenterDetail = {
+  id: 4,
+  accountNo: '000000004',
+  name: CENTER_NAME,
+  status: { id: 300, code: 'groupingStatusType.active', value: 'Active' },
+  active: true,
+  officeId: 1,
+  officeName: HEAD_OFFICE,
+  staffId: 2,
+  staffName: 'Okoth, Grace',
+  timeline: { activatedOnDate: [2026, 1, 15] },
+  groupMembers: [
+    {
+      id: 5,
+      accountNo: '000000005',
+      name: 'Kibera Womens Group',
+      status: { id: 300, value: 'Active' },
+      officeName: HEAD_OFFICE,
+    },
+  ],
+};
+
+describe('CenterViewComponent', () => {
+  let fixture: ComponentFixture<CenterViewComponent>;
+  let component: CenterViewComponent;
+  let http: HttpTestingController;
+  let dialog: jasmine.SpyObj<DialogService>;
+  let router: jasmine.SpyObj<Router>;
+
+  function create(): void {
+    fixture = TestBed.createComponent(CenterViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  /**
+   * Answers the center read and the calendar read that follows it, which every test needs before
+   * it can assert anything.
+   */
+  function flushCenter(detail: CenterDetail = ACTIVE_CENTER, meetings: unknown[] = []): void {
+    const request = http.expectOne((candidate) => candidate.url === CENTER_URL);
+    expect(request.request.params.get('associations')).toBe('groupMembers');
+    request.flush(detail);
+    http.expectOne((candidate) => candidate.url === `${CENTER_URL}/calendars`).flush(meetings);
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    dialog = jasmine.createSpyObj('DialogService', ['open', 'confirm']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    const adapters = provideFakeAdapters();
+
+    await TestBed.configureTestingModule({
+      imports: [CenterViewComponent],
+      providers: [
+        { provide: BASE_PATH, useValue: API },
+        { provide: DialogService, useValue: dialog },
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: new Map([['id', '4']]) } } },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        // The datatables tab pulls in TranslateModule, which needs the library configured.
+        ...provideTranslateTesting(),
+        ...adapters.providers,
+      ],
+    }).compileComponents();
+
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  /**
+   * The read has to name the association. `associations=all` returns nothing extra on a center —
+   * not even the group members — so a request without it would leave the groups tab empty by
+   * construction rather than because the center has none.
+   */
+  it('reads the center with its groups and renders them', () => {
+    create();
+    flushCenter();
+
+    expect(component.center()?.name).toBe(CENTER_NAME);
+    expect(component.groupMembers()).toHaveSize(1);
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="center-name"]').textContent,
+    ).toContain('Kibera Center');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="center-group-count"]').textContent,
+    ).toContain('1');
+  });
+
+  it('offers a retry rather than an empty page when the read fails', () => {
+    create();
+    http
+      .expectOne((candidate) => candidate.url === CENTER_URL)
+      .flush('boom', { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+
+    expect(component.loadFailed()).toBeTrue();
+    expect(fixture.nativeElement.querySelector('[data-testid="center-load-error"]')).not.toBeNull();
+  });
+
+  it('offers activate only while pending, and close only while active', () => {
+    create();
+    flushCenter({ ...ACTIVE_CENTER, status: { id: 100, value: 'Pending' }, active: false });
+
+    expect(component.canActivate()).toBeTrue();
+    expect(component.canClose()).toBeFalse();
+
+    component.center.set(ACTIVE_CENTER);
+    expect(component.canActivate()).toBeFalse();
+    expect(component.canClose()).toBeTrue();
+
+    component.center.set({ ...ACTIVE_CENTER, status: { id: 600, value: 'Closed' } });
+    expect(component.isClosed()).toBeTrue();
+    expect(component.canClose()).toBeFalse();
+  });
+
+  it('posts activate with the date the dialog returned', async () => {
+    create();
+    flushCenter({ ...ACTIVE_CENTER, status: { id: 100, value: 'Pending' } });
+
+    dialog.open.and.resolveTo({ date: '2026-02-01T00:00:00.000Z' });
+    await component.onAction('activate');
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === CENTER_URL && candidate.method === 'POST',
+    );
+    expect(request.request.params.get('command')).toBe('activate');
+    expect(request.request.body).toEqual({
+      locale: FINERACT_LOCALE,
+      dateFormat: FINERACT_DATE_FORMAT,
+      activationDate: '01 February 2026',
+    });
+    request.flush({});
+    flushCenter();
+  });
+
+  it('posts close with the reason, which the platform requires', async () => {
+    create();
+    flushCenter();
+
+    dialog.open.and.resolveTo({ date: '2026-03-02T00:00:00.000Z', closureReasonId: 9 });
+    await component.onAction('close');
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === CENTER_URL && candidate.method === 'POST',
+    );
+    expect(request.request.params.get('command')).toBe('close');
+    expect(request.request.body).toEqual({
+      locale: FINERACT_LOCALE,
+      dateFormat: FINERACT_DATE_FORMAT,
+      closureDate: '02 March 2026',
+      closureReasonId: 9,
+    });
+    request.flush({});
+    flushCenter();
+  });
+
+  /**
+   * Assignment is an update, not a command, and `name` is mandatory on it even though it is not
+   * being changed — omitting it answers validation.msg.center.name.cannot.be.blank.
+   */
+  it('assigns staff through an update that carries the unchanged name', async () => {
+    create();
+    flushCenter();
+
+    dialog.open.and.resolveTo({ staffId: 7 });
+    await component.onAssignStaff();
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === CENTER_URL && candidate.method === 'PUT',
+    );
+    expect(request.request.body).toEqual({
+      name: CENTER_NAME,
+      staffId: 7,
+      locale: FINERACT_LOCALE,
+      dateFormat: FINERACT_DATE_FORMAT,
+    });
+    request.flush({});
+    flushCenter();
+  });
+
+  /**
+   * There is no center-side unassign: the update ignores `staffId: null` and rejects `-1`. Only
+   * the groups resource accepts it, and it refuses `locale`/`dateFormat` as unsupported, so the
+   * body carries the staff id alone.
+   */
+  it('unassigns staff through the groups resource with a bare payload', async () => {
+    create();
+    flushCenter();
+
+    dialog.confirm.and.resolveTo(true);
+    await component.onUnassignStaff();
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === `${API}/v1/groups/4` && candidate.method === 'POST',
+    );
+    expect(request.request.params.get('command')).toBe('unassignStaff');
+    expect(request.request.body).toEqual({ staffId: 2 });
+    request.flush({});
+    flushCenter();
+  });
+
+  it('does not unassign staff when the confirmation is declined', async () => {
+    create();
+    flushCenter();
+
+    dialog.confirm.and.resolveTo(false);
+    await component.onUnassignStaff();
+
+    http.expectNone((candidate) => candidate.method === 'POST');
+  });
+
+  it('attaches and detaches groups through their own commands', async () => {
+    create();
+    flushCenter();
+
+    dialog.open.and.resolveTo({ groupMembers: [11, 12] });
+    await component.onManageGroups('add');
+
+    const attach = http.expectOne(
+      (candidate) => candidate.url === CENTER_URL && candidate.method === 'POST',
+    );
+    expect(attach.request.params.get('command')).toBe('associateGroups');
+    expect(attach.request.body).toEqual({ groupMembers: [11, 12] });
+    attach.flush({});
+    flushCenter();
+
+    dialog.open.and.resolveTo({ groupMembers: [5] });
+    await component.onManageGroups('remove');
+
+    const detach = http.expectOne(
+      (candidate) => candidate.url === CENTER_URL && candidate.method === 'POST',
+    );
+    expect(detach.request.params.get('command')).toBe('disassociateGroups');
+    detach.flush({});
+    flushCenter();
+  });
+
+  it('shows the meeting, and offers scheduling only once the center is active', () => {
+    create();
+    flushCenter({ ...ACTIVE_CENTER, status: { id: 100, value: 'Pending' } });
+    expect(component.canScheduleMeeting()).toBeFalse();
+
+    component.center.set(ACTIVE_CENTER);
+    component.meeting.set({
+      id: 3,
+      title: WEEKLY_COLLECTION,
+      frequency: { id: 2, value: 'WEEKLY' },
+    });
+    expect(component.canScheduleMeeting()).toBeTrue();
+    expect(component.meetingSummary()).toBe(`${WEEKLY_COLLECTION} (WEEKLY)`);
+  });
+
+  /**
+   * A weekly meeting must name its day: the platform refuses one without `repeatsOnDay`. The
+   * field is omitted entirely for other frequencies, which reject it.
+   */
+  it('posts a new weekly meeting with the day it repeats on', async () => {
+    create();
+    flushCenter();
+
+    dialog.open.and.resolveTo({
+      title: WEEKLY_COLLECTION,
+      startDate: '2026-04-06T00:00:00.000Z',
+      frequency: 2,
+      interval: 1,
+      typeId: 1,
+      repeatsOnDay: 1,
+    });
+    await component.onScheduleMeeting();
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === `${CENTER_URL}/calendars` && candidate.method === 'POST',
+    );
+    expect(request.request.body).toEqual({
+      title: WEEKLY_COLLECTION,
+      startDate: '06 April 2026',
+      frequency: 2,
+      interval: 1,
+      typeId: 1,
+      repeating: true,
+      locale: FINERACT_LOCALE,
+      dateFormat: FINERACT_DATE_FORMAT,
+      repeatsOnDay: 1,
+    });
+    request.flush({});
+    flushCenter();
+  });
+
+  it('updates the existing meeting rather than creating a second one', async () => {
+    create();
+    flushCenter(ACTIVE_CENTER, [{ id: 3, title: WEEKLY_COLLECTION }]);
+
+    dialog.open.and.resolveTo({
+      title: 'Fortnightly collection',
+      startDate: '2026-04-06T00:00:00.000Z',
+      frequency: 1,
+      interval: 2,
+      typeId: 1,
+    });
+    await component.onScheduleMeeting();
+
+    const request = http.expectOne(
+      (candidate) => candidate.url === `${CENTER_URL}/calendars/3` && candidate.method === 'PUT',
+    );
+    // No `repeatsOnDay`: it is meaningful only for a weekly meeting.
+    expect(request.request.body['repeatsOnDay']).toBeUndefined();
+    expect(request.request.body['interval']).toBe(2);
+    request.flush({});
+    flushCenter();
+  });
+
+  it('sends nothing when a dialog is dismissed', async () => {
+    create();
+    flushCenter();
+
+    dialog.open.and.resolveTo(undefined);
+    await component.onAction('close');
+    await component.onAssignStaff();
+    await component.onManageGroups('add');
+
+    http.expectNone((candidate) => candidate.method === 'POST');
+    http.expectNone((candidate) => candidate.method === 'PUT');
+  });
+});

--- a/src/app/features/centers/center-view.component.ts
+++ b/src/app/features/centers/center-view.component.ts
@@ -1,0 +1,645 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { Observable } from 'rxjs';
+import {
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPopover,
+  IonSegment,
+  IonSegmentButton,
+} from '@ionic/angular/standalone';
+
+import {
+  BASE_PATH,
+  CentersService,
+  GroupsService,
+  PostCentersCenterIdRequest,
+  PostGroupsGroupIdRequest,
+} from '../../api';
+import { I18N, TranslatePipe } from '../../core/adapters';
+import { DialogService } from '../../core/services/dialog.service';
+import { NotificationService } from '../../core/services/notification.service';
+import {
+  FINERACT_DATE_FORMAT,
+  FINERACT_LOCALE,
+  formatArrayDate,
+  formatDateToFineract,
+} from '../../core/utils/date-formatter';
+import {
+  CellTemplateDirective,
+  ColumnDef,
+  DataTableComponent,
+  HasPermissionDirective,
+  StatusBadgeComponent,
+} from '../../shared';
+import { EntityDatatablesComponent } from '../../shared/components/entity-datatables/entity-datatables.component';
+import { GroupNotesListComponent } from '../groups/tabs/group-notes-list.component';
+import {
+  CenterActionDialogComponent,
+  CenterActionDialogData,
+  CenterActionResult,
+} from './center-action-dialog.component';
+import {
+  CenterGroupsDialogComponent,
+  CenterGroupsDialogData,
+  CenterGroupsResult,
+} from './center-groups-dialog.component';
+import {
+  CenterMeetingDialogComponent,
+  CenterMeetingDialogData,
+  CenterMeetingResult,
+} from './center-meeting-dialog.component';
+import {
+  CenterStaffDialogComponent,
+  CenterStaffDialogData,
+  CenterStaffResult,
+} from './center-staff-dialog.component';
+import {
+  CENTER_COMMANDS,
+  CenterDetail,
+  CenterGroupMember,
+  CenterMeeting,
+  isCenterActive,
+  isCenterClosed,
+  isCenterPending,
+} from './center-detail.model';
+
+/** A tab index that is also what the segment binds to; `ion-segment` deals in strings. */
+const TAB = { GENERAL: '0', NOTES: '1', DATATABLES: '2' } as const;
+
+@Component({
+  selector: 'app-center-view',
+  standalone: true,
+  imports: [
+    RouterModule,
+    TranslatePipe,
+    DataTableComponent,
+    CellTemplateDirective,
+    HasPermissionDirective,
+    StatusBadgeComponent,
+    EntityDatatablesComponent,
+    GroupNotesListComponent,
+    IonButton,
+    IonCard,
+    IonCardContent,
+    IonCardHeader,
+    IonCardTitle,
+    IonIcon,
+    IonItem,
+    IonLabel,
+    IonList,
+    IonPopover,
+    IonSegment,
+    IonSegmentButton,
+  ],
+  template: `
+    <div class="page-container">
+      @if (loadFailed()) {
+        <div class="load-error" data-testid="center-load-error">
+          <p>{{ 'CENTERS.LOAD_FAILED' | appTranslate }}</p>
+          <ion-button size="small" (click)="loadCenter()">
+            {{ 'COMMON.RETRY' | appTranslate }}
+          </ion-button>
+        </div>
+      } @else if (center(); as detail) {
+        <ion-card>
+          <ion-card-header>
+            <div class="header-row">
+              <div>
+                <ion-card-title>
+                  <h1 data-testid="center-name">{{ detail.name }}</h1>
+                </ion-card-title>
+                <div class="subtitle">
+                  <app-status-badge
+                    data-testid="center-status"
+                    [status]="detail.status?.value ?? ''"
+                  ></app-status-badge>
+                  <span class="account-no">{{ detail.accountNo }}</span>
+                </div>
+              </div>
+
+              <div class="header-actions">
+                <ion-button
+                  color="primary"
+                  id="center-actions-trigger"
+                  data-testid="center-actions"
+                >
+                  {{ 'COMMON.ACTIONS' | appTranslate }}
+                  <ion-icon name="ellipsis-vertical-outline" slot="end"></ion-icon>
+                </ion-button>
+                <ion-popover trigger="center-actions-trigger" [dismissOnSelect]="true">
+                  <ng-template>
+                    <ion-list>
+                      @if (canActivate()) {
+                        <ion-item
+                          button
+                          data-testid="center-action-activate"
+                          (click)="onAction('activate')"
+                          *appHasPermission="'ACTIVATE_CENTER'"
+                        >
+                          <ion-label>{{ 'CENTERS.ACTIVATE' | appTranslate }}</ion-label>
+                        </ion-item>
+                      }
+                      @if (canClose()) {
+                        <ion-item
+                          button
+                          data-testid="center-action-close"
+                          (click)="onAction('close')"
+                          *appHasPermission="'CLOSE_CENTER'"
+                        >
+                          <ion-label>{{ 'CENTERS.CLOSE' | appTranslate }}</ion-label>
+                        </ion-item>
+                      }
+                      @if (!isClosed()) {
+                        <ion-item
+                          button
+                          data-testid="center-action-assign-staff"
+                          (click)="onAssignStaff()"
+                          *appHasPermission="'UPDATE_CENTER'"
+                        >
+                          <ion-label>{{ 'CENTERS.ASSIGN_STAFF' | appTranslate }}</ion-label>
+                        </ion-item>
+                        @if (detail.staffId) {
+                          <ion-item
+                            button
+                            data-testid="center-action-unassign-staff"
+                            (click)="onUnassignStaff()"
+                            *appHasPermission="'UNASSIGNSTAFF_GROUP'"
+                          >
+                            <ion-label>{{ 'CENTERS.UNASSIGN_STAFF' | appTranslate }}</ion-label>
+                          </ion-item>
+                        }
+                        @if (canScheduleMeeting()) {
+                          <ion-item
+                            button
+                            data-testid="center-action-meeting"
+                            (click)="onScheduleMeeting()"
+                            *appHasPermission="'CREATE_MEETING'"
+                          >
+                            <ion-label>
+                              {{
+                                (meeting() ? 'CENTERS.EDIT_MEETING' : 'CENTERS.ATTACH_MEETING')
+                                  | appTranslate
+                              }}
+                            </ion-label>
+                          </ion-item>
+                        }
+                        <ion-item
+                          button
+                          data-testid="center-action-attach-groups"
+                          (click)="onManageGroups('add')"
+                          *appHasPermission="'ASSOCIATEGROUPS_CENTER'"
+                        >
+                          <ion-label>{{ 'CENTERS.ATTACH_GROUPS' | appTranslate }}</ion-label>
+                        </ion-item>
+                        @if (groupMembers().length) {
+                          <ion-item
+                            button
+                            data-testid="center-action-detach-groups"
+                            (click)="onManageGroups('remove')"
+                            *appHasPermission="'DISASSOCIATEGROUPS_CENTER'"
+                          >
+                            <ion-label>{{ 'CENTERS.DETACH_GROUPS' | appTranslate }}</ion-label>
+                          </ion-item>
+                        }
+                        <ion-item
+                          button
+                          data-testid="center-action-edit"
+                          [routerLink]="['/centers/edit', centerId]"
+                          *appHasPermission="'UPDATE_CENTER'"
+                        >
+                          <ion-label>{{ 'COMMON.EDIT' | appTranslate }}</ion-label>
+                        </ion-item>
+                      }
+                    </ion-list>
+                  </ng-template>
+                </ion-popover>
+                <ion-button fill="clear" data-testid="center-back" (click)="onBack()">
+                  {{ 'COMMON.BACK' | appTranslate }}
+                </ion-button>
+              </div>
+            </div>
+          </ion-card-header>
+
+          <ion-card-content>
+            <ion-segment
+              [value]="activeTab()"
+              (ionChange)="activeTab.set($any($event).detail.value)"
+            >
+              <ion-segment-button [value]="TAB.GENERAL" data-testid="center-tab-general">
+                <ion-label>{{ 'COMMON.GENERAL' | appTranslate }}</ion-label>
+              </ion-segment-button>
+              <ion-segment-button [value]="TAB.NOTES" data-testid="center-tab-notes">
+                <ion-label>{{ 'COMMON.NOTES' | appTranslate }}</ion-label>
+              </ion-segment-button>
+              <ion-segment-button [value]="TAB.DATATABLES" data-testid="center-tab-datatables">
+                <ion-label>{{ 'COMMON.DATA_TABLES' | appTranslate }}</ion-label>
+              </ion-segment-button>
+            </ion-segment>
+
+            @switch (activeTab()) {
+              @case (TAB.GENERAL) {
+                <div class="summary-grid">
+                  <div class="summary-item">
+                    <span class="label">{{ 'COMMON.OFFICE' | appTranslate }}</span>
+                    <span class="value" data-testid="center-office">{{ detail.officeName }}</span>
+                  </div>
+                  <div class="summary-item">
+                    <span class="label">{{ 'COMMON.STAFF' | appTranslate }}</span>
+                    <span class="value" data-testid="center-staff-name">
+                      {{ detail.staffName || ('COMMON.UNASSIGNED' | appTranslate) }}
+                    </span>
+                  </div>
+                  <div class="summary-item">
+                    <span class="label">{{ 'CENTERS.ACTIVATION_DATE' | appTranslate }}</span>
+                    <span class="value" data-testid="center-activation-date">
+                      {{ activationDate() || '—' }}
+                    </span>
+                  </div>
+                  <div class="summary-item">
+                    <span class="label">{{ 'CENTERS.MEETING' | appTranslate }}</span>
+                    <span class="value" data-testid="center-meeting">
+                      {{ meetingSummary() }}
+                    </span>
+                  </div>
+                  <div class="summary-item">
+                    <span class="label">{{ 'CENTERS.GROUP_COUNT' | appTranslate }}</span>
+                    <span class="value" data-testid="center-group-count">
+                      {{ groupMembers().length }}
+                    </span>
+                  </div>
+                </div>
+
+                <h3 class="section-title">{{ 'CENTERS.GROUPS' | appTranslate }}</h3>
+                <app-data-table
+                  data-testid="center-groups-table"
+                  [columns]="groupColumns"
+                  [data]="groupMembers()"
+                  [totalRecords]="groupMembers().length"
+                  [showSearch]="true"
+                  [localLogic]="true"
+                >
+                  <ng-template appCellTemplate="name" let-row>
+                    <a [routerLink]="['/groups/view', row.id]" data-testid="center-group-link">
+                      {{ row.name }}
+                    </a>
+                  </ng-template>
+                  <ng-template appCellTemplate="status" let-row>
+                    <app-status-badge [status]="row.status?.value ?? ''"></app-status-badge>
+                  </ng-template>
+                </app-data-table>
+              }
+              @case (TAB.NOTES) {
+                <!--
+                  Notes are read and written through the *groups* resource.
+                  POST /centers/{id}/notes answers 404 "Note does not support resource centers",
+                  while /groups/{centerId}/notes works and stores a note of type "Group note" —
+                  a center is a group at a higher level in the platform's model.
+                -->
+                <app-group-notes-list
+                  [groupId]="centerId"
+                  [basePath]="'/centers'"
+                  data-testid="center-notes"
+                ></app-group-notes-list>
+              }
+              @case (TAB.DATATABLES) {
+                <app-entity-datatables
+                  data-testid="center-datatables"
+                  [entityId]="centerId"
+                  apptableName="m_center"
+                ></app-entity-datatables>
+              }
+            }
+          </ion-card-content>
+        </ion-card>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .page-container {
+        padding: 24px;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      .header-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+      h1 {
+        margin: 0;
+        font-size: 1.5rem;
+      }
+      .subtitle {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-top: 8px;
+      }
+      .account-no {
+        color: var(--text-muted, #6b7280);
+        font-size: 13px;
+      }
+      .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+        margin-top: 24px;
+      }
+      .summary-item {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .summary-item .label {
+        font-size: 12px;
+        color: var(--text-muted, #6b7280);
+      }
+      .summary-item .value {
+        font-weight: 600;
+      }
+      .section-title {
+        margin-top: 32px;
+        margin-bottom: 8px;
+      }
+      .load-error {
+        text-align: center;
+        padding: 48px 16px;
+      }
+    `,
+  ],
+})
+export class CenterViewComponent implements OnInit {
+  private readonly centersService = inject(CentersService);
+  private readonly groupsService = inject(GroupsService);
+  private readonly httpClient = inject(HttpClient);
+  private readonly basePath = inject(BASE_PATH);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly notifications = inject(NotificationService);
+  private readonly i18n = inject(I18N);
+
+  protected readonly TAB = TAB;
+
+  centerId = 0;
+  readonly center = signal<CenterDetail | null>(null);
+  readonly meeting = signal<CenterMeeting | null>(null);
+  readonly loadFailed = signal(false);
+  readonly activeTab = signal<string>(TAB.GENERAL);
+
+  readonly groupColumns: ColumnDef[] = [
+    { key: 'name', label: 'COMMON.NAME', sortable: true },
+    { key: 'accountNo', label: 'COMMON.ACCOUNT_NO', sortable: true },
+    { key: 'status', label: 'COMMON.STATUS', sortable: false },
+  ];
+
+  readonly groupMembers = computed<CenterGroupMember[]>(() => this.center()?.groupMembers ?? []);
+  readonly activationDate = computed(() =>
+    formatArrayDate(this.center()?.timeline?.activatedOnDate),
+  );
+
+  /**
+   * A meeting cannot start before the center was activated — the platform answers
+   * `validation.msg.calendar.cannot.be.before.centers.activation.date` — so the action is not
+   * offered until it is.
+   */
+  readonly canScheduleMeeting = computed(() => isCenterActive(this.center()));
+  readonly meetingSummary = computed(() => {
+    const meeting = this.meeting();
+    if (!meeting) return '—';
+    const frequency = meeting.frequency?.value ?? '';
+    return frequency ? `${meeting.title} (${frequency})` : (meeting.title ?? '—');
+  });
+
+  readonly canActivate = computed(() => isCenterPending(this.center()));
+  readonly canClose = computed(() => isCenterActive(this.center()));
+  readonly isClosed = computed(() => isCenterClosed(this.center()));
+
+  ngOnInit(): void {
+    this.centerId = Number(this.route.snapshot.paramMap.get('id'));
+    this.loadCenter();
+  }
+
+  /**
+   * Reads the center together with its groups.
+   *
+   * Goes through `HttpClient` rather than `getCentersCenterId`, whose generated signature carries
+   * no `associations` parameter — the same gap the deposit account view works around. Without the
+   * parameter the response has no `groupMembers` key at all, so the groups tab would be empty by
+   * construction rather than because the center has none. `associations=all` does *not* serve
+   * here either: on a center it returns nothing beyond the base fields.
+   */
+  loadCenter(): void {
+    this.loadFailed.set(false);
+
+    this.httpClient
+      .get<CenterDetail>(`${this.basePath}/v1/centers/${this.centerId}`, {
+        params: { associations: 'groupMembers' },
+      })
+      .subscribe({
+        next: (detail) => {
+          this.center.set(detail);
+          this.loadMeeting();
+        },
+        error: () => {
+          this.center.set(null);
+          this.loadFailed.set(true);
+        },
+      });
+  }
+
+  /**
+   * Reads the center's meeting.
+   *
+   * A center has at most one in practice, so the first calendar is the meeting. A failure here is
+   * deliberately not escalated to the whole page: the meeting is one field of the summary, and a
+   * center with an unreadable calendar is still worth showing.
+   */
+  private loadMeeting(): void {
+    this.httpClient
+      .get<CenterMeeting[]>(`${this.basePath}/v1/centers/${this.centerId}/calendars`)
+      .subscribe({
+        next: (calendars) => this.meeting.set(calendars?.[0] ?? null),
+        error: () => this.meeting.set(null),
+      });
+  }
+
+  async onScheduleMeeting(): Promise<void> {
+    const existing = this.meeting();
+    const result = await this.dialogService.open<CenterMeetingResult>(
+      CenterMeetingDialogComponent,
+      {
+        data: {
+          centerId: this.centerId,
+          meeting: existing ?? undefined,
+        } satisfies CenterMeetingDialogData,
+      },
+    );
+    if (!result) return;
+
+    const payload = {
+      title: result.title,
+      startDate: formatDateToFineract(result.startDate),
+      frequency: result.frequency,
+      interval: result.interval,
+      typeId: result.typeId,
+      repeating: true,
+      locale: FINERACT_LOCALE,
+      dateFormat: FINERACT_DATE_FORMAT,
+      ...(result.repeatsOnDay === undefined ? {} : { repeatsOnDay: result.repeatsOnDay }),
+    };
+    const url = `${this.basePath}/v1/centers/${this.centerId}/calendars`;
+
+    this.run(
+      existing?.id
+        ? this.httpClient.put(`${url}/${existing.id}`, payload)
+        : this.httpClient.post(url, payload),
+    );
+  }
+
+  async onAction(command: 'activate' | 'close'): Promise<void> {
+    const result = await this.dialogService.open<CenterActionResult>(CenterActionDialogComponent, {
+      data: { command } satisfies CenterActionDialogData,
+    });
+    if (!result) return;
+
+    const payload: Record<string, unknown> = {
+      locale: FINERACT_LOCALE,
+      dateFormat: FINERACT_DATE_FORMAT,
+    };
+    if (command === 'activate') {
+      payload['activationDate'] = formatDateToFineract(result.date);
+    } else {
+      payload['closureDate'] = formatDateToFineract(result.date);
+      payload['closureReasonId'] = result.closureReasonId;
+    }
+
+    // The generated request types describe neither the closure fields nor `groupMembers`; the
+    // platform accepts both. Casting at the call site keeps the untyped surface visible.
+    this.run(
+      this.centersService.postCentersCenterId(
+        this.centerId,
+        payload as PostCentersCenterIdRequest,
+        command,
+      ),
+    );
+  }
+
+  async onAssignStaff(): Promise<void> {
+    const detail = this.center();
+    const result = await this.dialogService.open<CenterStaffResult>(CenterStaffDialogComponent, {
+      data: {
+        officeId: detail?.officeId,
+        staffId: detail?.staffId,
+      } satisfies CenterStaffDialogData,
+    });
+    if (!result) return;
+
+    // Assignment is an update, not a command: the platform exposes no `assignStaff` on a center.
+    // `name` is mandatory on the update even though it is not being changed — omitting it answers
+    // `validation.msg.center.name.cannot.be.blank`.
+    this.run(
+      this.httpClient.put(`${this.basePath}/v1/centers/${this.centerId}`, {
+        name: detail?.name,
+        staffId: result.staffId,
+        locale: FINERACT_LOCALE,
+        dateFormat: FINERACT_DATE_FORMAT,
+      }),
+    );
+  }
+
+  async onUnassignStaff(): Promise<void> {
+    const staffId = this.center()?.staffId;
+    if (!staffId) return;
+
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('CENTERS.UNASSIGN_STAFF'),
+      message: this.i18n.translate('CENTERS.CONFIRM_UNASSIGN_STAFF'),
+    });
+    if (!confirmed) return;
+
+    // Unassignment has no center-side command, and the update path cannot express it either:
+    // `staffId: null` is ignored (the response reports no changes) and `staffId: -1` is rejected
+    // for not being greater than zero. It is reachable only through the groups resource, which
+    // accepts it for a center — and which rejects `locale` and `dateFormat` as unsupported, so
+    // the payload carries the staff id alone.
+    this.run(
+      this.groupsService.postGroupsGroupId(
+        this.centerId,
+        { staffId } as unknown as PostGroupsGroupIdRequest,
+        'unassignStaff',
+      ),
+    );
+  }
+
+  async onManageGroups(mode: 'add' | 'remove'): Promise<void> {
+    const result = await this.dialogService.open<CenterGroupsResult>(CenterGroupsDialogComponent, {
+      data: {
+        mode,
+        officeId: this.center()?.officeId,
+        members: this.groupMembers(),
+      } satisfies CenterGroupsDialogData,
+    });
+    if (!result) return;
+
+    const command =
+      mode === 'add' ? CENTER_COMMANDS.ASSOCIATE_GROUPS : CENTER_COMMANDS.DISASSOCIATE_GROUPS;
+    this.run(
+      this.centersService.postCentersCenterId(
+        this.centerId,
+        { groupMembers: result.groupMembers } as unknown as PostCentersCenterIdRequest,
+        command,
+      ),
+    );
+  }
+
+  onBack(): void {
+    void this.router.navigate(['/centers']);
+  }
+
+  private run(request: Observable<unknown>): void {
+    request.subscribe({
+      next: () => {
+        this.notifications.success(this.i18n.translate('COMMON.SUCCESS'));
+        this.loadCenter();
+      },
+      error: () => this.notifications.error(this.i18n.translate('COMMON.ERROR')),
+    });
+  }
+}

--- a/src/app/features/centers/centers-list.component.ts
+++ b/src/app/features/centers/centers-list.component.ts
@@ -20,7 +20,7 @@
 import { Component, inject, signal } from '@angular/core';
 
 import { TranslateModule } from '@ngx-translate/core';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { Subject, merge, of } from 'rxjs';
 import { catchError, map, startWith, switchMap, tap } from 'rxjs/operators';
 import {
@@ -37,6 +37,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
   selector: 'app-centers-list',
   standalone: true,
   imports: [
+    RouterModule,
     TranslateModule,
     StatusBadgeComponent,
     DataTableComponent,
@@ -60,6 +61,12 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
       [pageIndex]="pageIndex()"
       (pageChange)="onPage($event)"
     >
+      <ng-template appCellTemplate="name" let-center>
+        <a [routerLink]="['/centers/view', center.id]" data-testid="center-name-link">
+          {{ center.name }}
+        </a>
+      </ng-template>
+
       <ng-template appCellTemplate="status" let-center>
         <app-status-badge [status]="center.status?.value"></app-status-badge>
       </ng-template>

--- a/src/app/features/centers/centers.routes.ts
+++ b/src/app/features/centers/centers.routes.ts
@@ -32,4 +32,22 @@ export const CENTERS_ROUTES: Routes = [
     path: 'edit/:id',
     loadComponent: () => import('./center-form.component').then((m) => m.CenterFormComponent),
   },
+  {
+    path: 'view/:id',
+    loadComponent: () => import('./center-view.component').then((m) => m.CenterViewComponent),
+  },
+  // A center's notes are stored against the groups resource, so the note form is the group one.
+  // `basePath` sends it back to the center it was opened from rather than to a group view.
+  {
+    path: ':groupId/notes/create',
+    loadComponent: () =>
+      import('../groups/group-note-form.component').then((m) => m.GroupNoteFormComponent),
+    data: { basePath: '/centers' },
+  },
+  {
+    path: ':groupId/notes/edit/:id',
+    loadComponent: () =>
+      import('../groups/group-note-form.component').then((m) => m.GroupNoteFormComponent),
+    data: { basePath: '/centers' },
+  },
 ];

--- a/src/app/features/groups/group-note-form.component.ts
+++ b/src/app/features/groups/group-note-form.component.ts
@@ -132,6 +132,11 @@ export class GroupNoteFormComponent implements OnInit {
   private readonly i18n = inject(I18N);
 
   groupId!: number;
+  /**
+   * Where cancelling and saving return to. Centers reuse this form because their notes live under
+   * the groups resource, and returning them to a group view would be wrong.
+   */
+  basePath = '/groups';
   noteId?: number;
   isEditMode = false;
 
@@ -141,6 +146,7 @@ export class GroupNoteFormComponent implements OnInit {
 
   ngOnInit(): void {
     this.groupId = Number(this.route.snapshot.paramMap.get('groupId'));
+    this.basePath = (this.route.snapshot.data['basePath'] as string) ?? '/groups';
     const noteId = this.route.snapshot.paramMap.get('id');
 
     if (noteId) {
@@ -188,6 +194,6 @@ export class GroupNoteFormComponent implements OnInit {
   }
 
   onCancel(): void {
-    void this.router.navigate(['/groups/view', this.groupId]);
+    void this.router.navigate([`${this.basePath}/view`, this.groupId]);
   }
 }

--- a/src/app/features/groups/tabs/group-notes-list.component.ts
+++ b/src/app/features/groups/tabs/group-notes-list.component.ts
@@ -64,7 +64,7 @@ import { NotificationService } from '../../../core/services/notification.service
       <ion-button
         color="primary"
         data-testid="group-add-note"
-        [routerLink]="['/groups', groupId(), 'notes', 'create']"
+        [routerLink]="[basePath(), groupId(), 'notes', 'create']"
         *appHasPermission="'CREATE_GROUPNOTE'"
       >
         <ion-icon name="add-outline"></ion-icon>
@@ -89,7 +89,7 @@ import { NotificationService } from '../../../core/services/notification.service
           <ion-button
             fill="clear"
             color="primary"
-            [routerLink]="['/groups', groupId(), 'notes', 'edit', row.id]"
+            [routerLink]="[basePath(), groupId(), 'notes', 'edit', row.id]"
             *appHasPermission="'UPDATE_GROUPNOTE'"
             [appTooltip]="'COMMON.EDIT' | appTranslate"
             [attr.aria-label]="'COMMON.EDIT' | appTranslate"
@@ -126,6 +126,14 @@ import { NotificationService } from '../../../core/services/notification.service
 })
 export class GroupNotesListComponent implements OnInit {
   readonly groupId = input.required<number>();
+  /**
+   * Where the add and edit links point.
+   *
+   * A center's notes live under the *groups* resource — `/centers/{id}/notes` answers 404
+   * "Note does not support resource centers" — so the center view reuses this component with the
+   * center's id, and only the links need to stay inside `/centers`.
+   */
+  readonly basePath = input<string>('/groups');
 
   private readonly noteService = inject(NotesService);
   private readonly dialogService = inject(DialogService);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -269,7 +269,11 @@
     "VIEW_DETAILS": "View Details",
     "WEEKS": "Weeks",
     "YEARS": "Years",
-    "YES": "Yes"
+    "YES": "Yes",
+    "GENERAL": "General",
+    "NOTES": "Notes",
+    "DATA_TABLES": "Data Tables",
+    "UNASSIGNED": "Unassigned"
   },
   "ACTIONS": {
     "ACCOUNT_TRANSFER": "Account Transfer",
@@ -1196,7 +1200,34 @@
   "CENTERS": {
     "CREATE_CENTER": "Create Center",
     "EDIT_CENTER": "Edit Center",
-    "NAME": "Center Name"
+    "NAME": "Center Name",
+    "ACTIVATE": "Activate Center",
+    "CLOSE": "Close Center",
+    "ACTIVATION_DATE": "Activation Date",
+    "CLOSURE_DATE": "Closure Date",
+    "CLOSURE_REASON": "Closure Reason",
+    "NO_CLOSURE_REASONS": "No closure reasons have been configured, so this center cannot be closed. Add values to the CenterClosureReason code first.",
+    "ASSIGN_STAFF": "Assign Staff",
+    "UNASSIGN_STAFF": "Unassign Staff",
+    "CONFIRM_UNASSIGN_STAFF": "Unassign the member of staff currently responsible for this center?",
+    "NO_STAFF_IN_OFFICE": "No staff are available in this center’s office.",
+    "ATTACH_GROUPS": "Attach Groups",
+    "DETACH_GROUPS": "Detach Groups",
+    "SEARCH_GROUPS": "Search groups",
+    "NO_GROUPS_FOUND": "No unattached groups were found in this office.",
+    "NO_GROUPS": "This center has no groups.",
+    "GROUPS": "Groups",
+    "GROUP_COUNT": "Groups",
+    "LOAD_FAILED": "This center could not be loaded.",
+    "MEETING": "Meeting",
+    "ATTACH_MEETING": "Attach Meeting",
+    "EDIT_MEETING": "Edit Meeting",
+    "MEETING_TITLE": "Meeting Title",
+    "MEETING_START": "Starts On",
+    "MEETING_FREQUENCY": "Repeats",
+    "MEETING_INTERVAL": "Every",
+    "MEETING_TYPE": "Meeting Type",
+    "MEETING_DAY": "Repeats On"
   },
   "GROUPS": {
     "ACTIVATE": "Activate Group",


### PR DESCRIPTION
Closes #181.

`centers.routes.ts` declared list, create and edit. A center could be made and renamed and nothing else: its groups could not be seen or managed, staff could not be assigned, its meeting could not be scheduled, and it could not be activated or closed. For centre-based lending the center is the unit of daily work — and it is gated behind the institution types that advertise exactly that.

## What this adds

`/centers/view/:id` with **General**, **Notes** and **Data Tables** tabs, and an actions menu: activate, close, assign staff, unassign staff, attach groups, detach groups, and attach or reschedule the meeting. The center name in the list now links to it. The shell mirrors the group detail view, as the issue anticipated.

## What the platform actually does

Almost none of this is what the shape of the API suggests, and each point below is from probing a live instance rather than from documentation.

**The read must name the association.** `associations=all` returns *nothing* extra on a center — not even the group members that `associations=groupMembers` returns. The generated client has no `associations` parameter at all, so the read goes through `HttpClient`. Under the parameter that sounds right, the groups tab would have been empty by construction.

**A center is a group underneath**, and two operations exist *only* on the groups resource:

- `unassignStaff` — the center endpoint has no such command; `staffId: null` is silently ignored (the response reports no changes) and `staffId: -1` is refused for not being greater than zero. It also rejects `locale` and `dateFormat` as unsupported, so that payload carries the staff id alone.
- **Notes** — `/centers/{id}/notes` answers `404 "Note does not support resource centers"`, while `/groups/{centerId}/notes` stores one. The notes tab therefore reuses the group notes list against the center's id, with the links and the note form pointed back at the center rather than at a group view that does not exist.

**Assigning staff is an update, not a command**, and `name` is mandatory on it even though it is not being changed — omitting it answers `validation.msg.center.name.cannot.be.blank`, which reads like a form bug.

**Attach candidates come from `orphansOnly=true`**, the platform's own filter for groups with no parent center. Filtering this center's own members client-side would still have offered groups held by a *different* center, producing a refusal the operator cannot act on.

**A weekly meeting requires `repeatsOnDay`** (`validation.msg.calendar.repeatsOnDay.cannot.be.blank`), and no meeting may start before the center was activated. Weekly is the ordinary cadence for centre-based lending, so the day selector sits with the frequency rather than being hidden, and is withheld for the frequencies that reject it. This one was caught by the backend e2e failing, not by inspection — my first probe used a daily meeting, which needs no day.

Closure reasons come from `GET /centers/template?command=close`, and the `CenterClosureReason` code ships empty — so an institution that has not populated it cannot close a center at all. The dialog says that rather than presenting a select that looks broken.

## Not included

- **Attendance capture.** It needs a meeting-instance and per-client surface of its own, and the group detail view has no shell to share for it.
- **Staff assignment history.** This platform exposes no endpoint for it; `associations=all` returns nothing of the kind.

Both are called for by the issue, so they are flagged here rather than quietly dropped.

## Testing

- **955 unit specs** (up from 952 before this branch): the association-scoped read, the retry state, status gating, each command's exact payload, the staff update carrying the unchanged name, the bare unassign payload, attach/detach, a dismissed dialog sending nothing, and the weekly-meeting day handling on both create and update.
- **Backend e2e** against a real Fineract (`center-servicing.spec.ts`, registered in `BACKEND_SPECS`): a center activated, staffed, given a group, unstaffed, detached and finally given a weekly meeting; plus notes written through the groups resource and read back on the center.
- `lint`, `format:check`, `i18n:check`, `check:icons` and `build` clean.
