### PR TITLE
A11y/icon only button names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
         run: npm run i18n:check
       - name: Verify every ion-icon name is registered
         run: npm run check:icons
+      - name: Verify every icon-only button has an accessible name
+        run: npm run check:a11y-names
       # Fineract serves /v1/internal/** only under its `test` Spring profile, which upstream
       # states must not be enabled in production. The few screens built on those endpoints are
       # gated behind `developerToolsEnabled`; this pins that list so a new dependency on a

--- a/DOCS/CI_CHECKS.md
+++ b/DOCS/CI_CHECKS.md
@@ -31,6 +31,7 @@ npm run lint
 npm run format:check
 npm run i18n:check
 npm run check:icons
+npm run check:a11y-names
 npm run api:surface
 npm test -- --watch=false --browsers=ChromeHeadless
 npm run build
@@ -117,15 +118,42 @@ served minified, so a hand-copied spec fails this check as one 1.4 MB line — r
 ### `i18n-check`
 
 ```bash
-npm run i18n:check       # every referenced key exists in src/assets/i18n/en.json
-npm run check:icons      # every <ion-icon name> is registered in src/app/core/icons.ts
+npm run i18n:check         # every referenced key exists in src/assets/i18n/en.json
+npm run check:icons        # every <ion-icon name> is registered in src/app/core/icons.ts
+npm run check:a11y-names   # every icon-only <ion-button> has an accessible name
 ```
 
-Both failures are invisible at runtime rather than loud: a missing translation key
-renders as the raw key, and an unregistered ionicon renders as blank space with no
-console error.
+All three failures are invisible at runtime rather than loud: a missing translation
+key renders as the raw key, an unregistered ionicon renders as blank space with no
+console error, and an unnamed icon-only button looks perfectly fine on screen while
+announcing itself to a screen reader as "button" and nothing else.
 
 `npm run i18n:check -- --unused` lists orphaned keys.
+
+#### `check:a11y-names`
+
+An `<ion-button>` whose only content is an `<ion-icon>` has no text to compute an
+accessible name from, so it needs `[attr.aria-label]`, bound to the translation key
+that already names the action:
+
+```html
+<ion-button [attr.aria-label]="'COMMON.EDIT' | translate" [appTooltip]="'COMMON.EDIT' | translate">
+  <ion-icon name="create-outline"></ion-icon>
+</ion-button>
+```
+
+Two things look like they already do this and do not:
+
+- **`[appTooltip]`** sets `aria-describedby`. A description is not a name. It is never
+  consulted by the accessible name computation, it only exists 300ms after hover or
+  focus, and a screen reader user reading in browse mode never triggers it.
+- **`title`** names the wrong element. `<ion-button>` renders a native `<button>` into
+  its shadow root and that inner element is what carries `role=button`. Ionic forwards
+  `aria-label` to it but not `title`, so the title lands on the outer host, which the
+  accessibility tree exposes as `role=generic`, leaving the button itself anonymous.
+
+An `aria-label` on the `<ion-icon>` does count, because name-from-content descends into
+children, and the check accepts it.
 
 ### `test`
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "verify-api-client": "npm run generate-api && git diff --exit-code src/app/api",
     "i18n:check": "node scripts/check-translations.mjs",
     "check:icons": "node scripts/check-icons.mjs",
+    "check:a11y-names": "node scripts/check-a11y-names.mjs",
     "check:internal-endpoints": "node scripts/check-internal-endpoints.mjs",
     "api:surface": "node scripts/check-api-surface.mjs",
     "ga:check": "node scripts/ga-check.mjs",

--- a/scripts/check-a11y-names.mjs
+++ b/scripts/check-a11y-names.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Verifies that every icon-only `<ion-button>` has an accessible name.
+ *
+ * A button whose only content is an `<ion-icon>` has nothing to compute a name from: the
+ * icon is a font glyph, not text. A screen reader announces the control as "button" and
+ * nothing else, so a row of them is a row of identical buttons, including the ones that
+ * delete a record.
+ *
+ * Three things look like they solve this. Two of them do not:
+ *
+ * - `[appTooltip]`. `TooltipDirective` sets `aria-describedby`. A description is not a
+ *   name: it is never consulted by the accessible name computation, it is only present
+ *   300ms after hover or focus, and a screen reader user reading in browse mode never
+ *   triggers it at all.
+ * - `title`. `<ion-button>` renders a native `<button>` into its shadow root, and that
+ *   inner element is what carries `role=button`. Ionic forwards `aria-label` to it but not
+ *   `title`, so a title names the outer host, which the accessibility tree exposes as
+ *   `role=generic`, and the button itself stays anonymous. Read out of Chromium's own
+ *   accessibility tree rather than inferred: `title` on the host gives `role=generic
+ *   name="Edit"` sitting over `role=button name=""`, while `aria-label` on the same host
+ *   gives `role=button name="Edit"`.
+ * - An `aria-label` on the `<ion-icon>` itself. This one does work, because
+ *   name-from-content descends into children, and the check accepts it.
+ *
+ * The fix is `[attr.aria-label]` on the button, bound to the translation key that already
+ * names the action.
+ *
+ * Usage: node scripts/check-a11y-names.mjs
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SRC = 'src';
+const TAG = 'ion-button';
+
+/** Attributes that name the element outright, static or bound. */
+const NAMING_ATTRIBUTE = /(?:\[attr\.)?aria-label(?:ledby)?\]?=|aria-labelledby=/;
+/** An `<ion-icon>` element, self-closed or paired. Its content is a glyph, never text. */
+const ICON = /<ion-icon\b[^>]*?(?:\/>|>[\s\S]*?<\/ion-icon>)/g;
+const COMMENT = /<!--[\s\S]*?-->/g;
+/** Angular control flow left behind once the icons inside it are removed. */
+const CONTROL_FLOW = /@(?:if|else|for|empty|switch|case|default)\b[^{]*\{|\}/g;
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      // Generated API client has no templates.
+      if (entry === 'api' || entry === 'node_modules') continue;
+      out.push(...walk(path));
+    } else if (path.endsWith('.ts') || path.endsWith('.html')) {
+      if (path.endsWith('.spec.ts')) continue;
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/**
+ * End index of the opening tag that starts at `start`, tracking quotes.
+ *
+ * A plain search for `>` is wrong here: binding expressions contain them, and
+ * `[disabled]="from > to"` would truncate the tag halfway through its own attributes,
+ * hiding every attribute after it, including the aria-label this check looks for.
+ */
+function endOfOpeningTag(source, start) {
+  let quote = null;
+  for (let i = start; i < source.length; i++) {
+    const char = source[i];
+    if (quote) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '>') {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** Every `<ion-button>` in `source`. Buttons cannot nest, so the first close tag is ours. */
+function buttons(source) {
+  const found = [];
+  const opening = new RegExp(`<${TAG}(?=[\\s/>])`, 'g');
+
+  for (const match of source.matchAll(opening)) {
+    const tagEnd = endOfOpeningTag(source, match.index);
+    if (tagEnd === -1) continue;
+
+    const openTag = source.slice(match.index, tagEnd + 1);
+    if (openTag.endsWith('/>')) {
+      found.push({ openTag, content: '', index: match.index });
+      continue;
+    }
+
+    const close = source.indexOf(`</${TAG}>`, tagEnd);
+    if (close === -1) continue;
+    found.push({ openTag, content: source.slice(tagEnd + 1, close), index: match.index });
+  }
+  return found;
+}
+
+/** True when the button renders icons and nothing a name could be computed from. */
+function isIconOnly(content) {
+  ICON.lastIndex = 0;
+  if (!ICON.test(content)) return false;
+  ICON.lastIndex = 0;
+
+  return content.replace(COMMENT, '').replace(ICON, '').replace(CONTROL_FLOW, '').trim() === '';
+}
+
+const problems = [];
+
+for (const file of walk(SRC)) {
+  const source = readFileSync(file, 'utf8');
+
+  for (const { openTag, content, index } of buttons(source)) {
+    if (!isIconOnly(content)) continue;
+    // A name on the icon counts: name-from-content descends into children.
+    if (NAMING_ATTRIBUTE.test(openTag) || NAMING_ATTRIBUTE.test(content)) continue;
+
+    problems.push({ file: relative('.', file), line: source.slice(0, index).split('\n').length });
+  }
+}
+
+if (problems.length > 0) {
+  console.error('Icon-only <ion-button> with no accessible name. A screen reader announces');
+  console.error('these as "button" and nothing else:\n');
+  for (const { file, line } of problems) {
+    console.error(`  ${file}:${line}`);
+  }
+  console.error(
+    '\nAdd [attr.aria-label] to each, bound to the translation key that already names\n' +
+      'the action:  [attr.aria-label]="\'COMMON.EDIT\' | translate"\n\n' +
+      'Neither [appTooltip] nor title satisfies this. appTooltip sets aria-describedby,\n' +
+      'which is a description rather than a name; title names the outer host element and\n' +
+      "not the button Ionic renders into its shadow root. See this script's header.",
+  );
+  process.exit(1);
+}
+
+console.log('Every icon-only <ion-button> has an accessible name.');

--- a/src/app/features/clients/client-view.component.ts
+++ b/src/app/features/clients/client-view.component.ts
@@ -559,6 +559,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                             color="primary"
                             (click)="onSavingsTransaction(account.id, 'deposit')"
                             *appHasPermission="'DEPOSIT_SAVINGSACCOUNT'"
+                            [attr.aria-label]="'SAVINGS.DEPOSIT' | translate"
                             [appTooltip]="'SAVINGS.DEPOSIT' | translate"
                           >
                             <ion-icon name="add-circle-outline"></ion-icon>
@@ -570,6 +571,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                               color="secondary"
                               (click)="onSavingsAction(account.id, 'approve', account)"
                               *appHasPermission="'APPROVE_SAVINGSACCOUNT'"
+                              [attr.aria-label]="'LOANS.APPROVE' | translate"
                               [appTooltip]="'LOANS.APPROVE' | translate"
                             >
                               <ion-icon name="checkmark-circle-outline"></ion-icon>
@@ -582,6 +584,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                               color="primary"
                               (click)="onSavingsAction(account.id, 'activate', account)"
                               *appHasPermission="'ACTIVATE_SAVINGSACCOUNT'"
+                              [attr.aria-label]="'LOANS.ACTIVATE' | translate"
                               [appTooltip]="'LOANS.ACTIVATE' | translate"
                             >
                               <ion-icon name="play-circle-outline"></ion-icon>
@@ -594,6 +597,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                               color="danger"
                               (click)="onSavingsAction(account.id, 'close', account)"
                               *appHasPermission="'CLOSE_SAVINGSACCOUNT'"
+                              [attr.aria-label]="'LOANS.CLOSE' | translate"
                               [appTooltip]="'LOANS.CLOSE' | translate"
                             >
                               <ion-icon name="close-circle-outline"></ion-icon>
@@ -605,6 +609,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                             color="danger"
                             (click)="onSavingsTransaction(account.id, 'withdrawal')"
                             *appHasPermission="'WITHDRAW_SAVINGSACCOUNT'"
+                            [attr.aria-label]="'SAVINGS.WITHDRAWAL' | translate"
                             [appTooltip]="'SAVINGS.WITHDRAWAL' | translate"
                           >
                             <ion-icon name="remove-circle-outline"></ion-icon>
@@ -678,6 +683,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                             color="primary"
                             (click)="onLoanTransaction(account.id, 'repayment')"
                             *appHasPermission="'REPAYMENT_LOAN'"
+                            [attr.aria-label]="'LOANS.REPAYMENT' | translate"
                             [appTooltip]="'LOANS.REPAYMENT' | translate"
                           >
                             <ion-icon name="card-outline"></ion-icon>
@@ -688,6 +694,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                               fill="clear"
                               color="secondary"
                               (click)="onLoanAction(account.id, 'approve')"
+                              [attr.aria-label]="'LOANS.APPROVE' | translate"
                               [appTooltip]="'LOANS.APPROVE' | translate"
                             >
                               <ion-icon name="checkmark-circle-outline"></ion-icon>
@@ -699,6 +706,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                               fill="clear"
                               color="secondary"
                               (click)="onLoanAction(account.id, 'disburse')"
+                              [attr.aria-label]="'LOANS.DISBURSE' | translate"
                               [appTooltip]="'LOANS.DISBURSE' | translate"
                             >
                               <ion-icon name="open-outline"></ion-icon>
@@ -711,6 +719,7 @@ const CLIENT_COMMAND_NAMES: Record<string, string> = {
                               color="danger"
                               (click)="onLoanAction(account.id, 'close')"
                               *appHasPermission="'CLOSE_LOAN'"
+                              [attr.aria-label]="'LOANS.CLOSE' | translate"
                               [appTooltip]="'LOANS.CLOSE' | translate"
                             >
                               <ion-icon name="close-circle-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-addresses-list.component.ts
+++ b/src/app/features/clients/tabs/client-addresses-list.component.ts
@@ -80,6 +80,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'addresses', 'edit', row.addressId]"
             *appHasPermission="'UPDATE_ADDRESS'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-documents-list.component.ts
+++ b/src/app/features/clients/tabs/client-documents-list.component.ts
@@ -69,6 +69,7 @@ import { DOWNLOAD } from '../../../core/adapters';
             color="primary"
             (click)="onDownload(row.id)"
             *appHasPermission="'READ_DOCUMENT'"
+            [attr.aria-label]="'COMMON.DOWNLOAD' | translate"
             [appTooltip]="'COMMON.DOWNLOAD' | translate"
           >
             <ion-icon name="download-outline"></ion-icon>
@@ -78,6 +79,7 @@ import { DOWNLOAD } from '../../../core/adapters';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_DOCUMENT'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-family-members-list.component.ts
+++ b/src/app/features/clients/tabs/client-family-members-list.component.ts
@@ -72,6 +72,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'family-members', 'edit', row.id]"
             *appHasPermission="'UPDATE_CLIENTFAMILYMEMBER'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -81,6 +82,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_CLIENTFAMILYMEMBER'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-identifiers-list.component.ts
+++ b/src/app/features/clients/tabs/client-identifiers-list.component.ts
@@ -68,6 +68,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'identifiers', 'edit', row.id]"
             *appHasPermission="'UPDATE_CLIENTIDENTIFIER'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -77,6 +78,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_CLIENTIDENTIFIER'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-notes-list.component.ts
+++ b/src/app/features/clients/tabs/client-notes-list.component.ts
@@ -74,6 +74,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'notes', 'edit', row.id]"
             *appHasPermission="'UPDATE_NOTE'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -83,6 +84,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_NOTE'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/loans/loan-documents-tab.component.ts
+++ b/src/app/features/loans/loan-documents-tab.component.ts
@@ -105,6 +105,7 @@ import { DOWNLOAD } from '../../core/adapters';
               fill="clear"
               color="primary"
               (click)="onDownload(doc.id)"
+              [attr.aria-label]="'COMMON.DOWNLOAD' | translate"
               [appTooltip]="'COMMON.DOWNLOAD' | translate"
             >
               <ion-icon name="download-outline"></ion-icon>
@@ -113,6 +114,7 @@ import { DOWNLOAD } from '../../core/adapters';
               fill="clear"
               color="danger"
               (click)="onDelete(doc.id)"
+              [attr.aria-label]="'COMMON.DELETE' | translate"
               [appTooltip]="'COMMON.DELETE' | translate"
             >
               <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/loans/loan-form.component.ts
+++ b/src/app/features/loans/loan-form.component.ts
@@ -122,6 +122,7 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                   [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                   (click)="onCreateClient()"
                   style="margin-top: 4px;"
@@ -155,6 +156,7 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'PRODUCTS.CREATE_LOAN_PRODUCT' | translate"
                   [appTooltip]="'PRODUCTS.CREATE_LOAN_PRODUCT' | translate"
                   (click)="onCreateProduct()"
                   style="margin-top: 4px;"

--- a/src/app/features/loans/loan-view.component.ts
+++ b/src/app/features/loans/loan-view.component.ts
@@ -972,6 +972,7 @@ import {
                         <ion-button
                           fill="clear"
                           (click)="onViewTransaction(tx)"
+                          [attr.aria-label]="'COMMON.VIEW' | translate"
                           [appTooltip]="'COMMON.VIEW' | translate"
                         >
                           <ion-icon name="eye-outline"></ion-icon>

--- a/src/app/features/organization/staff/staff-list.component.ts
+++ b/src/app/features/organization/staff/staff-list.component.ts
@@ -82,6 +82,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['edit', row.id]"
             *appHasPermission="'UPDATE_STAFF'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>

--- a/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
@@ -115,6 +115,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                   [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                   (click)="onCreateClient()"
                   style="margin-top: 4px;"
@@ -150,6 +151,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'PRODUCTS.CREATE_FIXED_DEPOSIT_PRODUCT' | translate"
                   [appTooltip]="'PRODUCTS.CREATE_FIXED_DEPOSIT_PRODUCT' | translate"
                   (click)="onCreateProduct()"
                   style="margin-top: 4px;"

--- a/src/app/features/products/fixed-deposits/fixed-deposit-products-list.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposit-products-list.component.ts
@@ -61,6 +61,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
         <ion-button
           fill="clear"
           color="primary"
+          [attr.aria-label]="'COMMON.EDIT' | translate"
           [appTooltip]="'COMMON.EDIT' | translate"
           (click)="onEdit(product)"
         >

--- a/src/app/features/products/fixed-deposits/fixed-deposits-list.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposits-list.component.ts
@@ -74,6 +74,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
           <ion-button
             fill="clear"
             color="secondary"
+            [attr.aria-label]="'LOANS.APPROVE' | translate"
             [appTooltip]="'LOANS.APPROVE' | translate"
             (click)="onApprove(account)"
           >

--- a/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
@@ -117,6 +117,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                   [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                   (click)="onCreateClient()"
                   style="margin-top: 4px;"
@@ -160,6 +161,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'PRODUCTS.CREATE_RECURRING_DEPOSIT_PRODUCT' | translate"
                   [appTooltip]="'PRODUCTS.CREATE_RECURRING_DEPOSIT_PRODUCT' | translate"
                   (click)="onCreateProduct()"
                   style="margin-top: 4px;"

--- a/src/app/features/products/recurring-deposits/recurring-deposit-products-list.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposit-products-list.component.ts
@@ -61,6 +61,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
         <ion-button
           fill="clear"
           color="primary"
+          [attr.aria-label]="'COMMON.EDIT' | translate"
           [appTooltip]="'COMMON.EDIT' | translate"
           (click)="onEdit(product)"
         >

--- a/src/app/features/products/recurring-deposits/recurring-deposits-list.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposits-list.component.ts
@@ -76,6 +76,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
           <ion-button
             fill="clear"
             color="secondary"
+            [attr.aria-label]="'LOANS.APPROVE' | translate"
             [appTooltip]="'LOANS.APPROVE' | translate"
             (click)="onApprove(account)"
           >

--- a/src/app/features/products/savings-account-form.component.ts
+++ b/src/app/features/products/savings-account-form.component.ts
@@ -109,6 +109,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                   [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                   (click)="onCreateClient()"
                   style="margin-top: 4px;"
@@ -141,6 +142,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'PRODUCTS.CREATE_SAVINGS_PRODUCT' | translate"
                   [appTooltip]="'PRODUCTS.CREATE_SAVINGS_PRODUCT' | translate"
                   (click)="onCreateProduct()"
                   style="margin-top: 4px;"

--- a/src/app/features/products/savings-accounts-list.component.ts
+++ b/src/app/features/products/savings-accounts-list.component.ts
@@ -102,6 +102,7 @@ import {
           <ion-button
             fill="clear"
             color="secondary"
+            [attr.aria-label]="'LOANS.APPROVE' | translate"
             [appTooltip]="'LOANS.APPROVE' | translate"
             (click)="onApprove(account)"
             *appHasPermission="'APPROVE_SAVINGSACCOUNT'"

--- a/src/app/features/security/audit-logs/audit-logs-list.component.ts
+++ b/src/app/features/security/audit-logs/audit-logs-list.component.ts
@@ -215,6 +215,7 @@ export interface AuditFilters {
             fill="clear"
             color="primary"
             (click)="onViewDetails(row)"
+            [attr.aria-label]="'COMMON.VIEW_DETAILS' | translate"
             [appTooltip]="'COMMON.VIEW_DETAILS' | translate"
           >
             <ion-icon name="eye-outline"></ion-icon>

--- a/src/app/features/settings/holidays-list.component.ts
+++ b/src/app/features/settings/holidays-list.component.ts
@@ -146,6 +146,7 @@ export class ConfirmDialogComponent {
           <ion-button
             fill="clear"
             color="primary"
+            [attr.aria-label]="'HOLIDAYS.ACTIVATE' | translate"
             [appTooltip]="'HOLIDAYS.ACTIVATE' | translate"
             (click)="onActivateHoliday(holiday)"
           >

--- a/src/app/features/system/bulk-import/bulk-import.component.ts
+++ b/src/app/features/system/bulk-import/bulk-import.component.ts
@@ -127,6 +127,7 @@ import {
             fill="clear"
             color="primary"
             (click)="onDownloadResult(row['importDocumentId'])"
+            [attr.aria-label]="'SYSTEM.DOWNLOAD_RESULT' | translate"
             [appTooltip]="'SYSTEM.DOWNLOAD_RESULT' | translate"
           >
             <ion-icon name="download-outline"></ion-icon>

--- a/src/app/features/system/data-tables/datatables-list.component.ts
+++ b/src/app/features/system/data-tables/datatables-list.component.ts
@@ -68,6 +68,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['edit', row.registeredTableName]"
             *appHasPermission="'UPDATE_DATATABLE'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -77,6 +78,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.registeredTableName)"
             *appHasPermission="'DELETE_DATATABLE'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/system/delinquency/delinquency-management.component.ts
+++ b/src/app/features/system/delinquency/delinquency-management.component.ts
@@ -93,6 +93,7 @@ import {
                   color="primary"
                   [routerLink]="['ranges', 'edit', row.id]"
                   *appHasPermission="'UPDATE_DELINQUENCYRANGE'"
+                  [attr.aria-label]="'COMMON.EDIT' | translate"
                   [appTooltip]="'COMMON.EDIT' | translate"
                 >
                   <ion-icon name="create-outline"></ion-icon>
@@ -102,6 +103,7 @@ import {
                   color="danger"
                   (click)="onDeleteRange(row.id)"
                   *appHasPermission="'DELETE_DELINQUENCYRANGE'"
+                  [attr.aria-label]="'COMMON.DELETE' | translate"
                   [appTooltip]="'COMMON.DELETE' | translate"
                 >
                   <ion-icon name="trash-outline"></ion-icon>
@@ -143,6 +145,7 @@ import {
                   color="primary"
                   [routerLink]="['buckets', 'edit', row.id]"
                   *appHasPermission="'UPDATE_DELINQUENCYBUCKET'"
+                  [attr.aria-label]="'COMMON.EDIT' | translate"
                   [appTooltip]="'COMMON.EDIT' | translate"
                 >
                   <ion-icon name="create-outline"></ion-icon>
@@ -152,6 +155,7 @@ import {
                   color="danger"
                   (click)="onDeleteBucket(row.id)"
                   *appHasPermission="'DELETE_DELINQUENCYBUCKET'"
+                  [attr.aria-label]="'COMMON.DELETE' | translate"
                   [appTooltip]="'COMMON.DELETE' | translate"
                 >
                   <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/shared/directives/tooltip.directive.spec.ts
+++ b/src/app/shared/directives/tooltip.directive.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TooltipDirective } from './tooltip.directive';
+
+const TOOLTIP_TEXT = 'Saves the form';
+const DESCRIBED_BY = 'aria-describedby';
+
+@Component({
+  template: `<button id="host" [appTooltip]="text()">Save</button>`,
+  standalone: true,
+  imports: [TooltipDirective],
+})
+class TestComponent {
+  readonly text = signal(TOOLTIP_TEXT);
+}
+
+const HOST_SELECTOR = '#host';
+const TOOLTIP_SELECTOR = '.app-tooltip';
+/** Matches SHOW_DELAY in the directive. */
+const SHOW_DELAY = 300;
+
+describe('TooltipDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let host: HTMLElement;
+
+  const tooltip = () => document.querySelector<HTMLElement>(TOOLTIP_SELECTOR);
+  const hover = () => host.dispatchEvent(new MouseEvent('mouseenter'));
+  const leave = () => host.dispatchEvent(new MouseEvent('mouseleave'));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TestComponent] });
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    host = fixture.debugElement.query(By.css(HOST_SELECTOR)).nativeElement;
+  });
+
+  afterEach(() => {
+    // A test that leaves the tooltip up would leak it into the next one: the element is
+    // appended to document.body, which the fixture does not own and does not tear down.
+    for (const stray of document.querySelectorAll(TOOLTIP_SELECTOR)) stray.remove();
+  });
+
+  it('should not show anything before the delay has elapsed', fakeAsync(() => {
+    hover();
+    tick(SHOW_DELAY - 1);
+
+    expect(tooltip()).toBeNull();
+
+    tick(1);
+    expect(tooltip()).not.toBeNull();
+  }));
+
+  it('should show the text on hover and describe the host', fakeAsync(() => {
+    hover();
+    tick(SHOW_DELAY);
+
+    const el = tooltip();
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toBe(TOOLTIP_TEXT);
+    expect(el?.getAttribute('role')).toBe('tooltip');
+    expect(host.getAttribute(DESCRIBED_BY)).toBe(el!.id);
+  }));
+
+  it('should show on focus, so the tooltip is reachable from the keyboard', fakeAsync(() => {
+    host.dispatchEvent(new FocusEvent('focusin'));
+    tick(SHOW_DELAY);
+
+    expect(tooltip()?.textContent).toBe(TOOLTIP_TEXT);
+  }));
+
+  it('should describe the host and never name it', fakeAsync(() => {
+    // The distinction this directive is regularly mistaken for handling. aria-describedby is
+    // a description; it is not consulted when the accessible name is computed. An icon-only
+    // button therefore still needs its own aria-label, which scripts/check-a11y-names.mjs
+    // enforces. Asserting it here keeps the boundary explicit at the directive itself.
+    hover();
+    tick(SHOW_DELAY);
+
+    expect(host.getAttribute(DESCRIBED_BY)).toBeTruthy();
+    expect(host.getAttribute('aria-label')).toBeNull();
+  }));
+
+  it('should remove the tooltip and the description on mouseleave', fakeAsync(() => {
+    hover();
+    tick(SHOW_DELAY);
+    leave();
+
+    expect(tooltip()).toBeNull();
+    expect(host.getAttribute(DESCRIBED_BY)).toBeNull();
+  }));
+
+  it('should dismiss on Escape', fakeAsync(() => {
+    hover();
+    tick(SHOW_DELAY);
+    host.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(tooltip()).toBeNull();
+  }));
+
+  it('should cancel a pending tooltip when the pointer leaves within the delay', fakeAsync(() => {
+    hover();
+    tick(SHOW_DELAY - 100);
+    leave();
+    tick(SHOW_DELAY);
+
+    // A passing hover must not leave a tooltip behind after the timer would have fired.
+    expect(tooltip()).toBeNull();
+  }));
+
+  it('should show nothing when the text is empty', fakeAsync(() => {
+    fixture.componentInstance.text.set('');
+    fixture.detectChanges();
+
+    hover();
+    tick(SHOW_DELAY);
+
+    expect(tooltip()).toBeNull();
+  }));
+
+  it('should not open a second tooltip while one is already showing', fakeAsync(() => {
+    hover();
+    tick(SHOW_DELAY);
+    hover();
+    tick(SHOW_DELAY);
+
+    expect(document.querySelectorAll(TOOLTIP_SELECTOR)).toHaveSize(1);
+  }));
+
+  it('should clean up on destroy', fakeAsync(() => {
+    hover();
+    tick(SHOW_DELAY);
+    fixture.destroy();
+
+    expect(tooltip()).toBeNull();
+  }));
+});


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

<!-- Commits must be signed to merge — see CONTRIBUTING.md#commit-signing if you haven't set this up. -->

## What and why

<!-- One or two sentences explaining what changed and why. -->

Closes #

## Verification

<!-- List what you ran and what you checked. Note whether the UI was exercised with mocks, a real Fineract backend, or both. -->

-

## Screenshots

<!-- Add screenshots or a short recording for UI changes. Write "Not applicable" for non-UI changes. -->

## Checklist

<!-- Check each item, or explain why it does not apply. -->

- [ ] I did not hand-edit generated files under `src/app/api/`.
- [ ] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [ ] User-facing strings use translation keys.
- [ ] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant.
- [ ] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.
