### PR TITLE
fix(e2e): stop the backend suite depending on the hour it runs at

### DIFF
--- a/e2e/center-servicing.spec.ts
+++ b/e2e/center-servicing.spec.ts
@@ -40,6 +40,7 @@
 import { expect, test, recordingTimeout } from './fixtures';
 import { login, uniqueSuffix } from './utils/fineract-login';
 import { ionSelect } from './utils/ionic-locators';
+import { captureJson } from './utils/capture-response';
 import { createApiContext, seedCenter, seedGroup, seedStaff } from './utils/seed-api';
 
 test.describe('Center servicing', () => {
@@ -65,9 +66,26 @@ test.describe('Center servicing', () => {
     await expect(page.getByTestId('center-group-count')).toHaveText('0');
 
     // --- Activate ------------------------------------------------------------------------------
-    await page.getByTestId('center-actions').click();
-    await page.getByTestId('center-action-activate').click();
-    await page.getByTestId('center-action-confirm').click();
+    //
+    // The response is captured rather than only the resulting badge. A refused activation leaves
+    // the badge on "Pending" and the assertion then reports nothing beyond that, which says
+    // neither what was sent nor why the platform objected — the difference between a diagnosable
+    // failure and one that has to be reproduced before it can be read.
+    const activation = await captureJson<Record<string, unknown>>(
+      page,
+      new RegExp(`/centers/${center.centerId}(\\?|$)`),
+      'POST',
+      async () => {
+        await page.getByTestId('center-actions').click();
+        await page.getByTestId('center-action-activate').click();
+        await page.getByTestId('center-action-confirm').click();
+      },
+    );
+    expect(
+      activation['resourceId'],
+      `activation was refused; the platform answered: ${JSON.stringify(activation)}`,
+    ).toBeDefined();
+
     await expect(page.getByTestId('center-status')).toContainText(/active/i, { timeout: 20000 });
 
     // --- Assign staff --------------------------------------------------------------------------

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -79,6 +79,20 @@ export default defineConfig({
     baseURL: 'https://localhost:4200',
     trace: 'on-first-retry',
     ignoreHTTPSErrors: true,
+    // Pinned to the e2e tenant's own timezone, which is what makes the suite deterministic
+    // rather than a function of the hour it runs at.
+    //
+    // Fineract stamps and validates dates in the *tenant's* zone -- `m_tenants.timezone_id`,
+    // which its seed data sets to Asia/Kolkata -- while the application fills date fields from
+    // the *browser's* clock. Between 18:30 and 24:00 UTC those disagree by a day, so a UTC
+    // runner would send 15 August for a record the platform had already stamped 16 August and
+    // be refused: "Submitted on date cannot be after the activation date". A suite whose result
+    // depends on what time of day it starts is not a signal.
+    //
+    // This makes the *harness* deterministic. It does not fix the underlying behaviour, which
+    // affects any deployment whose users are not in the tenant's timezone -- see #358. Remove
+    // this pin when that is fixed; the suite passing without it is the proof.
+    timezoneId: 'Asia/Kolkata',
     // `DEMO_RECORD=1` records every spec, not just the ones that fail — the suites *are* the
     // flows, so recording them is what produces a demo of the application rather than a separate
     // script that could drift from what the app actually does. See DOCS/DEMO.md.


### PR DESCRIPTION
The centre activation test failed on CI three attempts running while passing on every local run. The cause was the wall clock.

## What was happening

Fineract stamps and validates dates in the **tenant's** timezone — `m_tenants.timezone_id`, which its seed data sets to `Asia/Kolkata`. The application fills date fields from the **browser's** clock. Between **18:30 and 24:00 UTC** those disagree by a day.

The CI job started at **18:35 UTC** — inside that window. So the browser offered `15 August` as the activation date for a centre the platform had already stamped `16 August`, and the platform refused it:

```
error.msg.group.submittedOnDate.after.activation.date
"Submitted on date cannot be after the activation date"   args: [{"value":"2026-08-16"}]
```

A machine already in `Asia/Kolkata` agrees with the tenant and **cannot** reproduce it. That is why a full 46/46 local run — fresh volume, current image, file order, one worker — said nothing was wrong, twice.

## The fix

Pin the browser timezone to the tenant's, so the suite is deterministic on any machine rather than a function of when it starts.

Verified by running the centre spec under three timezones:

| Run | Before | After |
|---|---|---|
| `TZ=UTC` (CI's zone) | **fails** | passes |
| `TZ=America/New_York` | — | passes |
| Host `Asia/Kolkata` | passes | passes |

## What this does not fix

**The harness, not the behaviour.** Defaulting date fields from the browser rather than the platform affects any deployment whose users are not in the tenant's timezone — for about five and a half hours a day, real users get refused for a date they never chose, or worse, get a record accepted with the wrong day on it.

That is raised separately as **#358**, with this reproduction. The pin carries a comment saying it should be removed when #358 lands, and that the suite passing without it is the proof the fix is real. I did not want a harness change to quietly make a product bug invisible.

## The diagnostic change

The activation step now captures the platform's response instead of only checking the resulting badge.

A refused activation left the badge on `Pending`, and the assertion reported nothing beyond `unexpected value " Pending "` — neither what was sent nor why the platform objected. With the response captured, the very first run named the validation error outright. That is what turned this from a flake into a diagnosis, and it is why the change is worth keeping regardless of the timezone fix.

## Things I ruled out along the way

Recorded because each looked plausible and each was wrong:

- **Caused by #356** — it changes no date, centre or e2e code; only `config.json`, by adding a key.
- **A Fineract version difference** — CI pulls `apache/fineract:latest`, which had moved to the 1.16.0-SNAPSHOT image while my local was 1.15.0-132. A real difference, so I recreated the stack on the new image. Still passed.
- **`FINERACT_DEFAULT_TENANTDB_TIMEZONE_ID=UTC`** as an alternative fix — not honoured; the tenant stayed `Asia/Kolkata`. Tested before proposing rather than after.
- **Suite ordering or a polluted database** — the previous two CI-only failures were both ambient-state problems, so this was the first suspect. A faithful CI-conditions run passed 46/46.

## Verification

- Centre spec passes under `TZ=UTC`, `TZ=America/New_York` and host IST.
- Full backend suite: 46/46 on a fresh volume, one worker, file order.
- `lint` and `format:check` clean. No production code is touched — the change is confined to `playwright.config.ts` and one spec.
