### PR TITLE
feat: gate the screens that drive Fineract's test-only endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,12 @@ jobs:
         run: npm run i18n:check
       - name: Verify every ion-icon name is registered
         run: npm run check:icons
+      # Fineract serves /v1/internal/** only under its `test` Spring profile, which upstream
+      # states must not be enabled in production. The few screens built on those endpoints are
+      # gated behind `developerToolsEnabled`; this pins that list so a new dependency on a
+      # test-only endpoint has to be a deliberate choice.
+      - name: Verify no ungated dependency on test-only Fineract endpoints
+        run: npm run check:internal-endpoints
 
   test:
     name: Unit Tests

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "verify-api-client": "npm run generate-api && git diff --exit-code src/app/api",
     "i18n:check": "node scripts/check-translations.mjs",
     "check:icons": "node scripts/check-icons.mjs",
+    "check:internal-endpoints": "node scripts/check-internal-endpoints.mjs",
     "api:surface": "node scripts/check-api-surface.mjs",
     "ga:check": "node scripts/ga-check.mjs",
     "demo:record": "DEMO_RECORD=1 DEMO_BEAT_MS=900 PLAYWRIGHT_OUTPUT_DIR=demo-recordings FINERACT_SERVER_URL=/fineract-provider/api/v1 FINERACT_TENANT_ID=default FINERACT_USERNAME=mifos FINERACT_PASSWORD=password playwright test --project=backend --workers=1"

--- a/public/config.json
+++ b/public/config.json
@@ -2,5 +2,6 @@
   "fineractApiUrl": "/api/v1",
   "defaultTenant": "default",
   "rbacEnabled": true,
-  "institutionType": "universal"
+  "institutionType": "universal",
+  "developerToolsEnabled": false
 }

--- a/scripts/check-internal-endpoints.mjs
+++ b/scripts/check-internal-endpoints.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Stops Fineract's test-only endpoints from re-entering the product surface unnoticed.
+ *
+ * Fineract serves `/v1/internal/**` only when the backend runs with its `test` Spring profile,
+ * which upstream states must not be enabled in production. On a normal deployment every one of
+ * those endpoints answers 404, so a screen built on them cannot work for a real user.
+ *
+ * The application keeps a small number of such screens deliberately, as tooling for a test
+ * instance. They are gated behind `developerToolsEnabled` in `config.json` — hidden from the
+ * navigation and unreachable by URL unless a deployment opts in. This check does not ban the
+ * pattern; it pins the list, so that adding a *new* dependency on an internal endpoint is a
+ * decision someone makes on purpose rather than a thing that quietly happens.
+ *
+ * Discovery is done from the generated client rather than from a hardcoded list of names: each
+ * generated method carries an `@endpoint <verb> <path>` tag, so the set of internal methods is
+ * derived from whatever the current spec says, and follows it when the spec changes.
+ *
+ *   node scripts/check-internal-endpoints.mjs
+ *
+ * Exit 1 on an unapproved reference, or on an allow-list entry that no longer references one —
+ * a stale entry is as misleading as a missing one.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const GENERATED_API = join(ROOT, 'src', 'app', 'api');
+
+/**
+ * Files permitted to call an internal endpoint, and why.
+ *
+ * Every entry must be gated by `developerToolsEnabled` — through the route guard, the navigation
+ * flag, or a template condition. Adding a file here without gating it defeats the point.
+ */
+const ALLOWED = new Map([
+  [
+    'src/app/features/admin/cob-tools/cob-tools.component.ts',
+    'COB tooling for a test instance; route gated by developerToolsGuard',
+  ],
+  [
+    'src/app/features/admin/wc-cob-tools/wc-cob-tools.component.ts',
+    'Working-capital COB tooling for a test instance; route gated by developerToolsGuard',
+  ],
+  [
+    'src/app/features/admin/external-events/external-events.component.ts',
+    'Internal external-event log for a test instance; route gated by developerToolsGuard',
+  ],
+  [
+    'src/app/features/admin/progressive-loan/progressive-loan-model.component.ts',
+    'Progressive-loan schedule model, described by the spec as internal; route gated by developerToolsGuard',
+  ],
+  [
+    'src/app/features/working-capital/loans/wc-account-lock/wc-loan-account-lock.component.ts',
+    'Places a working-capital loan lock; route gated by developerToolsGuard',
+  ],
+  [
+    'src/app/features/loans/loan-account-lock/loan-account-lock.component.ts',
+    'Lock listing is supported and ungated; only the place-lock action is gated in the template',
+  ],
+]);
+
+function walk(dir, acc = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, acc);
+    else if (p.endsWith('.ts')) acc.push(p);
+  }
+  return acc;
+}
+
+/** Generated method names whose `@endpoint` tag points under `/v1/internal/`. */
+function internalMethods() {
+  const methods = new Map();
+  for (const file of walk(join(GENERATED_API, 'api'))) {
+    const src = readFileSync(file, 'utf8');
+    const re = /@endpoint\s+(\w+)\s+(\/v1\/internal\/\S*)/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      const after = src.slice(m.index, m.index + 3000);
+      const name = /public (\w+)\(/.exec(after);
+      if (name) methods.set(name[1], `${m[1].toUpperCase()} ${m[2]}`);
+    }
+  }
+  return methods;
+}
+
+const methods = internalMethods();
+if (methods.size === 0) {
+  console.error(
+    'No /v1/internal/ operations found in the generated client.\n' +
+      'Either the spec no longer exposes them — in which case this check and the screens that ' +
+      'depend on them should be revisited — or the client layout changed and this script needs ' +
+      'updating. Failing rather than passing silently.',
+  );
+  process.exit(1);
+}
+
+const sources = walk(join(ROOT, 'src', 'app')).filter(
+  (f) => !f.startsWith(GENERATED_API) && !f.endsWith('.spec.ts'),
+);
+
+const used = new Map();
+for (const file of sources) {
+  const src = readFileSync(file, 'utf8');
+  for (const [name, endpoint] of methods) {
+    if (new RegExp(`\\b${name}\\b`).test(src)) {
+      const rel = relative(ROOT, file);
+      if (!used.has(rel)) used.set(rel, []);
+      used.get(rel).push(endpoint);
+    }
+  }
+}
+
+const unapproved = [...used.keys()].filter((f) => !ALLOWED.has(f)).sort();
+const stale = [...ALLOWED.keys()].filter((f) => !used.has(f)).sort();
+
+console.log(
+  `Checked ${sources.length} files against ${methods.size} internal operations; ` +
+    `${used.size} file(s) reference one.`,
+);
+
+if (unapproved.length) {
+  console.error('\n✖ Files calling a /v1/internal/ endpoint without approval:\n');
+  for (const f of unapproved) {
+    console.error(`  ${f}`);
+    for (const ep of used.get(f)) console.error(`      ${ep}`);
+  }
+  console.error(
+    '\nThese endpoints exist only under the backend test profile and answer 404 in production.\n' +
+      'Either drop the dependency, or gate the screen behind developerToolsEnabled and add it to\n' +
+      'ALLOWED in this script with the reason.',
+  );
+}
+
+if (stale.length) {
+  console.error('\n✖ Allow-list entries that no longer call an internal endpoint:\n');
+  for (const f of stale) console.error(`  ${f}`);
+  console.error('\nRemove them from ALLOWED so the list keeps describing the code.');
+}
+
+if (unapproved.length || stale.length) process.exit(1);
+console.log('✓ Every internal-endpoint call site is approved and gated.');

--- a/src/app/core/guards/developer-tools.guard.ts
+++ b/src/app/core/guards/developer-tools.guard.ts
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { inject } from '@angular/core';
+import { CanMatchFn } from '@angular/router';
+
+import { ConfigService } from '../services/config.service';
+
+/**
+ * Gates the screens that drive Fineract's `/v1/internal/**` endpoints.
+ *
+ * Those endpoints are served only when the backend runs with its `test` Spring profile, which
+ * upstream states must not be enabled in production — on a normal deployment every one of them
+ * answers 404. Hiding the navigation entry is not enough on its own, because the routes stay
+ * reachable by URL, so the same flag is enforced here as well.
+ *
+ * `CanMatchFn` rather than `CanActivateFn`: a non-matching route falls through to the wildcard
+ * route and the user lands on the dashboard, which is the same thing that happens for any address
+ * this deployment does not serve. That is the intent — with the flag off, these paths simply are
+ * not part of the application.
+ */
+export const developerToolsGuard: CanMatchFn = () => inject(ConfigService).developerToolsEnabled();

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -65,6 +65,17 @@ export interface AppConfig {
   /** Institution type to assume when the user has not selected one. */
   institutionType: InstitutionType;
   /**
+   * Exposes the screens that drive Fineract's `/v1/internal/**` endpoints — COB tools, the
+   * progressive-loan schedule model, the internal external-event log, and the loan account
+   * locks.
+   *
+   * Off by default, and it should stay off anywhere real. Those endpoints are served only when
+   * the backend runs with its `test` Spring profile, which upstream states must not be enabled
+   * in production; on a normal deployment every one of them answers 404. Enabling this on a test
+   * instance is the supported way to reach them.
+   */
+  developerToolsEnabled?: boolean;
+  /**
    * Absolute API origins this deployment permits, beyond its own.
    *
    * The endpoint override exists so an operator can point the app at their own Fineract. It is
@@ -92,6 +103,7 @@ const DEFAULT_CONFIG: AppConfig = {
   defaultTenant: 'default',
   rbacEnabled: true,
   institutionType: 'universal',
+  developerToolsEnabled: false,
 };
 
 /**
@@ -153,6 +165,14 @@ export class ConfigService {
 
   /** Whether permission and institution gating applies. See {@link AppConfig.rbacEnabled}. */
   readonly rbacEnabled = computed(() => this._config().rbacEnabled);
+
+  /**
+   * Whether the `/v1/internal/**` screens are exposed. See {@link AppConfig.developerToolsEnabled}.
+   *
+   * Deliberately defaults to `false` when the key is absent, so an existing `config.json` that
+   * predates this flag keeps the tools hidden rather than inheriting them.
+   */
+  readonly developerToolsEnabled = computed(() => this._config().developerToolsEnabled === true);
 
   /** Navigation entries this deployment hides, as a set of `labelKey`s. */
   readonly hiddenNavKeys = computed(() => new Set(this._config().nav?.hidden ?? []));

--- a/src/app/core/services/navigation-config.service.spec.ts
+++ b/src/app/core/services/navigation-config.service.spec.ts
@@ -119,6 +119,8 @@ describe('NavigationConfigService', () => {
       (item) => item.route === route || (item.children && findRoute(item.children, route)),
     );
 
+  const COB_TOOLS_ROUTE = '/admin/cob-tools';
+  const PLACE_LOCK_ROUTE = '/working-capital/loans/account-locks';
   const SECURITY_USERS_ROUTE = '/security/users';
   const ACCOUNTING_CHART_ROUTE = '/accounting/chart-of-accounts';
 
@@ -264,10 +266,14 @@ describe('NavigationConfigService', () => {
       expect(findRoute(items, '/interop/accounts')).toBeTrue();
       expect(findRoute(items, '/interop/health')).toBeTrue();
       expect(findRoute(items, '/campaigns/email-messages')).toBeTrue();
-      expect(findRoute(items, '/working-capital/loans/account-locks')).toBeTrue();
       expect(findRoute(items, '/working-capital/loans/cob-catchup')).toBeTrue();
-      expect(findRoute(items, '/admin/wc-cob-tools')).toBeTrue();
       expect(findRoute(items, '/transfers/history')).toBeTrue();
+
+      // Hidden for a different reason than the twelve above: these drive Fineract's
+      // /v1/internal endpoints and are gated by `developerToolsEnabled`, not by permission.
+      // They were ungated siblings when this test was written.
+      expect(findRoute(items, '/working-capital/loans/account-locks')).toBeFalse();
+      expect(findRoute(items, '/admin/wc-cob-tools')).toBeFalse();
     });
 
     it('shows only the specific interop routes the user has permission for', () => {
@@ -377,6 +383,42 @@ describe('NavigationConfigService', () => {
       expect(
         isVisible({ route: '/x', labelKey: 'x', requiredPermissions: 'CREATE_CLIENT' }),
       ).toBeFalse();
+    });
+  });
+
+  describe('developer tools', () => {
+    /**
+     * These screens drive Fineract's /v1/internal endpoints, which the backend serves only under
+     * its test Spring profile and which answer 404 on a normal deployment.
+     */
+    it('hides the internal-endpoint screens by default', () => {
+      TestBed.resetTestingModule();
+      configure();
+      setPermissions(['ALL_FUNCTIONS']);
+
+      expect(findRoute(service.filteredNavItems(), COB_TOOLS_ROUTE)).toBeFalse();
+      expect(findRoute(service.filteredNavItems(), PLACE_LOCK_ROUTE)).toBeFalse();
+    });
+
+    it('shows them when the deployment opts in', () => {
+      TestBed.resetTestingModule();
+      configure({ developerToolsEnabled: true });
+      setPermissions(['ALL_FUNCTIONS']);
+
+      expect(findRoute(service.filteredNavItems(), COB_TOOLS_ROUTE)).toBeTrue();
+      expect(findRoute(service.filteredNavItems(), PLACE_LOCK_ROUTE)).toBeTrue();
+    });
+
+    /**
+     * Turning RBAC off means "show this user everything they may reach", not "expose endpoints
+     * this deployment cannot serve" — so the developer-tool check sits before that short-circuit.
+     */
+    it('keeps them hidden even when RBAC is disabled', () => {
+      TestBed.resetTestingModule();
+      configure({ rbacEnabled: false });
+
+      expect(findRoute(service.filteredNavItems(), COB_TOOLS_ROUTE)).toBeFalse();
+      expect(findRoute(service.filteredNavItems(), SECURITY_USERS_ROUTE)).toBeTrue();
     });
   });
 });

--- a/src/app/core/services/navigation-config.service.ts
+++ b/src/app/core/services/navigation-config.service.ts
@@ -60,6 +60,11 @@ export interface NavItemConfig {
   children?: NavItemConfig[];
   /** Marks a purely visual separator between sibling items; no other field applies. */
   divider?: boolean;
+  /**
+   * Drives Fineract's `/v1/internal/**` endpoints, which exist only under the backend's `test`
+   * profile. Hidden unless the deployment sets `developerToolsEnabled`.
+   */
+  developerTool?: boolean;
 }
 
 /**
@@ -93,6 +98,7 @@ const NAV_CONFIG: readonly NavItemConfig[] = [
     route: '/loans/account-locks',
     labelKey: 'LOAN_ACCOUNT_LOCK.TITLE',
     icon: ICON_LOCK_CLOSED_OUTLINE,
+    developerTool: true,
   },
   {
     route: '/loans/cob-catchup',
@@ -221,13 +227,19 @@ const NAV_CONFIG: readonly NavItemConfig[] = [
         route: '/working-capital/loans/account-locks',
         labelKey: 'WC_LOAN_ACCOUNT_LOCK.TITLE',
         icon: ICON_LOCK_CLOSED_OUTLINE,
+        developerTool: true,
       },
       {
         route: '/working-capital/loans/cob-catchup',
         labelKey: 'WC_LOAN_COB_CATCHUP.TITLE',
         icon: 'refresh-circle-outline',
       },
-      { route: '/admin/wc-cob-tools', labelKey: 'WC_COB_TOOLS.TITLE', icon: ICON_OPTIONS_OUTLINE },
+      {
+        route: '/admin/wc-cob-tools',
+        labelKey: 'WC_COB_TOOLS.TITLE',
+        icon: ICON_OPTIONS_OUTLINE,
+        developerTool: true,
+      },
     ],
   },
   {
@@ -304,17 +316,29 @@ const NAV_CONFIG: readonly NavItemConfig[] = [
         icon: 'layers-outline',
       },
       { route: '/admin/inline-job', labelKey: 'INLINE_JOB.TITLE', icon: 'play-circle-outline' },
-      { route: '/admin/cob-tools', labelKey: 'COB_TOOLS.TITLE', icon: 'construct-outline' },
-      { route: '/admin/wc-cob-tools', labelKey: 'WC_COB_TOOLS.TITLE', icon: 'build-outline' },
+      {
+        route: '/admin/cob-tools',
+        labelKey: 'COB_TOOLS.TITLE',
+        icon: 'construct-outline',
+        developerTool: true,
+      },
+      {
+        route: '/admin/wc-cob-tools',
+        labelKey: 'WC_COB_TOOLS.TITLE',
+        icon: 'build-outline',
+        developerTool: true,
+      },
       {
         route: '/admin/external-events',
         labelKey: 'EXTERNAL_EVENTS.TITLE',
         icon: ICON_CALENDAR_OUTLINE,
+        developerTool: true,
       },
       {
         route: '/admin/progressive-loan',
         labelKey: 'PROGRESSIVE_LOAN.TITLE',
         icon: ICON_TRENDING_UP_OUTLINE,
+        developerTool: true,
       },
     ],
   },
@@ -630,6 +654,7 @@ export class NavigationConfigService {
     this.authService.currentUser();
     this.institutionConfig.institutionType();
     this.config.rbacEnabled();
+    this.config.developerToolsEnabled();
     this.hidden();
     return filterNavItems(NAV_CONFIG, (item) => this.isItemVisible(item));
   });
@@ -638,6 +663,13 @@ export class NavigationConfigService {
     // Checked before the RBAC short-circuit: hiding an entry is what this deployment offers,
     // which is a separate question from what this user is allowed to reach.
     if (this.hidden().has(item.labelKey)) {
+      return false;
+    }
+
+    // Checked before the RBAC short-circuit, and for the same reason the `hidden` check is:
+    // turning RBAC off means "show this user everything they may reach", not "expose endpoints
+    // this deployment cannot serve". A developer tool stays hidden either way.
+    if (item.developerTool && !this.config.developerToolsEnabled()) {
       return false;
     }
 

--- a/src/app/features/admin/admin.routes.ts
+++ b/src/app/features/admin/admin.routes.ts
@@ -18,6 +18,7 @@
  */
 
 import { Routes } from '@angular/router';
+import { developerToolsGuard } from '../../core/guards/developer-tools.guard';
 
 export const ADMIN_ROUTES: Routes = [
   {
@@ -34,20 +35,24 @@ export const ADMIN_ROUTES: Routes = [
   },
   {
     path: 'cob-tools',
+    canMatch: [developerToolsGuard],
     loadComponent: () => import('./cob-tools/cob-tools.component').then((m) => m.CobToolsComponent),
   },
   {
     path: 'wc-cob-tools',
+    canMatch: [developerToolsGuard],
     loadComponent: () =>
       import('./wc-cob-tools/wc-cob-tools.component').then((m) => m.WcCobToolsComponent),
   },
   {
     path: 'external-events',
+    canMatch: [developerToolsGuard],
     loadComponent: () =>
       import('./external-events/external-events.component').then((m) => m.ExternalEventsComponent),
   },
   {
     path: 'progressive-loan',
+    canMatch: [developerToolsGuard],
     loadComponent: () =>
       import('./progressive-loan/progressive-loan-model.component').then(
         (m) => m.ProgressiveLoanModelComponent,

--- a/src/app/features/loans/loan-account-lock/loan-account-lock.component.ts
+++ b/src/app/features/loans/loan-account-lock/loan-account-lock.component.ts
@@ -21,6 +21,7 @@ import { JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { LoanAccountLockService, LoanAccountLockResponseDTO } from '../../../api';
+import { ConfigService } from '../../../core/services/config.service';
 import { NotificationService } from '../../../core/services/notification.service';
 import {
   IonButton,
@@ -88,30 +89,38 @@ import {
           }
         </div>
 
-        <hr class="divider" />
+        <!--
+          Placing a lock posts to /v1/internal/loans/{id}/place-lock/{owner}, which Fineract
+          serves only under its test Spring profile and which answers 404 on a normal deployment.
+          The lock *listing* above uses the supported /v1/loans/locked, so only this half is
+          gated rather than the whole screen.
+        -->
+        @if (developerToolsEnabled()) {
+          <hr class="divider" />
 
-        <div class="section">
-          <h3>{{ 'LOAN_ACCOUNT_LOCK.PLACE_LOCK' | translate }}</h3>
+          <div class="section">
+            <h3>{{ 'LOAN_ACCOUNT_LOCK.PLACE_LOCK' | translate }}</h3>
 
-          <ion-item fill="outline">
-            <ion-label position="stacked">{{
-              'LOAN_ACCOUNT_LOCK.LOCK_OWNER' | translate
-            }}</ion-label>
-            <ion-input
-              [attr.aria-label]="'LOAN_ACCOUNT_LOCK.LOCK_OWNER' | translate"
-              type="text"
-              [(ngModel)]="lockOwner"
-            ></ion-input>
-          </ion-item>
+            <ion-item fill="outline">
+              <ion-label position="stacked">{{
+                'LOAN_ACCOUNT_LOCK.LOCK_OWNER' | translate
+              }}</ion-label>
+              <ion-input
+                [attr.aria-label]="'LOAN_ACCOUNT_LOCK.LOCK_OWNER' | translate"
+                type="text"
+                [(ngModel)]="lockOwner"
+              ></ion-input>
+            </ion-item>
 
-          <ion-button
-            color="secondary"
-            [disabled]="isLoading() || !loanId || !lockOwner"
-            (click)="placeLock()"
-          >
-            {{ 'LOAN_ACCOUNT_LOCK.PLACE_LOCK' | translate }}
-          </ion-button>
-        </div>
+            <ion-button
+              color="secondary"
+              [disabled]="isLoading() || !loanId || !lockOwner"
+              (click)="placeLock()"
+            >
+              {{ 'LOAN_ACCOUNT_LOCK.PLACE_LOCK' | translate }}
+            </ion-button>
+          </div>
+        }
       </ion-card-content>
     </ion-card>
   `,
@@ -138,6 +147,10 @@ import {
 })
 export class LoanAccountLockComponent {
   private readonly loanAccountLockService = inject(LoanAccountLockService);
+  private readonly config = inject(ConfigService);
+
+  /** Gates the place-lock half of this screen; see the note in the template. */
+  readonly developerToolsEnabled = this.config.developerToolsEnabled;
   private readonly notifications = inject(NotificationService);
   private readonly translate = inject(TranslateService);
 

--- a/src/app/features/working-capital/working-capital.routes.ts
+++ b/src/app/features/working-capital/working-capital.routes.ts
@@ -18,6 +18,7 @@
  */
 
 import { Routes } from '@angular/router';
+import { developerToolsGuard } from '../../core/guards/developer-tools.guard';
 
 export const WORKING_CAPITAL_ROUTES: Routes = [
   {
@@ -99,6 +100,7 @@ export const WORKING_CAPITAL_ROUTES: Routes = [
   },
   {
     path: 'loans/account-locks',
+    canMatch: [developerToolsGuard],
     loadComponent: () =>
       import('./loans/wc-account-lock/wc-loan-account-lock.component').then(
         (m) => m.WcLoanAccountLockComponent,

--- a/src/app/testing/config.ts
+++ b/src/app/testing/config.ts
@@ -28,6 +28,7 @@ const TEST_CONFIG: AppConfig = {
   defaultTenant: 'default',
   rbacEnabled: true,
   institutionType: 'universal',
+  developerToolsEnabled: false,
 };
 
 /**
@@ -66,6 +67,9 @@ export function provideTestConfig(overrides: Partial<AppConfig> = {}): Provider 
     useValue: {
       config: config.asReadonly(),
       rbacEnabled: computed(() => config().rbacEnabled),
+      // Same defaulting as the real service: absent means off, so a spec that does not mention
+      // developer tools gets the production behaviour.
+      developerToolsEnabled: computed(() => config().developerToolsEnabled === true),
       hiddenNavKeys: computed(() => new Set(config().nav?.hidden ?? [])),
       get apiUrl() {
         return config().fineractApiUrl;


### PR DESCRIPTION
Closes #357.

Fineract serves `/v1/internal/**` only when the backend runs with its **`test` Spring profile**, which upstream states must not be enabled in production. Six screens depend on those endpoints and were routed *and* listed in the navigation — so on a normal deployment a user could reach them and every action returned 404.

Verified against a running instance, using the same credentials the passing e2e suite uses:

```
GET /v1/internal/externalevents             → 404
GET /v1/internal/cob/partitions/10          → 404
GET /v1/internal/loan/progressive/1/model   → 404
```

The spec agrees — it describes several of them as internal, and the working-capital ones as *"(testing only)"*.

## Gated, not deleted

Against a test instance these are legitimate tooling, and deletion is not reversible. `developerToolsEnabled` in `config.json` exposes them and is **off** unless a deployment opts in — a runtime flag, so a QA environment needs no rebuild.

Enforced in two places, because hiding a nav entry leaves the route reachable by URL:

- `NavItemConfig.developerTool` hides the entry
- `developerToolsGuard` (`CanMatch`) stops the route matching at all

**The developer-tool check sits *before* the `rbacEnabled` short-circuit**, for the same reason the existing `hidden` check does: turning RBAC off means "show this user everything they may reach", not "expose endpoints this deployment cannot serve". There's a test for exactly that.

| Screen | Treatment |
|---|---|
| Admin → COB Tools | Gated (wholly internal) |
| Admin → WC COB Tools | Gated (wholly internal) |
| Admin → External Events *(internal log)* | Gated (wholly internal) |
| Admin → Progressive Loan Model | Gated (wholly internal) |
| Working Capital → Account Locks | Gated (wholly internal) |
| **Loans → Account Locks** | **Screen kept** — see below |

**Loans → Account Locks keeps its screen.** Its listing uses the supported `/v1/loans/locked`; only the *place-lock* action posts to an internal endpoint, so only that half is gated. I initially gated the whole route and corrected it — removing it would have removed working, supported functionality, which is the opposite of the goal.

`System → External Events` (`/v1/externalevents/configuration`) is a **different, supported screen** and is untouched. The two are easy to confuse.

## The CI guard

`scripts/check-internal-endpoints.mjs` pins the list so a new dependency on a test-only endpoint has to be deliberate.

It derives the internal operations from the generated client's `@endpoint` tags rather than a hardcoded list of names, so it follows the spec when the spec changes. It fails on **both**:

- a new ungated reference, and
- an allow-list entry that no longer calls an internal endpoint — a stale entry is as misleading as a missing one.

Both failure modes were verified by introducing them:

```
✖ Files calling a /v1/internal/ endpoint without approval:
    src/app/features/system/external-events/external-events.component.ts
        GET /v1/internal/externalevents                              → exit 1

✖ Allow-list entries that no longer call an internal endpoint:
    src/app/features/does-not-exist.component.ts                     → exit 1
```

It also fails loudly if it finds *no* internal operations at all, rather than passing silently — that would mean either the spec dropped them (worth revisiting these screens) or the client layout changed.

Wired into the CI job that already runs the i18n and icon checks.

## Testing

- **952 unit specs.** New: the screens stay hidden by default, appear when a deployment opts in, and stay hidden when RBAC is off.
- Two existing nav specs asserted the previous behaviour (`/admin/wc-cob-tools` and `/working-capital/loans/account-locks` visible as "ungated siblings"). They are updated to record the new rule **with a comment explaining the reason differs from permission gating** — not relaxed.
- `provideTestConfig` implements the new accessor, so the double keeps matching the real service.
- `lint`, `format:check`, `i18n:check`, `check:icons`, `check-license.sh`, `build`, and Apache RAT (666 approved, 0 unapproved) all clean.

Follows the legacy-functionality audit. The audit recommended this as a **PMC decision**; gating rather than removing keeps that decision open — if the PMC prefers exclusion, the routes and components can come out later without anything else changing.
