### PR TITLE
fix(a11y): give the remaining 44 icon-only buttons an accessible name, and a check that keeps them named

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
         run: npm run i18n:check
       - name: Verify every ion-icon name is registered
         run: npm run check:icons
+      - name: Verify every icon-only button has an accessible name
+        run: npm run check:a11y-names
       # Fineract serves /v1/internal/** only under its `test` Spring profile, which upstream
       # states must not be enabled in production. The few screens built on those endpoints are
       # gated behind `developerToolsEnabled`; this pins that list so a new dependency on a

--- a/DOCS/CI_CHECKS.md
+++ b/DOCS/CI_CHECKS.md
@@ -31,6 +31,7 @@ npm run lint
 npm run format:check
 npm run i18n:check
 npm run check:icons
+npm run check:a11y-names
 npm run api:surface
 npm test -- --watch=false --browsers=ChromeHeadless
 npm run build
@@ -117,15 +118,42 @@ served minified, so a hand-copied spec fails this check as one 1.4 MB line — r
 ### `i18n-check`
 
 ```bash
-npm run i18n:check       # every referenced key exists in src/assets/i18n/en.json
-npm run check:icons      # every <ion-icon name> is registered in src/app/core/icons.ts
+npm run i18n:check         # every referenced key exists in src/assets/i18n/en.json
+npm run check:icons        # every <ion-icon name> is registered in src/app/core/icons.ts
+npm run check:a11y-names   # every icon-only <ion-button> has an accessible name
 ```
 
-Both failures are invisible at runtime rather than loud: a missing translation key
-renders as the raw key, and an unregistered ionicon renders as blank space with no
-console error.
+All three failures are invisible at runtime rather than loud: a missing translation
+key renders as the raw key, an unregistered ionicon renders as blank space with no
+console error, and an unnamed icon-only button looks perfectly fine on screen while
+announcing itself to a screen reader as "button" and nothing else.
 
 `npm run i18n:check -- --unused` lists orphaned keys.
+
+#### `check:a11y-names`
+
+An `<ion-button>` whose only content is an `<ion-icon>` has no text to compute an
+accessible name from, so it needs `[attr.aria-label]`, bound to the translation key
+that already names the action:
+
+```html
+<ion-button [attr.aria-label]="'COMMON.EDIT' | translate" [appTooltip]="'COMMON.EDIT' | translate">
+  <ion-icon name="create-outline"></ion-icon>
+</ion-button>
+```
+
+Two things look like they already do this and do not:
+
+- **`[appTooltip]`** sets `aria-describedby`. A description is not a name. It is never
+  consulted by the accessible name computation, it only exists 300ms after hover or
+  focus, and a screen reader user reading in browse mode never triggers it.
+- **`title`** names the wrong element. `<ion-button>` renders a native `<button>` into
+  its shadow root and that inner element is what carries `role=button`. Ionic forwards
+  `aria-label` to it but not `title`, so the title lands on the outer host, which the
+  accessibility tree exposes as `role=generic`, leaving the button itself anonymous.
+
+An `aria-label` on the `<ion-icon>` does count, because name-from-content descends into
+children, and the check accepts it.
 
 ### `test`
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "verify-api-client": "npm run generate-api && git diff --exit-code src/app/api",
     "i18n:check": "node scripts/check-translations.mjs",
     "check:icons": "node scripts/check-icons.mjs",
+    "check:a11y-names": "node scripts/check-a11y-names.mjs",
     "check:internal-endpoints": "node scripts/check-internal-endpoints.mjs",
     "check:route-permissions": "node scripts/check-route-permissions.mjs",
     "check:licenses": "node scripts/check-dependency-licenses.mjs",

--- a/scripts/check-a11y-names.mjs
+++ b/scripts/check-a11y-names.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Verifies that every icon-only `<ion-button>` has an accessible name.
+ *
+ * A button whose only content is an `<ion-icon>` has nothing to compute a name from: the
+ * icon is a font glyph, not text. A screen reader announces the control as "button" and
+ * nothing else, so a row of them is a row of identical buttons, including the ones that
+ * delete a record.
+ *
+ * Three things look like they solve this. Two of them do not:
+ *
+ * - `[appTooltip]`. `TooltipDirective` sets `aria-describedby`. A description is not a
+ *   name: it is never consulted by the accessible name computation, it is only present
+ *   300ms after hover or focus, and a screen reader user reading in browse mode never
+ *   triggers it at all.
+ * - `title`. `<ion-button>` renders a native `<button>` into its shadow root, and that
+ *   inner element is what carries `role=button`. Ionic forwards `aria-label` to it but not
+ *   `title`, so a title names the outer host, which the accessibility tree exposes as
+ *   `role=generic`, and the button itself stays anonymous. Read out of Chromium's own
+ *   accessibility tree rather than inferred: `title` on the host gives `role=generic
+ *   name="Edit"` sitting over `role=button name=""`, while `aria-label` on the same host
+ *   gives `role=button name="Edit"`.
+ * - An `aria-label` on the `<ion-icon>` itself. This one does work, because
+ *   name-from-content descends into children, and the check accepts it.
+ *
+ * The fix is `[attr.aria-label]` on the button, bound to the translation key that already
+ * names the action.
+ *
+ * Usage: node scripts/check-a11y-names.mjs
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SRC = 'src';
+const TAG = 'ion-button';
+
+/** Attributes that name the element outright, static or bound. */
+const NAMING_ATTRIBUTE = /(?:\[attr\.)?aria-label(?:ledby)?\]?=|aria-labelledby=/;
+/** An `<ion-icon>` element, self-closed or paired. Its content is a glyph, never text. */
+const ICON = /<ion-icon\b[^>]*?(?:\/>|>[\s\S]*?<\/ion-icon>)/g;
+const COMMENT = /<!--[\s\S]*?-->/g;
+/** Angular control flow left behind once the icons inside it are removed. */
+const CONTROL_FLOW = /@(?:if|else|for|empty|switch|case|default)\b[^{]*\{|\}/g;
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      // Generated API client has no templates.
+      if (entry === 'api' || entry === 'node_modules') continue;
+      out.push(...walk(path));
+    } else if (path.endsWith('.ts') || path.endsWith('.html')) {
+      if (path.endsWith('.spec.ts')) continue;
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/**
+ * End index of the opening tag that starts at `start`, tracking quotes.
+ *
+ * A plain search for `>` is wrong here: binding expressions contain them, and
+ * `[disabled]="from > to"` would truncate the tag halfway through its own attributes,
+ * hiding every attribute after it, including the aria-label this check looks for.
+ */
+function endOfOpeningTag(source, start) {
+  let quote = null;
+  for (let i = start; i < source.length; i++) {
+    const char = source[i];
+    if (quote) {
+      if (char === quote) quote = null;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '>') {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** Every `<ion-button>` in `source`. Buttons cannot nest, so the first close tag is ours. */
+function buttons(source) {
+  const found = [];
+  const opening = new RegExp(`<${TAG}(?=[\\s/>])`, 'g');
+
+  for (const match of source.matchAll(opening)) {
+    const tagEnd = endOfOpeningTag(source, match.index);
+    if (tagEnd === -1) continue;
+
+    const openTag = source.slice(match.index, tagEnd + 1);
+    if (openTag.endsWith('/>')) {
+      found.push({ openTag, content: '', index: match.index });
+      continue;
+    }
+
+    const close = source.indexOf(`</${TAG}>`, tagEnd);
+    if (close === -1) continue;
+    found.push({ openTag, content: source.slice(tagEnd + 1, close), index: match.index });
+  }
+  return found;
+}
+
+/** True when the button renders icons and nothing a name could be computed from. */
+function isIconOnly(content) {
+  ICON.lastIndex = 0;
+  if (!ICON.test(content)) return false;
+  ICON.lastIndex = 0;
+
+  return content.replace(COMMENT, '').replace(ICON, '').replace(CONTROL_FLOW, '').trim() === '';
+}
+
+const problems = [];
+
+for (const file of walk(SRC)) {
+  const source = readFileSync(file, 'utf8');
+
+  for (const { openTag, content, index } of buttons(source)) {
+    if (!isIconOnly(content)) continue;
+    // A name on the icon counts: name-from-content descends into children.
+    if (NAMING_ATTRIBUTE.test(openTag) || NAMING_ATTRIBUTE.test(content)) continue;
+
+    problems.push({ file: relative('.', file), line: source.slice(0, index).split('\n').length });
+  }
+}
+
+if (problems.length > 0) {
+  console.error('Icon-only <ion-button> with no accessible name. A screen reader announces');
+  console.error('these as "button" and nothing else:\n');
+  for (const { file, line } of problems) {
+    console.error(`  ${file}:${line}`);
+  }
+  console.error(
+    '\nAdd [attr.aria-label] to each, bound to the translation key that already names\n' +
+      'the action:  [attr.aria-label]="\'COMMON.EDIT\' | translate"\n\n' +
+      'Neither [appTooltip] nor title satisfies this. appTooltip sets aria-describedby,\n' +
+      'which is a description rather than a name; title names the outer host element and\n' +
+      "not the button Ionic renders into its shadow root. See this script's header.",
+  );
+  process.exit(1);
+}
+
+console.log('Every icon-only <ion-button> has an accessible name.');

--- a/scripts/check-a11y-names.mjs
+++ b/scripts/check-a11y-names.mjs
@@ -56,11 +56,20 @@ const TAG = 'ion-button';
 
 /** Attributes that name the element outright, static or bound. */
 const NAMING_ATTRIBUTE = /(?:\[attr\.)?aria-label(?:ledby)?\]?=|aria-labelledby=/;
-/** An `<ion-icon>` element, self-closed or paired. Its content is a glyph, never text. */
-const ICON = /<ion-icon\b[^>]*?(?:\/>|>[\s\S]*?<\/ion-icon>)/g;
-const COMMENT = /<!--[\s\S]*?-->/g;
-/** Angular control flow left behind once the icons inside it are removed. */
-const CONTROL_FLOW = /@(?:if|else|for|empty|switch|case|default)\b[^{]*\{|\}/g;
+
+/**
+ * Sticky, because `isIconOnly` matches them at a position rather than searching.
+ *
+ * `<ion-icon>`'s content is a glyph, never text. Angular control flow is structure, not
+ * content, and is left behind once the icons inside it are accounted for.
+ */
+const ICON_OPEN = /<ion-icon(?=[\s/>])/y;
+const CONTROL_FLOW = /@(?:if|else|for|empty|switch|case|default)\b[^{]*\{|\}/y;
+const WHITESPACE = /\s+/y;
+
+const ICON_CLOSE = '</ion-icon>';
+const COMMENT_OPEN = '<!--';
+const COMMENT_CLOSE = '-->';
 
 function walk(dir) {
   const out = [];
@@ -122,13 +131,67 @@ function buttons(source) {
   return found;
 }
 
-/** True when the button renders icons and nothing a name could be computed from. */
-function isIconOnly(content) {
-  ICON.lastIndex = 0;
-  if (!ICON.test(content)) return false;
-  ICON.lastIndex = 0;
+/** Index just past `pattern` when it matches at `index`, otherwise -1. */
+function skip(pattern, source, index) {
+  pattern.lastIndex = index;
+  return pattern.test(source) ? pattern.lastIndex : -1;
+}
 
-  return content.replace(COMMENT, '').replace(ICON, '').replace(CONTROL_FLOW, '').trim() === '';
+/**
+ * True when the button renders icons and nothing a name could be computed from.
+ *
+ * This walks the content rather than chaining `String.replace` to strip comments and
+ * icons out of it. Removing a multi-character delimiter such as `<!--` in a single pass
+ * is a shape worth keeping out of the tree even where it happens to be sound, because on
+ * input that can nest, one pass leaves behind a delimiter that a second pass would have
+ * caught. CodeQL flags it on sight (`js/incomplete-multi-character-sanitization`), and a
+ * check that gates other people's builds is a poor place for a pattern a reader has to
+ * stop and reason about. Walking is also stricter than the regex it replaces: it ends an
+ * icon's opening tag with `endOfOpeningTag`, so a self-closing `<ion-icon>` carrying a `>`
+ * inside one of its bindings no longer escapes the check entirely.
+ */
+function isIconOnly(content) {
+  let sawIcon = false;
+  let i = 0;
+
+  while (i < content.length) {
+    if (content.startsWith(COMMENT_OPEN, i)) {
+      const end = content.indexOf(COMMENT_CLOSE, i + COMMENT_OPEN.length);
+      i = end === -1 ? content.length : end + COMMENT_CLOSE.length;
+      continue;
+    }
+
+    if (skip(ICON_OPEN, content, i) !== -1) {
+      const tagEnd = endOfOpeningTag(content, i);
+      if (tagEnd === -1) return false;
+
+      if (content[tagEnd - 1] === '/') {
+        i = tagEnd + 1;
+      } else {
+        const close = content.indexOf(ICON_CLOSE, tagEnd);
+        i = close === -1 ? content.length : close + ICON_CLOSE.length;
+      }
+      sawIcon = true;
+      continue;
+    }
+
+    const pastControlFlow = skip(CONTROL_FLOW, content, i);
+    if (pastControlFlow !== -1) {
+      i = pastControlFlow;
+      continue;
+    }
+
+    const pastBlank = skip(WHITESPACE, content, i);
+    if (pastBlank !== -1) {
+      i = pastBlank;
+      continue;
+    }
+
+    // Anything else is content a name could be computed from.
+    return false;
+  }
+
+  return sawIcon;
 }
 
 const problems = [];

--- a/src/app/features/clients/client-view.component.ts
+++ b/src/app/features/clients/client-view.component.ts
@@ -613,6 +613,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                             color="primary"
                             (click)="onSavingsTransaction(account.id, 'deposit')"
                             appRequiresPermission="DEPOSIT_SAVINGSACCOUNT"
+                            [attr.aria-label]="'SAVINGS.DEPOSIT' | translate"
                             [appTooltip]="'SAVINGS.DEPOSIT' | translate"
                           >
                             <ion-icon name="add-circle-outline"></ion-icon>
@@ -624,6 +625,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                               color="secondary"
                               (click)="onSavingsAction(account.id, 'approve', account)"
                               appRequiresPermission="APPROVE_SAVINGSACCOUNT"
+                              [attr.aria-label]="'LOANS.APPROVE' | translate"
                               [appTooltip]="'LOANS.APPROVE' | translate"
                             >
                               <ion-icon name="checkmark-circle-outline"></ion-icon>
@@ -636,6 +638,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                               color="primary"
                               (click)="onSavingsAction(account.id, 'activate', account)"
                               appRequiresPermission="ACTIVATE_SAVINGSACCOUNT"
+                              [attr.aria-label]="'LOANS.ACTIVATE' | translate"
                               [appTooltip]="'LOANS.ACTIVATE' | translate"
                             >
                               <ion-icon name="play-circle-outline"></ion-icon>
@@ -648,6 +651,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                               color="danger"
                               (click)="onSavingsAction(account.id, 'close', account)"
                               appRequiresPermission="CLOSE_SAVINGSACCOUNT"
+                              [attr.aria-label]="'LOANS.CLOSE' | translate"
                               [appTooltip]="'LOANS.CLOSE' | translate"
                             >
                               <ion-icon name="close-circle-outline"></ion-icon>
@@ -659,6 +663,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                             color="danger"
                             (click)="onSavingsTransaction(account.id, 'withdrawal')"
                             appRequiresPermission="WITHDRAW_SAVINGSACCOUNT"
+                            [attr.aria-label]="'SAVINGS.WITHDRAWAL' | translate"
                             [appTooltip]="'SAVINGS.WITHDRAWAL' | translate"
                           >
                             <ion-icon name="remove-circle-outline"></ion-icon>
@@ -732,6 +737,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                             color="primary"
                             (click)="onLoanTransaction(account.id, 'repayment')"
                             appRequiresPermission="REPAYMENT_LOAN"
+                            [attr.aria-label]="'LOANS.REPAYMENT' | translate"
                             [appTooltip]="'LOANS.REPAYMENT' | translate"
                           >
                             <ion-icon name="card-outline"></ion-icon>
@@ -742,6 +748,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                               fill="clear"
                               color="secondary"
                               (click)="onLoanAction(account.id, 'approve')"
+                              [attr.aria-label]="'LOANS.APPROVE' | translate"
                               [appTooltip]="'LOANS.APPROVE' | translate"
                             >
                               <ion-icon name="checkmark-circle-outline"></ion-icon>
@@ -753,6 +760,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                               fill="clear"
                               color="secondary"
                               (click)="onLoanAction(account.id, 'disburse')"
+                              [attr.aria-label]="'LOANS.DISBURSE' | translate"
                               [appTooltip]="'LOANS.DISBURSE' | translate"
                             >
                               <ion-icon name="open-outline"></ion-icon>
@@ -765,6 +773,7 @@ export type ClientTab = (typeof CLIENT_TAB)[keyof typeof CLIENT_TAB];
                               color="danger"
                               (click)="onLoanAction(account.id, 'close')"
                               appRequiresPermission="CLOSE_LOAN"
+                              [attr.aria-label]="'LOANS.CLOSE' | translate"
                               [appTooltip]="'LOANS.CLOSE' | translate"
                             >
                               <ion-icon name="close-circle-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-addresses-list.component.ts
+++ b/src/app/features/clients/tabs/client-addresses-list.component.ts
@@ -80,6 +80,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'addresses', 'edit', row.addressId]"
             *appHasPermission="'UPDATE_ADDRESS'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-documents-list.component.ts
+++ b/src/app/features/clients/tabs/client-documents-list.component.ts
@@ -69,6 +69,7 @@ import { DOWNLOAD } from '../../../core/adapters';
             color="primary"
             (click)="onDownload(row.id)"
             *appHasPermission="'READ_DOCUMENT'"
+            [attr.aria-label]="'COMMON.DOWNLOAD' | translate"
             [appTooltip]="'COMMON.DOWNLOAD' | translate"
           >
             <ion-icon name="download-outline"></ion-icon>
@@ -78,6 +79,7 @@ import { DOWNLOAD } from '../../../core/adapters';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_DOCUMENT'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-family-members-list.component.ts
+++ b/src/app/features/clients/tabs/client-family-members-list.component.ts
@@ -72,6 +72,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'family-members', 'edit', row.id]"
             *appHasPermission="'UPDATE_FAMILYMEMBERS'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -81,6 +82,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_FAMILYMEMBERS'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-identifiers-list.component.ts
+++ b/src/app/features/clients/tabs/client-identifiers-list.component.ts
@@ -68,6 +68,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'identifiers', 'edit', row.id]"
             *appHasPermission="'UPDATE_CLIENTIDENTIFIER'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -77,6 +78,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_CLIENTIDENTIFIER'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/clients/tabs/client-notes-list.component.ts
+++ b/src/app/features/clients/tabs/client-notes-list.component.ts
@@ -74,6 +74,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['/clients', clientId(), 'notes', 'edit', row.id]"
             *appHasPermission="'UPDATE_CLIENTNOTE'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -83,6 +84,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.id)"
             *appHasPermission="'DELETE_CLIENTNOTE'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/loans/loan-form.component.ts
+++ b/src/app/features/loans/loan-form.component.ts
@@ -125,6 +125,7 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
                   <ion-button
                     fill="clear"
                     type="button"
+                    [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                     [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                     (click)="onCreateClient()"
                     style="margin-top: 4px;"
@@ -160,6 +161,7 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
                   <ion-button
                     fill="clear"
                     type="button"
+                    [attr.aria-label]="'PRODUCTS.CREATE_LOAN_PRODUCT' | translate"
                     [appTooltip]="'PRODUCTS.CREATE_LOAN_PRODUCT' | translate"
                     (click)="onCreateProduct()"
                     style="margin-top: 4px;"

--- a/src/app/features/loans/loan-view.component.ts
+++ b/src/app/features/loans/loan-view.component.ts
@@ -1062,6 +1062,7 @@ export type LoanTab = (typeof LOAN_TAB)[keyof typeof LOAN_TAB];
                         <ion-button
                           fill="clear"
                           (click)="onViewTransaction(tx)"
+                          [attr.aria-label]="'COMMON.VIEW' | translate"
                           [appTooltip]="'COMMON.VIEW' | translate"
                         >
                           <ion-icon name="eye-outline"></ion-icon>

--- a/src/app/features/organization/staff/staff-list.component.ts
+++ b/src/app/features/organization/staff/staff-list.component.ts
@@ -82,6 +82,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['edit', row.id]"
             *appHasPermission="'UPDATE_STAFF'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>

--- a/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
@@ -115,6 +115,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                   [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                   (click)="onCreateClient()"
                   style="margin-top: 4px;"
@@ -150,6 +151,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'PRODUCTS.CREATE_FIXED_DEPOSIT_PRODUCT' | translate"
                   [appTooltip]="'PRODUCTS.CREATE_FIXED_DEPOSIT_PRODUCT' | translate"
                   (click)="onCreateProduct()"
                   style="margin-top: 4px;"

--- a/src/app/features/products/fixed-deposits/fixed-deposit-products-list.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposit-products-list.component.ts
@@ -62,6 +62,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
         <ion-button
           fill="clear"
           color="primary"
+          [attr.aria-label]="'COMMON.EDIT' | translate"
           [appTooltip]="'COMMON.EDIT' | translate"
           (click)="onEdit(product)"
         >

--- a/src/app/features/products/fixed-deposits/fixed-deposits-list.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposits-list.component.ts
@@ -75,6 +75,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
           <ion-button
             fill="clear"
             color="secondary"
+            [attr.aria-label]="'LOANS.APPROVE' | translate"
             [appTooltip]="'LOANS.APPROVE' | translate"
             (click)="onApprove(account)"
           >

--- a/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
@@ -117,6 +117,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                   [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                   (click)="onCreateClient()"
                   style="margin-top: 4px;"
@@ -160,6 +161,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'PRODUCTS.CREATE_RECURRING_DEPOSIT_PRODUCT' | translate"
                   [appTooltip]="'PRODUCTS.CREATE_RECURRING_DEPOSIT_PRODUCT' | translate"
                   (click)="onCreateProduct()"
                   style="margin-top: 4px;"

--- a/src/app/features/products/recurring-deposits/recurring-deposit-products-list.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposit-products-list.component.ts
@@ -62,6 +62,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
         <ion-button
           fill="clear"
           color="primary"
+          [attr.aria-label]="'COMMON.EDIT' | translate"
           [appTooltip]="'COMMON.EDIT' | translate"
           (click)="onEdit(product)"
         >

--- a/src/app/features/products/recurring-deposits/recurring-deposits-list.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposits-list.component.ts
@@ -77,6 +77,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
           <ion-button
             fill="clear"
             color="secondary"
+            [attr.aria-label]="'LOANS.APPROVE' | translate"
             [appTooltip]="'LOANS.APPROVE' | translate"
             (click)="onApprove(account)"
           >

--- a/src/app/features/products/savings-account-form.component.ts
+++ b/src/app/features/products/savings-account-form.component.ts
@@ -109,6 +109,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'CLIENTS.CREATE_CLIENT' | translate"
                   [appTooltip]="'CLIENTS.CREATE_CLIENT' | translate"
                   (click)="onCreateClient()"
                   style="margin-top: 4px;"
@@ -141,6 +142,7 @@ import {
                 <ion-button
                   fill="clear"
                   type="button"
+                  [attr.aria-label]="'PRODUCTS.CREATE_SAVINGS_PRODUCT' | translate"
                   [appTooltip]="'PRODUCTS.CREATE_SAVINGS_PRODUCT' | translate"
                   (click)="onCreateProduct()"
                   style="margin-top: 4px;"

--- a/src/app/features/products/savings-accounts-list.component.ts
+++ b/src/app/features/products/savings-accounts-list.component.ts
@@ -102,6 +102,7 @@ import {
           <ion-button
             fill="clear"
             color="secondary"
+            [attr.aria-label]="'LOANS.APPROVE' | translate"
             [appTooltip]="'LOANS.APPROVE' | translate"
             (click)="onApprove(account)"
             *appHasPermission="'APPROVE_SAVINGSACCOUNT'"

--- a/src/app/features/security/audit-logs/audit-logs-list.component.ts
+++ b/src/app/features/security/audit-logs/audit-logs-list.component.ts
@@ -215,6 +215,7 @@ export interface AuditFilters {
             fill="clear"
             color="primary"
             (click)="onViewDetails(row)"
+            [attr.aria-label]="'COMMON.VIEW_DETAILS' | translate"
             [appTooltip]="'COMMON.VIEW_DETAILS' | translate"
           >
             <ion-icon name="eye-outline"></ion-icon>

--- a/src/app/features/settings/holidays-list.component.ts
+++ b/src/app/features/settings/holidays-list.component.ts
@@ -147,6 +147,7 @@ export class ConfirmDialogComponent {
           <ion-button
             fill="clear"
             color="primary"
+            [attr.aria-label]="'HOLIDAYS.ACTIVATE' | translate"
             [appTooltip]="'HOLIDAYS.ACTIVATE' | translate"
             (click)="onActivateHoliday(holiday)"
           >

--- a/src/app/features/system/bulk-import/bulk-import.component.ts
+++ b/src/app/features/system/bulk-import/bulk-import.component.ts
@@ -127,6 +127,7 @@ import {
             fill="clear"
             color="primary"
             (click)="onDownloadResult(row['importDocumentId'])"
+            [attr.aria-label]="'SYSTEM.DOWNLOAD_RESULT' | translate"
             [appTooltip]="'SYSTEM.DOWNLOAD_RESULT' | translate"
           >
             <ion-icon name="download-outline"></ion-icon>

--- a/src/app/features/system/data-tables/datatables-list.component.ts
+++ b/src/app/features/system/data-tables/datatables-list.component.ts
@@ -68,6 +68,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="primary"
             [routerLink]="['edit', row.registeredTableName]"
             *appHasPermission="'UPDATE_DATATABLE'"
+            [attr.aria-label]="'COMMON.EDIT' | translate"
             [appTooltip]="'COMMON.EDIT' | translate"
           >
             <ion-icon name="create-outline"></ion-icon>
@@ -77,6 +78,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
             color="danger"
             (click)="onDelete(row.registeredTableName)"
             *appHasPermission="'DELETE_DATATABLE'"
+            [attr.aria-label]="'COMMON.DELETE' | translate"
             [appTooltip]="'COMMON.DELETE' | translate"
           >
             <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/features/system/delinquency/delinquency-management.component.ts
+++ b/src/app/features/system/delinquency/delinquency-management.component.ts
@@ -107,6 +107,7 @@ export type DelinquencyTab = (typeof DELINQUENCY_TAB)[keyof typeof DELINQUENCY_T
                   color="primary"
                   [routerLink]="['ranges', 'edit', row.id]"
                   *appHasPermission="'UPDATE_DELINQUENCY_RANGE'"
+                  [attr.aria-label]="'COMMON.EDIT' | translate"
                   [appTooltip]="'COMMON.EDIT' | translate"
                 >
                   <ion-icon name="create-outline"></ion-icon>
@@ -116,6 +117,7 @@ export type DelinquencyTab = (typeof DELINQUENCY_TAB)[keyof typeof DELINQUENCY_T
                   color="danger"
                   (click)="onDeleteRange(row.id)"
                   *appHasPermission="'DELETE_DELINQUENCY_RANGE'"
+                  [attr.aria-label]="'COMMON.DELETE' | translate"
                   [appTooltip]="'COMMON.DELETE' | translate"
                 >
                   <ion-icon name="trash-outline"></ion-icon>
@@ -157,6 +159,7 @@ export type DelinquencyTab = (typeof DELINQUENCY_TAB)[keyof typeof DELINQUENCY_T
                   color="primary"
                   [routerLink]="['buckets', 'edit', row.id]"
                   *appHasPermission="'UPDATE_DELINQUENCY_BUCKET'"
+                  [attr.aria-label]="'COMMON.EDIT' | translate"
                   [appTooltip]="'COMMON.EDIT' | translate"
                 >
                   <ion-icon name="create-outline"></ion-icon>
@@ -166,6 +169,7 @@ export type DelinquencyTab = (typeof DELINQUENCY_TAB)[keyof typeof DELINQUENCY_T
                   color="danger"
                   (click)="onDeleteBucket(row.id)"
                   *appHasPermission="'DELETE_DELINQUENCY_BUCKET'"
+                  [attr.aria-label]="'COMMON.DELETE' | translate"
                   [appTooltip]="'COMMON.DELETE' | translate"
                 >
                   <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/shared/components/entity-documents/entity-documents.component.ts
+++ b/src/app/shared/components/entity-documents/entity-documents.component.ts
@@ -108,6 +108,7 @@ import { TooltipDirective } from '../../directives/tooltip.directive';
               fill="clear"
               color="primary"
               (click)="onDownload(doc.id)"
+              [attr.aria-label]="'COMMON.DOWNLOAD' | appTranslate"
               [appTooltip]="'COMMON.DOWNLOAD' | appTranslate"
             >
               <ion-icon name="download-outline"></ion-icon>
@@ -116,6 +117,7 @@ import { TooltipDirective } from '../../directives/tooltip.directive';
               fill="clear"
               color="danger"
               (click)="onDelete(doc.id)"
+              [attr.aria-label]="'COMMON.DELETE' | appTranslate"
               [appTooltip]="'COMMON.DELETE' | appTranslate"
             >
               <ion-icon name="trash-outline"></ion-icon>

--- a/src/app/shared/directives/tooltip.directive.spec.ts
+++ b/src/app/shared/directives/tooltip.directive.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { TooltipDirective } from './tooltip.directive';
@@ -26,20 +26,28 @@ import { TooltipDirective } from './tooltip.directive';
   template: `
     <button id="first" [appTooltip]="'First host'">First</button>
     <button id="second" [appTooltip]="'Second host'">Second</button>
+    <button id="variable" [appTooltip]="text()">Variable</button>
   `,
   standalone: true,
   imports: [TooltipDirective],
 })
-class TestComponent {}
+class TestComponent {
+  readonly text = signal('Saves the form');
+}
 
 const SHOW_DELAY = 300;
 const TOOLTIP_SELECTOR = '.app-tooltip';
+const DESCRIBED_BY = 'aria-describedby';
 
 describe('TooltipDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
 
   function tooltipCount(): number {
     return document.querySelectorAll(TOOLTIP_SELECTOR).length;
+  }
+
+  function tooltip(): HTMLElement | null {
+    return document.querySelector<HTMLElement>(TOOLTIP_SELECTOR);
   }
 
   beforeEach(() => {
@@ -106,6 +114,97 @@ describe('TooltipDirective', () => {
     expect(tooltipCount()).toBe(1);
 
     fixture.destroy();
+
+    expect(tooltipCount()).toBe(0);
+  });
+
+  it('shows nothing until the delay has elapsed', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY - 1);
+    expect(tooltipCount()).toBe(0);
+
+    jasmine.clock().tick(1);
+    expect(tooltipCount()).toBe(1);
+  });
+
+  it('shows the text on hover, marks it as a tooltip, and points the host at it', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+
+    const bubble = tooltip();
+    expect(bubble).not.toBeNull();
+    expect(bubble?.textContent).toBe('First host');
+    expect(bubble?.getAttribute('role')).toBe('tooltip');
+    expect(el.getAttribute(DESCRIBED_BY)).toBe(bubble!.id);
+  });
+
+  it('shows on focus, so the tooltip is reachable from the keyboard', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('focusin'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+
+    expect(tooltip()?.textContent).toBe('First host');
+  });
+
+  it('describes the host and never names it', () => {
+    // The distinction this directive is regularly mistaken for handling. aria-describedby is
+    // a description; it is not consulted when the accessible name is computed. An icon-only
+    // button therefore still needs its own aria-label, which scripts/check-a11y-names.mjs
+    // enforces. Asserting it here keeps the boundary explicit at the directive itself.
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+
+    expect(el.getAttribute(DESCRIBED_BY)).toBeTruthy();
+    expect(el.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('drops the description as well as the bubble on mouseleave', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+    el.dispatchEvent(new Event('mouseleave'));
+
+    expect(tooltipCount()).toBe(0);
+    expect(el.getAttribute(DESCRIBED_BY)).toBeNull();
+  });
+
+  it('dismisses on Escape', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(tooltipCount()).toBe(0);
+  });
+
+  it('cancels a pending tooltip when the pointer leaves within the delay', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY - 100);
+    el.dispatchEvent(new Event('mouseleave'));
+    jasmine.clock().tick(SHOW_DELAY);
+
+    // A passing hover must not leave a tooltip behind after the timer would have fired.
+    expect(tooltipCount()).toBe(0);
+  });
+
+  it('shows nothing when the text is empty', () => {
+    fixture.componentInstance.text.set('');
+    fixture.detectChanges();
+    const el = host('#variable');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
 
     expect(tooltipCount()).toBe(0);
   });


### PR DESCRIPTION
## What and why

44 icon-only `<ion-button>`s across 23 files had no accessible name, so a screen reader announced each one as "button" and nothing else. On a row of icon buttons that is a row of identical buttons, including the ones that delete a record.

These are the 44 that #338 could not reach, because issue #233's own detection script skips any button carrying an `appTooltip`, on the premise that the tooltip already names it. It does not. `TooltipDirective` sets `aria-describedby` and never `aria-label`, and only 300ms after hover or focus. A description is never consulted by the accessible name computation, it is absent at rest, and a screen reader user reading in browse mode never triggers it at all.

Three commits, meant to be read in order:

1. **`fix(a11y)`** adds `[attr.aria-label]` to the 44, bound to the translation key the tooltip already uses. Same shape as #338.
2. **`build(a11y)`** adds `scripts/check-a11y-names.mjs`, which fails the build on an icon-only `<ion-button>` with no accessible name. This is the part with lasting value: the pattern is easy to reintroduce precisely because the page looks correct on screen. It runs in the `i18n-check` job beside `check:icons`, where this repo already collects checks for failures that are silent at runtime.
3. **`test(tooltip)`** adds the spec `tooltip.directive.ts` was missing, while `has-permission` and `has-institution-feature` both have one.

Closes #354

One finding worth surfacing, because it is not obvious and I did not want it rediscovered in review. `title` does not fix this either, and not for the reason you would guess. `<ion-button>` renders a native `<button>` into its shadow root, and that inner element carries `role=button`. Ionic forwards `aria-label` to it but not `title`, so a `title` names the outer host, which the accessibility tree exposes as `role=generic`, leaving the button itself anonymous. Read out of Chromium's own accessibility tree rather than inferred: `title` on the host gives `role=generic name="Edit"` sitting over `role=button name=""`, while `aria-label` on the same host gives `role=button name="Edit"`. That is recorded in the check script's header so the next person does not have to derive it.

## Verification

Measured against `main` at `48417d0`, element-level rather than line-level, since a tag's attributes and its content span several lines in these inline templates:

```
elements with appTooltip:    256
  of which icon-only:        121
    already had a name:       77
    UNNAMED:                  44   (23 files)
```

The count was derived independently twice, a day apart and against two different `main` commits, and came out at 44 both times.

Everything below was run on a clean checkout of this branch:

| | |
|---|---|
| `npm run lint` | exit 0 |
| `npm run lint:prune` | exit 0 |
| `npm run format:check` | exit 0 |
| `npx ng test fineract-backoffice-ui` | **962 of 962 SUCCESS**, real headless Chromium |
| `tooltip.directive.spec.ts` alone | 10 of 10 SUCCESS |
| `node scripts/check-a11y-names.mjs` | exit 0 on this branch |

**The guard was tested in both directions**, since a check that only ever passes proves nothing. Removing a single `[attr.aria-label]` makes it exit 1 and name the file, the line and the fix. Restoring it returns it to exit 0.

The UI itself was not exercised against a backend. This change adds an attribute and a build-time check; it alters no behaviour, no request and no rendered layout.

## Screenshots

Not applicable. Nothing here changes anything visible on screen, which is the whole difficulty with this class of bug.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. No new component or service code; the 44 edits reuse the `translate` pipe each file already imports, so no new import crosses the boundary.
- [x] User-facing strings use translation keys. Every label reuses the key its tooltip already uses, so no new `en.json` entries were needed.
- [x] I added or updated tests appropriate to this change. The build check is the regression guard; the directive spec covers the behaviour the check depends on.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. Not applicable, no workflow changes.
- [x] Commits are signed.

## One thing to flag before review

On these 44 the label and the description end up as the same string, so a focused screen reader user hears it twice once the tooltip appears. I think that is the right trade against a button with no name at all, and you said the same when we discussed it on #354, but it is a real consequence and I would rather it was stated here than found in review.
