### PR TITLE
chore(e2e): let the suites record themselves as a demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ yarn-error.log
 # Playwright
 /playwright-report
 /test-results
+/demo-recordings
 /playwright-results.json
 
 # Miscellaneous

--- a/DOCS/DEMO.md
+++ b/DOCS/DEMO.md
@@ -1,0 +1,80 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+# Recording a demo of the application
+
+The end-to-end suites double as the demo. Every backend spec drives a real Fineract through the
+real UI, so recording them produces a walkthrough of what the application actually does — rather
+than a separate demo script that would drift from it the first time a screen changed.
+
+```bash
+npm run e2e:stack        # bring up Fineract (add --fresh for a clean volume)
+npm run demo:record
+```
+
+Videos land in `demo-recordings/`, one directory per test, each containing `video.webm`. The
+directory is git-ignored.
+
+## What the switches do
+
+| Variable                | Effect                                                                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEMO_RECORD=1`         | Records every spec, not only the ones that fail. Read in `playwright.config.ts`.                                                                                                            |
+| `DEMO_BEAT_MS`          | Inserts a pause between steps so a recording is watchable. Cosmetic: nothing synchronises on it, so the specs are equally correct with it unset. Currently honoured by `full-demo.spec.ts`. |
+| `PLAYWRIGHT_OUTPUT_DIR` | Where the recordings are written.                                                                                                                                                           |
+
+`npm run demo:record` sets all three and runs the `backend` project with a single worker, so the
+recordings are in a sensible order rather than interleaved.
+
+## What each recording shows
+
+| Flow                                                                                                                                                | Spec                                                                                                              |
+| --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Offices, loan products, a client, the full loan lifecycle, custom fields, collateral, disbursement details, notes, and a repayment that is adjusted | `full-demo.spec.ts`                                                                                               |
+| Center detail view: activate, assign and unassign staff, attach and detach groups, schedule the weekly meeting, notes                               | `center-servicing.spec.ts`                                                                                        |
+| Group membership and lifecycle                                                                                                                      | `group-membership.spec.ts`                                                                                        |
+| Client transfers between offices                                                                                                                    | `client-transfer.spec.ts`                                                                                         |
+| Savings transaction correction — deposits, holds, releases and undo                                                                                 | `savings-transaction-correction.spec.ts`                                                                          |
+| Term deposit servicing — lifecycle, transactions and undo                                                                                           | `deposit-account-servicing.spec.ts`                                                                               |
+| Deposit product configuration                                                                                                                       | `deposit-product-configuration.spec.ts`                                                                           |
+| Product accounting — loan and share products mapped to the ledger                                                                                   | `loan-product-accounting.spec.ts`, `share-product-accounting.spec.ts`                                             |
+| Reporting — dynamic and cascading parameters, and chart reports                                                                                     | `report-parameter-backend.spec.ts`                                                                                |
+| Loan servicing — charge-off, schedule type, account actions                                                                                         | `loan-charge-off.spec.ts`, `loan-schedule-type.spec.ts`, `loan-account-actions.spec.ts`, `loan-servicing.spec.ts` |
+| Share account servicing                                                                                                                             | `share-account-servicing.spec.ts`                                                                                 |
+| Teller cash management                                                                                                                              | `teller-cash-management.spec.ts`                                                                                  |
+| Login and tenant selection                                                                                                                          | `login.spec.ts`                                                                                                   |
+
+To record one flow on its own:
+
+```bash
+DEMO_RECORD=1 DEMO_BEAT_MS=900 npm run test:e2e:local -- e2e/center-servicing.spec.ts
+```
+
+## Stitching the recordings together
+
+Playwright writes one `webm` per test. Any player handles them individually; to concatenate them
+into a single file, `ffmpeg` will do it — it is not needed to record or to watch them:
+
+```bash
+find demo-recordings -name video.webm | sort | sed "s|^|file '$PWD/|;s|$|'|" > /tmp/demo-list.txt
+ffmpeg -f concat -safe 0 -i /tmp/demo-list.txt -c copy demo.webm
+```
+
+The clips have no audio and no captions. They are a record of the flows working, not a produced
+video — if a narrated demo is needed, these are the raw material for it.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "i18n:check": "node scripts/check-translations.mjs",
     "check:icons": "node scripts/check-icons.mjs",
     "api:surface": "node scripts/check-api-surface.mjs",
-    "ga:check": "node scripts/ga-check.mjs"
+    "ga:check": "node scripts/ga-check.mjs",
+    "demo:record": "DEMO_RECORD=1 DEMO_BEAT_MS=900 PLAYWRIGHT_OUTPUT_DIR=demo-recordings FINERACT_SERVER_URL=/fineract-provider/api/v1 FINERACT_TENANT_ID=default FINERACT_USERNAME=mifos FINERACT_PASSWORD=password playwright test --project=backend --workers=1"
   },
   "prettier": {
     "printWidth": 100,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,7 +56,10 @@ export default defineConfig({
     baseURL: 'https://localhost:4200',
     trace: 'on-first-retry',
     ignoreHTTPSErrors: true,
-    video: process.env.CI ? 'on' : 'retain-on-failure',
+    // `DEMO_RECORD=1` records every spec, not just the ones that fail — the suites *are* the
+    // flows, so recording them is what produces a demo of the application rather than a separate
+    // script that could drift from what the app actually does. See DOCS/DEMO.md.
+    video: process.env.DEMO_RECORD === '1' || process.env.CI ? 'on' : 'retain-on-failure',
   },
   projects: [
     // Seeds the reference data the real-backend specs need — enabled currencies, a


### PR DESCRIPTION
The end-to-end suites already drive a real Fineract through the real UI, so they *are* a walkthrough of the application. `full-demo.spec.ts` was already recorded that way; this makes the same switch available to all of them.

```bash
npm run e2e:stack        # add --fresh for a clean volume
npm run demo:record
```

`DEMO_RECORD=1` turns video on for every spec rather than only for failures, and the script sets it together with the pacing (`DEMO_BEAT_MS`) and an output directory, running the backend project single-worker so the clips come out in a sensible order.

**Verified by running it:** 46 tests, **45 videos, 198 MB**, covering the loan lifecycle, groups, centers, savings and deposit servicing, product accounting, reporting, teller cash management, client transfers and login.

## Why record the suites instead of writing a demo script

A demo script has nothing keeping it honest, and drifts from the application the first time a screen changes. These clips cannot drift: a flow that stopped working would fail the suite before it recorded anything. The recording is a by-product of the tests passing, which is exactly the property you want from a demo.

`DOCS/DEMO.md` maps each flow to the spec that records it, and gives the `ffmpeg` incantation for stitching the clips into one file — ffmpeg is needed for that alone, not to record or to watch them.

The clips have no audio and no captions. They are a record of the flows working, not a produced video; if a narrated demo is wanted, these are the raw material.
