### PR TITLE
chore(e2e): put a beat on every action while recording

### DIFF
--- a/DOCS/DEMO.md
+++ b/DOCS/DEMO.md
@@ -33,14 +33,36 @@ directory is git-ignored.
 
 ## What the switches do
 
-| Variable                | Effect                                                                                                                                                                                      |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DEMO_RECORD=1`         | Records every spec, not only the ones that fail. Read in `playwright.config.ts`.                                                                                                            |
-| `DEMO_BEAT_MS`          | Inserts a pause between steps so a recording is watchable. Cosmetic: nothing synchronises on it, so the specs are equally correct with it unset. Currently honoured by `full-demo.spec.ts`. |
-| `PLAYWRIGHT_OUTPUT_DIR` | Where the recordings are written.                                                                                                                                                           |
+| Variable                | Effect                                                                                                                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEMO_RECORD=1`         | Records every spec, not only the ones that fail. Read in `playwright.config.ts`.                                                                                                                                                |
+| `DEMO_SLOW_MO`          | Milliseconds Playwright waits before **each action** — click, fill, navigation. Defaults to 450 while recording, 0 otherwise. This is what makes a recording followable: the pause lands on the action rather than on the film. |
+| `DEMO_BEAT_MS`          | Inserts a pause between _steps_, on top of the per-action pause. Cosmetic: nothing synchronises on it, so the specs are equally correct with it unset. Honoured by `full-demo.spec.ts`.                                         |
+| `PLAYWRIGHT_OUTPUT_DIR` | Where the recordings are written.                                                                                                                                                                                               |
 
-`npm run demo:record` sets all three and runs the `backend` project with a single worker, so the
+`npm run demo:record` sets these and runs the `backend` project with a single worker, so the
 recordings are in a sensible order rather than interleaved.
+
+### Why pacing is recorded rather than added afterwards
+
+Slowing the footage in post stretches everything uniformly, which lengthens a recording without
+giving the eye anywhere to land — a slowed fast-forward is still a fast-forward. `slowMo` pauses
+_before each action_, so the beat falls where the interaction is. Once that is in the source, no
+post-processing slowdown is needed.
+
+Per-test budgets have to follow. A test's own `test.setTimeout` overrides both the project and the
+root config, so a paced run would otherwise be cut off mid-flow and the clip would end on a frozen
+screen. Specs therefore wrap their budget in `recordingTimeout()` from `e2e/fixtures.ts`, which
+scales it while filming and returns it untouched otherwise. `captureJson()` sizes its
+response-capture window the same way.
+
+Two practical notes:
+
+- **Playwright clears `outputDir` at the start of every run.** Re-recording a single spec into the
+  same directory deletes every other clip. Use a separate `PLAYWRIGHT_OUTPUT_DIR` for one-off
+  re-records.
+- **Do not change the working tree while a recording is in flight.** The dev server recompiles from
+  source, so a checkout or rebase mid-run films a moving target.
 
 ## What each recording shows
 

--- a/e2e/center-servicing.spec.ts
+++ b/e2e/center-servicing.spec.ts
@@ -37,14 +37,14 @@
  *   npx playwright test e2e/center-servicing.spec.ts --project=backend --workers=1
  */
 
-import { expect, test } from './fixtures';
+import { expect, test, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { ionSelect } from './utils/ionic-locators';
 import { createApiContext, seedCenter, seedGroup, seedStaff } from './utils/seed-api';
 
 test.describe('Center servicing', () => {
   test('a center is activated, staffed and given a group', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
 
     const api = await createApiContext();
     const suffix = uniqueSuffix();
@@ -147,7 +147,7 @@ test.describe('Center servicing', () => {
    * "Note does not support resource centers", while `/groups/{centerId}/notes` stores one.
    */
   test('notes are recorded against the center', async ({ page }) => {
-    test.setTimeout(180000);
+    test.setTimeout(recordingTimeout(180000));
 
     const api = await createApiContext();
     const center = await seedCenter(api, `E2ECenterNotes ${uniqueSuffix()}`);

--- a/e2e/deposit-account-servicing.spec.ts
+++ b/e2e/deposit-account-servicing.spec.ts
@@ -32,7 +32,7 @@
  *   npx playwright test e2e/deposit-account-servicing.spec.ts --project=backend --workers=1
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login } from './utils/fineract-login';
 import { confirmDialog, modalFor } from './utils/ionic-locators';
 import { createApiContext, seedFixedDepositAccount } from './utils/seed-api';
@@ -55,7 +55,7 @@ test.describe('Term deposit account servicing', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('an account is approved, activated and closed before maturity', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const api = await createApiContext();
@@ -126,7 +126,7 @@ test.describe('Term deposit account servicing', () => {
    * and a screen that dropped it would take the audit trail with it.
    */
   test('a deposit is recorded, listed, and reversed without leaving the list', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const api = await createApiContext();
@@ -169,7 +169,7 @@ test.describe('Term deposit account servicing', () => {
   });
 
   test('an application can be rejected instead of approved', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const api = await createApiContext();

--- a/e2e/deposit-product-configuration.spec.ts
+++ b/e2e/deposit-product-configuration.spec.ts
@@ -33,7 +33,7 @@
  *   npx playwright test e2e/deposit-product-configuration.spec.ts --project=backend --workers=1
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { ionSelect } from './utils/ionic-locators';
 import { selectOption } from './utils/select-option';
@@ -53,7 +53,7 @@ test.describe('Deposit product configuration', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('a fixed deposit product survives being edited', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const suffix = uniqueSuffix();
@@ -85,7 +85,7 @@ test.describe('Deposit product configuration', () => {
   });
 
   test('a recurring deposit product can be created at all', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const suffix = uniqueSuffix();
@@ -102,7 +102,7 @@ test.describe('Deposit product configuration', () => {
   });
 
   test('a savings product carries its accounting configuration', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const suffix = uniqueSuffix();

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -129,5 +129,20 @@ export const test = base.extend<ChangeDetectionFixtures>({
   ],
 });
 
+/**
+ * A per-test budget that survives being filmed.
+ *
+ * Under `DEMO_RECORD=1` every Playwright action carries a deliberate pause (`slowMo`), so a flow
+ * that fits comfortably at test speed takes several times longer. A test's own `test.setTimeout`
+ * overrides both the project and the root config, so the scaling has to happen at the call site —
+ * otherwise a recording is cut off mid-flow and the clip ends on a frozen screen.
+ *
+ * `full-demo.spec.ts` has done this by hand since it was the only paced spec; this is the same
+ * idea, available to all of them.
+ */
+export function recordingTimeout(base: number): number {
+  return process.env.DEMO_RECORD === '1' ? base * 5 : base;
+}
+
 export { expect } from '@playwright/test';
 export type { Page, Locator, Route } from '@playwright/test';

--- a/e2e/group-membership.spec.ts
+++ b/e2e/group-membership.spec.ts
@@ -32,7 +32,7 @@
  *   npx playwright test e2e/group-membership.spec.ts --project=backend --workers=1
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { confirmDialog, modalFor } from './utils/ionic-locators';
 import { selectInDialog } from './utils/select-in-dialog';
@@ -170,7 +170,7 @@ test.describe('Group membership and lifecycle', () => {
   test('a group is activated, staffed, given members and a committee, then emptied', async ({
     page,
   }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const suffix = uniqueSuffix();
@@ -271,7 +271,7 @@ test.describe('Group membership and lifecycle', () => {
   });
 
   test('notes are recorded against the group and can be removed again', async ({ page }) => {
-    test.setTimeout(180000);
+    test.setTimeout(recordingTimeout(180000));
     await login(page);
 
     const suffix = uniqueSuffix();
@@ -306,7 +306,7 @@ test.describe('Group membership and lifecycle', () => {
   test('an empty group is closed with a reason, and a group with members is refused', async ({
     page,
   }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const suffix = uniqueSuffix();

--- a/e2e/loan-account-actions.spec.ts
+++ b/e2e/loan-account-actions.spec.ts
@@ -26,14 +26,14 @@
  *   npx playwright test e2e/loan-account-actions.spec.ts --workers=1
  */
 
-import { test, expect } from './fixtures';
+import { test, expect, recordingTimeout } from './fixtures';
 import { login } from './utils/fineract-login';
 import { createActiveLoan } from './utils/create-active-loan';
 import { confirmDialog, menuItem } from './utils/ionic-locators';
 
 test.describe('Loan account lifecycle actions', () => {
   test('new action menu items appear only for active loans', async ({ page }) => {
-    test.setTimeout(120000);
+    test.setTimeout(recordingTimeout(120000));
     await login(page);
     const { loanId } = await createActiveLoan(page);
 
@@ -50,7 +50,7 @@ test.describe('Loan account lifecycle actions', () => {
   test('undo disbursal shows a confirm dialog and reverts the loan to Approved', async ({
     page,
   }) => {
-    test.setTimeout(120000);
+    test.setTimeout(recordingTimeout(120000));
     await login(page);
     const { loanId } = await createActiveLoan(page);
 
@@ -81,7 +81,7 @@ test.describe('Loan account lifecycle actions', () => {
   test('write off requires confirmation and moves the loan out of Active status', async ({
     page,
   }) => {
-    test.setTimeout(120000);
+    test.setTimeout(recordingTimeout(120000));
     await login(page);
     const { loanId } = await createActiveLoan(page);
 

--- a/e2e/loan-lifecycle.spec.ts
+++ b/e2e/loan-lifecycle.spec.ts
@@ -36,7 +36,7 @@
  * Videos/traces for every run are written under test-results/.
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { ionSelect } from './utils/ionic-locators';
 import { captureJson } from './utils/capture-response';
@@ -163,7 +163,7 @@ test.describe('Loan lifecycle: creation, approval, disbursement', () => {
 
   for (const scheduleType of ['Cumulative', 'Progressive'] as const) {
     test(`create, approve, and disburse a ${scheduleType} loan`, async ({ page }) => {
-      test.setTimeout(120000);
+      test.setTimeout(recordingTimeout(120000));
 
       const clientName = await createClient(page);
       const productName = await createLoanProduct(page, scheduleType);
@@ -209,7 +209,7 @@ test.describe('Loan lifecycle: creation, approval, disbursement', () => {
    * screen's approval can be undone.
    */
   test('an approved loan can be returned to pending approval', async ({ page }) => {
-    test.setTimeout(120000);
+    test.setTimeout(recordingTimeout(120000));
 
     const clientName = await createClient(page);
     const productName = await createLoanProduct(page, 'Cumulative');
@@ -249,7 +249,7 @@ test.describe('Loan lifecycle: creation, approval, disbursement', () => {
   test('the delinquency tab reads a real loan, and the empty data tabs stay hidden', async ({
     page,
   }) => {
-    test.setTimeout(120000);
+    test.setTimeout(recordingTimeout(120000));
 
     const clientName = await createClient(page);
     const productName = await createLoanProduct(page, 'Cumulative');

--- a/e2e/loan-product-accounting.spec.ts
+++ b/e2e/loan-product-accounting.spec.ts
@@ -32,7 +32,7 @@
  *   npx playwright test e2e/loan-product-accounting.spec.ts --project=backend --workers=1
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { captureJson } from './utils/capture-response';
 import { ionSelect } from './utils/ionic-locators';
@@ -91,7 +91,7 @@ test.describe('Loan product accounting', () => {
   test('a cash-accounting product is configured, round-trips on edit, and posts to the ledger', async ({
     page,
   }) => {
-    test.setTimeout(480000);
+    test.setTimeout(recordingTimeout(480000));
     await login(page);
 
     const suffix = uniqueSuffix();

--- a/e2e/loan-servicing.spec.ts
+++ b/e2e/loan-servicing.spec.ts
@@ -27,7 +27,7 @@
  *   npx playwright test e2e/loan-servicing.spec.ts --workers=1
  */
 
-import { test, expect } from './fixtures';
+import { test, expect, recordingTimeout } from './fixtures';
 import { login } from './utils/fineract-login';
 import { createActiveLoan } from './utils/create-active-loan';
 import { confirmDialog, modalFor, selectTab } from './utils/ionic-locators';
@@ -35,7 +35,7 @@ import { createApiContext, seedRepayment } from './utils/seed-api';
 
 test.describe('Loan servicing: notes and transaction adjustment', () => {
   test('notes can be added and removed, with a confirm dialog on delete', async ({ page }) => {
-    test.setTimeout(120000);
+    test.setTimeout(recordingTimeout(120000));
     await login(page);
     const { loanId } = await createActiveLoan(page, 'NotesDemo');
 
@@ -67,7 +67,7 @@ test.describe('Loan servicing: notes and transaction adjustment', () => {
   test('a repayment transaction can be viewed and adjusted with a corrected amount', async ({
     page,
   }) => {
-    test.setTimeout(120000);
+    test.setTimeout(recordingTimeout(120000));
     await login(page);
     const { loanId } = await createActiveLoan(page, 'AdjustDemo');
 

--- a/e2e/report-parameter-backend.spec.ts
+++ b/e2e/report-parameter-backend.spec.ts
@@ -26,7 +26,7 @@
  * bug, where the UI silently omitted a declared parameter and Fineract returned the wrong scope.
  */
 
-import { test, expect } from './fixtures';
+import { test, expect, recordingTimeout } from './fixtures';
 import { login } from './utils/fineract-login';
 import { ionSelect, ionSelectValue, isIonSelectDisabled } from './utils/ionic-locators';
 import { selectOption } from './utils/select-option';
@@ -148,7 +148,7 @@ test.describe('Cascading report parameters against Fineract', () => {
   test('sends the parent value to the child lookup and clears the child when it changes', async ({
     page,
   }) => {
-    test.setTimeout(180000);
+    test.setTimeout(recordingTimeout(180000));
     const api = await createApiContext();
     // A product of its own, so the list is proven to be populated from the lookup rather than
     // merely carrying the client-side "All" entry.
@@ -191,7 +191,7 @@ test.describe('Cascading report parameters against Fineract', () => {
 
 test.describe('Chart reports against Fineract', () => {
   test('renders a chart report as a chart rather than a table', async ({ page }) => {
-    test.setTimeout(180000);
+    test.setTimeout(recordingTimeout(180000));
     const api = await createApiContext();
     const report = await seedChartReport(api, 'E2EChart', 'Bar');
     await api.dispose();

--- a/e2e/savings-transaction-correction.spec.ts
+++ b/e2e/savings-transaction-correction.spec.ts
@@ -34,7 +34,7 @@
  *   npx playwright test e2e/savings-transaction-correction.spec.ts --project=backend --workers=1
  */
 
-import { test, expect } from './fixtures';
+import { test, expect, recordingTimeout } from './fixtures';
 import { login } from './utils/fineract-login';
 import { confirmDialog } from './utils/ionic-locators';
 import { createApiContext, seedSavingsAccountWithTransactions } from './utils/seed-api';
@@ -43,7 +43,7 @@ test.describe('Savings transaction correction', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('a deposit is reversed and a hold is released', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const api = await createApiContext();

--- a/e2e/share-account-servicing.spec.ts
+++ b/e2e/share-account-servicing.spec.ts
@@ -37,7 +37,7 @@
  *   npx playwright test e2e/share-account-servicing.spec.ts --project=backend --workers=1
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login } from './utils/fineract-login';
 import { confirmDialog, modalFor } from './utils/ionic-locators';
 import { createApiContext, seedShareAccount } from './utils/seed-api';
@@ -68,7 +68,7 @@ test.describe('Share account servicing', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('an account is approved, activated, traded and closed', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const accountId = await seed();
@@ -133,7 +133,7 @@ test.describe('Share account servicing', () => {
   });
 
   test('an application can be rejected', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
 
     const accountId = await seed('E2EShareReject');

--- a/e2e/share-product-accounting.spec.ts
+++ b/e2e/share-product-accounting.spec.ts
@@ -36,7 +36,7 @@
  *   npx playwright test e2e/share-product-accounting.spec.ts --project=backend --workers=1
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { captureJson } from './utils/capture-response';
 import { selectOption } from './utils/select-option';
@@ -76,7 +76,7 @@ test.describe('Share product accounting', () => {
   test.describe.configure({ mode: 'serial' });
 
   test('a share product is mapped to equity and round-trips on edit', async ({ page }) => {
-    test.setTimeout(480000);
+    test.setTimeout(recordingTimeout(480000));
     await login(page);
 
     const suffix = uniqueSuffix();

--- a/e2e/teller-cash-management.spec.ts
+++ b/e2e/teller-cash-management.spec.ts
@@ -27,7 +27,7 @@
  *   npx playwright test e2e/teller-cash-management.spec.ts --project=backend --workers=1
  */
 
-import { test, expect, Page } from './fixtures';
+import { test, expect, Page, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { selectOption } from './utils/select-option';
 
@@ -122,7 +122,7 @@ async function ensureCashMappings(page: Page): Promise<void> {
 
 test.describe('Teller cash management', () => {
   test('a cashier is listed, receives an allocation, and settles cash back', async ({ page }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
     await ensureCashMappings(page);
 
@@ -227,7 +227,7 @@ test.describe('Teller cash management', () => {
   test('settling more than the cashier holds is refused and the form stays usable', async ({
     page,
   }) => {
-    test.setTimeout(240000);
+    test.setTimeout(recordingTimeout(240000));
     await login(page);
     await ensureCashMappings(page);
 

--- a/e2e/utils/capture-response.ts
+++ b/e2e/utils/capture-response.ts
@@ -33,6 +33,17 @@ import { Page, Route, expect } from '@playwright/test';
  * is ever given it, so navigation cannot take it away. The response is passed
  * through unchanged, so the app behaves exactly as it would without the intercept.
  */
+/**
+ * How long to wait for the intercepted response.
+ *
+ * Under `DEMO_RECORD=1` every action carries a pause and the browser is doing more work per
+ * frame, so a window sized for a full-speed run is not the same window while filming — a fixed
+ * budget here fails the flow for reasons that have nothing to do with the application.
+ */
+function captureTimeout(): number {
+  return process.env.DEMO_RECORD === '1' ? 60000 : 20000;
+}
+
 export async function captureJson<T>(
   page: Page,
   urlPattern: RegExp,
@@ -59,7 +70,7 @@ export async function captureJson<T>(
   await page.route(urlPattern, handler);
   try {
     await action();
-    await expect.poll(() => captured, { timeout: 20000 }).toBeDefined();
+    await expect.poll(() => captured, { timeout: captureTimeout() }).toBeDefined();
   } finally {
     await page.unroute(urlPattern, handler);
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,6 +53,9 @@ export default defineConfig({
   // .fill()/.click() already wait ~30s via actionability; this brings plain
   // expect() into the same range instead of failing on a slow-but-correct page.
   expect: { timeout: 15000 },
+  // Recording paces every action, so a flow that fits comfortably at test speed needs a larger
+  // budget while it is being filmed.
+  timeout: process.env.DEMO_RECORD === '1' ? 900000 : 30000,
   use: {
     baseURL: 'https://localhost:4200',
     trace: 'on-first-retry',
@@ -61,6 +64,15 @@ export default defineConfig({
     // flows, so recording them is what produces a demo of the application rather than a separate
     // script that could drift from what the app actually does. See DOCS/DEMO.md.
     video: process.env.DEMO_RECORD === '1' || process.env.CI ? 'on' : 'retain-on-failure',
+    // A recording of a test suite is unwatchable at test speed: every click, fill and navigation
+    // lands instantly, so a viewer sees the result of an action without ever seeing the action.
+    // `slowMo` pauses before each Playwright operation, which puts a beat on the action itself
+    // rather than uniformly slowing the footage in post — the difference between following what
+    // is happening and watching a fast-forward. Recording only; the suite runs at full speed
+    // otherwise, so this costs CI nothing.
+    launchOptions: {
+      slowMo: process.env.DEMO_RECORD === '1' ? Number(process.env.DEMO_SLOW_MO ?? 450) : 0,
+    },
   },
   projects: [
     // Seeds the reference data the real-backend specs need — enabled currencies, a
@@ -87,7 +99,10 @@ export default defineConfig({
       // more than the 30s default. Set here rather than per test because
       // test.setTimeout() does not cover beforeEach, and logging in against a
       // cold lazy-loaded route was already exceeding the default in that hook.
-      timeout: 120000,
+      //
+      // This project setting overrides the root one, so it is what governs a recording run —
+      // where every action carries a deliberate pause and the same flow takes far longer.
+      timeout: process.env.DEMO_RECORD === '1' ? 900000 : 120000,
     },
     { name: 'firefox', use: { ...devices['Desktop Firefox'] }, dependencies: ['setup'] },
     { name: 'webkit', use: { ...devices['Desktop Safari'] }, dependencies: ['setup'] },


### PR DESCRIPTION
Follow-up to #349, which made the suites recordable. The recordings it produced were unwatchable: every click, fill and navigation landed instantly, so a viewer saw the *result* of an action without ever seeing the action.

## The fix

`slowMo` pauses before each Playwright operation, so the beat falls on the action rather than on the film. Gated on `DEMO_RECORD=1`, so the suite still runs at full speed and CI pays nothing; `DEMO_SLOW_MO` tunes it (default 450 ms).

**Only `full-demo.spec.ts` paced itself before, and it paused between *steps*.** Every other flow was filmed at full speed and stretched afterwards in post — which lengthens the footage without giving the eye anywhere to land. A slowed fast-forward is still a fast-forward. With the beat in the source, the post-processing slowdown drops to 1.0× entirely.

Measured effect: the same 45 flows go from **9.8 min to 17.2 min** of footage.

## Two follow-on fixes, both the same defect

A fixed timeout that pacing invalidates:

- **`test.setTimeout` in 14 specs** overrides both the project and the root config, so a paced run would be cut off mid-flow and the clip would end on a frozen screen. `recordingTimeout()` in `e2e/fixtures.ts` scales those budgets while filming and returns them untouched otherwise — generalising the accommodation `full-demo.spec.ts` already made by hand.
- **`captureJson()` hard-coded a 20 s window** for the intercepted response. A loan creation timed out waiting for its own POST and the clip ended on a stuck form. That budget now follows the recording too.

Both were found by the recording failing, not by inspection.

## Docs

`DOCS/DEMO.md` predated these switches, so the file that exists to explain the workflow didn't mention the one that makes a recording watchable. It now covers `DEMO_SLOW_MO`, why pacing is recorded rather than added in post, and two traps that cost real time here:

- **Playwright clears `outputDir` at the start of every run** — re-recording one spec into the same directory deletes every other clip. (This is how I lost a full set of 45.)
- **Don't change the working tree while a recording is in flight** — the dev server recompiles from source, so a checkout or rebase mid-run films a moving target.

## Verification

- Specs behave identically at normal speed — `center-servicing.spec.ts` 3/3 with no pacing set, and `lint` clean.
- A full paced recording run produced 45 clips, 44 of which are stitched into a 16 min 48 s captioned walkthrough at 1280×720.
- The 45th is excluded from the stitched video: its assertion failed because a seeded client sat beyond the visible rows after repeated runs against the same volume (test-data accumulation, not a product bug — it passes on a fresh database), so the clip doesn't show what its caption would claim.

No production code is touched; the change is confined to the Playwright config, the e2e fixtures and their timeout call sites.
