### PR TITLE
fix(ux): replace native confirm on accounting, organization and working-capital deletes

### DIFF
--- a/src/app/features/accounting/provisioning-categories/provisioning-categories-list.component.ts
+++ b/src/app/features/accounting/provisioning-categories/provisioning-categories-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { ProvisioningCategoryService, ProvisioningCategoryData } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists provisioning categories. Categories are small master-data records
@@ -78,6 +79,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class ProvisioningCategoriesListComponent implements OnInit {
   private readonly categoryService = inject(ProvisioningCategoryService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'categoryName', label: 'PROVISIONING_CATEGORIES.NAME', sortable: true },
@@ -111,10 +114,21 @@ export class ProvisioningCategoriesListComponent implements OnInit {
   }
 
   onDelete(row: ProvisioningCategoryData): void {
-    if (!row.id || !window.confirm('Delete this provisioning category?')) return;
-    this.categoryService.deleteProvisioningcategoryCategoryId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete provisioning category', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('PROVISIONING_CATEGORIES.DELETE'),
+        message: this.translate.instant('PROVISIONING_CATEGORIES.CONFIRM_DELETE', {
+          name: row.categoryName,
+        }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.categoryService.deleteProvisioningcategoryCategoryId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete provisioning category', err),
+        });
+      });
   }
 }

--- a/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.spec.ts
+++ b/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('ProvisioningCriteriaListComponent', () => {
   let component: ProvisioningCriteriaListComponent;
   let fixture: ComponentFixture<ProvisioningCriteriaListComponent>;
   let serviceSpy: jasmine.SpyObj<ProvisioningCriteriaService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('ProvisioningCriteriaService', [
@@ -37,6 +39,8 @@ describe('ProvisioningCriteriaListComponent', () => {
       'deleteProvisioningcriteriaCriteriaId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getProvisioningcriteria.and.returnValue(
       of([{ criteriaId: 1, criteriaName: 'Default', createdBy: 'admin' }]) as unknown as ReturnType<
         ProvisioningCriteriaService['getProvisioningcriteria']
@@ -48,6 +52,7 @@ describe('ProvisioningCriteriaListComponent', () => {
       providers: [
         { provide: ProvisioningCriteriaService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -68,8 +73,8 @@ describe('ProvisioningCriteriaListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/accounting/provisioning-criteria/edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteProvisioningcriteriaCriteriaId.and.returnValue(
       of({}) as unknown as ReturnType<
         ProvisioningCriteriaService['deleteProvisioningcriteriaCriteriaId']
@@ -77,14 +82,16 @@ describe('ProvisioningCriteriaListComponent', () => {
     );
 
     component.onDelete({ criteriaId: 5, criteriaName: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteProvisioningcriteriaCriteriaId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getProvisioningcriteria).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ criteriaId: 5, criteriaName: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteProvisioningcriteriaCriteriaId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.ts
+++ b/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { ProvisioningCriteriaService, GetProvisioningCriteriaResponse } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists provisioning criteria. The list response carries the criteria name and
@@ -78,6 +79,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class ProvisioningCriteriaListComponent implements OnInit {
   private readonly criteriaService = inject(ProvisioningCriteriaService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'criteriaName', label: 'PROVISIONING_CRITERIA.NAME', sortable: true },
@@ -111,10 +114,21 @@ export class ProvisioningCriteriaListComponent implements OnInit {
   }
 
   onDelete(row: GetProvisioningCriteriaResponse): void {
-    if (!row.criteriaId || !window.confirm('Delete this provisioning criteria?')) return;
-    this.criteriaService.deleteProvisioningcriteriaCriteriaId(row.criteriaId).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete provisioning criteria', err),
-    });
+    if (!row.criteriaId) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('PROVISIONING_CRITERIA.DELETE'),
+        message: this.translate.instant('PROVISIONING_CRITERIA.CONFIRM_DELETE', {
+          name: row.criteriaName,
+        }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.criteriaService.deleteProvisioningcriteriaCriteriaId(row.criteriaId!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete provisioning criteria', err),
+        });
+      });
   }
 }

--- a/src/app/features/organization/account-number-formats/account-number-formats-list.component.spec.ts
+++ b/src/app/features/organization/account-number-formats/account-number-formats-list.component.spec.ts
@@ -18,83 +18,85 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ProvisioningCategoriesListComponent } from './provisioning-categories-list.component';
-import { ProvisioningCategoryService } from '../../../api';
+import { AccountNumberFormatsListComponent } from './account-number-formats-list.component';
+import { AccountNumberFormatService } from '../../../api';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
-import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { DialogService } from '../../../core/services/dialog.service';
+import { provideTranslateTesting } from '../../../testing/i18n-testing';
 
-describe('ProvisioningCategoriesListComponent', () => {
-  let component: ProvisioningCategoriesListComponent;
-  let fixture: ComponentFixture<ProvisioningCategoriesListComponent>;
-  let serviceSpy: jasmine.SpyObj<ProvisioningCategoryService>;
+describe('AccountNumberFormatsListComponent', () => {
+  let component: AccountNumberFormatsListComponent;
+  let fixture: ComponentFixture<AccountNumberFormatsListComponent>;
+  let serviceSpy: jasmine.SpyObj<AccountNumberFormatService>;
   let routerSpy: jasmine.SpyObj<Router>;
   let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
-    serviceSpy = jasmine.createSpyObj('ProvisioningCategoryService', [
-      'getProvisioningcategory',
-      'deleteProvisioningcategoryCategoryId',
+    serviceSpy = jasmine.createSpyObj('AccountNumberFormatService', [
+      'getAccountnumberformats',
+      'deleteAccountnumberformatsAccountNumberFormatId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
     dialogService.confirm.and.resolveTo(true);
-    serviceSpy.getProvisioningcategory.and.returnValue(
+    serviceSpy.getAccountnumberformats.and.returnValue(
       of([
-        { id: 1, categoryName: 'STANDARD', categoryDescription: 'Standard' },
-      ]) as unknown as ReturnType<ProvisioningCategoryService['getProvisioningcategory']>,
+        { id: 1, accountType: { id: 1, value: 'CLIENT' }, prefixType: { id: 2, value: 'OFFICE' } },
+      ]) as unknown as ReturnType<AccountNumberFormatService['getAccountnumberformats']>,
     );
 
     await TestBed.configureTestingModule({
-      imports: [ProvisioningCategoriesListComponent, TranslateModule.forRoot()],
+      imports: [AccountNumberFormatsListComponent],
       providers: [
-        { provide: ProvisioningCategoryService, useValue: serviceSpy },
+        { provide: AccountNumberFormatService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
         { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
+        ...provideTranslateTesting(),
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(ProvisioningCategoriesListComponent);
+    fixture = TestBed.createComponent(AccountNumberFormatsListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should load categories on init', () => {
+  it('should load formats on init', () => {
     expect(component).toBeTruthy();
-    expect(serviceSpy.getProvisioningcategory).toHaveBeenCalled();
-    expect(component.categories()).toHaveSize(1);
+    expect(serviceSpy.getAccountnumberformats).toHaveBeenCalled();
+    expect(component.formats()).toHaveSize(1);
   });
 
-  it('should navigate to edit with the category id', () => {
-    component.onEdit({ id: 3, categoryName: 'X' });
+  it('should navigate to edit with the format id', () => {
+    component.onEdit({ id: 3, accountType: { id: 1, value: 'LOAN' } });
     expect(routerSpy.navigate).toHaveBeenCalledWith([
-      '/accounting/provisioning-categories/edit',
+      '/organization/account-number-formats/edit',
       3,
     ]);
   });
 
-  it('should delete after confirmation and reload', async () => {
+  it('should delete after confirmation and drop the row', async () => {
     dialogService.confirm.and.resolveTo(true);
-    serviceSpy.deleteProvisioningcategoryCategoryId.and.returnValue(
+    serviceSpy.deleteAccountnumberformatsAccountNumberFormatId.and.returnValue(
       of({}) as unknown as ReturnType<
-        ProvisioningCategoryService['deleteProvisioningcategoryCategoryId']
+        AccountNumberFormatService['deleteAccountnumberformatsAccountNumberFormatId']
       >,
     );
 
-    component.onDelete({ id: 5, categoryName: 'Y' });
+    component.onDelete({ id: 1, accountType: { id: 1, value: 'CLIENT' } });
     await fixture.whenStable();
 
-    expect(serviceSpy.deleteProvisioningcategoryCategoryId).toHaveBeenCalledWith(5);
-    expect(serviceSpy.getProvisioningcategory).toHaveBeenCalledTimes(2);
+    expect(serviceSpy.deleteAccountnumberformatsAccountNumberFormatId).toHaveBeenCalledWith(1);
+    expect(component.formats()).toHaveSize(0);
   });
 
   it('should not delete when cancelled', async () => {
     dialogService.confirm.and.resolveTo(false);
-    component.onDelete({ id: 5, categoryName: 'Y' });
+    component.onDelete({ id: 1, accountType: { id: 1, value: 'CLIENT' } });
     await fixture.whenStable();
-    expect(serviceSpy.deleteProvisioningcategoryCategoryId).not.toHaveBeenCalled();
+    expect(serviceSpy.deleteAccountnumberformatsAccountNumberFormatId).not.toHaveBeenCalled();
+    expect(component.formats()).toHaveSize(1);
   });
 });

--- a/src/app/features/organization/account-number-formats/account-number-formats-list.component.ts
+++ b/src/app/features/organization/account-number-formats/account-number-formats-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { AccountNumberFormatService, GetAccountNumberFormatsIdResponse } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 @Component({
   selector: 'app-account-number-formats-list',
@@ -81,6 +82,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class AccountNumberFormatsListComponent implements OnInit {
   private readonly accountNumberFormatService = inject(AccountNumberFormatService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'accountType', label: 'ACCOUNT_NUMBER_FORMATS.ACCOUNT_TYPE', sortable: true },
@@ -115,19 +118,26 @@ export class AccountNumberFormatsListComponent implements OnInit {
 
   onDelete(row: GetAccountNumberFormatsIdResponse): void {
     if (!row.id) return;
-    const confirmed = window.confirm(
-      `Delete account number format for "${row.accountType?.value ?? row.id}"?`,
-    );
-    if (!confirmed) return;
-    this.accountNumberFormatService
-      .deleteAccountnumberformatsAccountNumberFormatId(row.id)
-      .subscribe({
-        next: () => {
-          this.formats.set(this.formats().filter((f) => f.id !== row.id));
-        },
-        error: (err: unknown) => {
-          console.error('Failed to delete account number format', err);
-        },
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('ACCOUNT_NUMBER_FORMATS.DELETE'),
+        message: this.translate.instant('ACCOUNT_NUMBER_FORMATS.CONFIRM_DELETE', {
+          name: row.accountType?.value ?? row.id,
+        }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.accountNumberFormatService
+          .deleteAccountnumberformatsAccountNumberFormatId(row.id!)
+          .subscribe({
+            next: () => {
+              this.formats.set(this.formats().filter((f) => f.id !== row.id));
+            },
+            error: (err: unknown) => {
+              console.error('Failed to delete account number format', err);
+            },
+          });
       });
   }
 }

--- a/src/app/features/working-capital/breach/wc-breach-list.component.spec.ts
+++ b/src/app/features/working-capital/breach/wc-breach-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('WcBreachListComponent', () => {
   let component: WcBreachListComponent;
   let fixture: ComponentFixture<WcBreachListComponent>;
   let serviceSpy: jasmine.SpyObj<WorkingCapitalBreachService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('WorkingCapitalBreachService', [
@@ -37,6 +39,8 @@ describe('WcBreachListComponent', () => {
       'deleteWorkingCapitalBreachBreachesBreachId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getWorkingCapitalBreachBreaches.and.returnValue(
       of([{ id: 1, name: 'Covenant A', breachAmount: 1000 }]) as unknown as ReturnType<
         WorkingCapitalBreachService['getWorkingCapitalBreachBreaches']
@@ -48,6 +52,7 @@ describe('WcBreachListComponent', () => {
       providers: [
         { provide: WorkingCapitalBreachService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -68,8 +73,8 @@ describe('WcBreachListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/working-capital/breach/edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteWorkingCapitalBreachBreachesBreachId.and.returnValue(
       of({}) as unknown as ReturnType<
         WorkingCapitalBreachService['deleteWorkingCapitalBreachBreachesBreachId']
@@ -77,14 +82,16 @@ describe('WcBreachListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteWorkingCapitalBreachBreachesBreachId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getWorkingCapitalBreachBreaches).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteWorkingCapitalBreachBreachesBreachId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/working-capital/breach/wc-breach-list.component.ts
+++ b/src/app/features/working-capital/breach/wc-breach-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { WorkingCapitalBreachService, WorkingCapitalBreachData } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists working-capital covenant breach definitions. Breaches are small master-data
@@ -81,6 +82,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class WcBreachListComponent implements OnInit {
   private readonly breachService = inject(WorkingCapitalBreachService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'WC_BREACH.NAME', sortable: true },
@@ -117,10 +120,19 @@ export class WcBreachListComponent implements OnInit {
   }
 
   onDelete(row: WorkingCapitalBreachData): void {
-    if (!row.id || !window.confirm('Delete this breach definition?')) return;
-    this.breachService.deleteWorkingCapitalBreachBreachesBreachId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete breach', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('WC_BREACH.DELETE'),
+        message: this.translate.instant('WC_BREACH.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.breachService.deleteWorkingCapitalBreachBreachesBreachId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete breach', err),
+        });
+      });
   }
 }

--- a/src/app/features/working-capital/loan-products/wc-loan-products-list.component.spec.ts
+++ b/src/app/features/working-capital/loan-products/wc-loan-products-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('WcLoanProductsListComponent', () => {
   let component: WcLoanProductsListComponent;
   let fixture: ComponentFixture<WcLoanProductsListComponent>;
   let serviceSpy: jasmine.SpyObj<WorkingCapitalLoanProductsService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('WorkingCapitalLoanProductsService', [
@@ -37,6 +39,8 @@ describe('WcLoanProductsListComponent', () => {
       'deleteWorkingCapitalLoanProductsProductId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getWorkingCapitalLoanProducts.and.returnValue(
       of([
         { id: 1, name: 'WC Product A', shortName: 'WCA', principal: 5000 },
@@ -50,6 +54,7 @@ describe('WcLoanProductsListComponent', () => {
       providers: [
         { provide: WorkingCapitalLoanProductsService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -70,8 +75,8 @@ describe('WcLoanProductsListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/working-capital/loan-products/edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteWorkingCapitalLoanProductsProductId.and.returnValue(
       of({}) as unknown as ReturnType<
         WorkingCapitalLoanProductsService['deleteWorkingCapitalLoanProductsProductId']
@@ -79,14 +84,16 @@ describe('WcLoanProductsListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteWorkingCapitalLoanProductsProductId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getWorkingCapitalLoanProducts).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteWorkingCapitalLoanProductsProductId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/working-capital/loan-products/wc-loan-products-list.component.ts
+++ b/src/app/features/working-capital/loan-products/wc-loan-products-list.component.ts
@@ -19,11 +19,12 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 import {
   WorkingCapitalLoanProductsService,
   GetWorkingCapitalLoanProductsResponse,
@@ -87,6 +88,8 @@ import {
 export class WcLoanProductsListComponent implements OnInit {
   private readonly productService = inject(WorkingCapitalLoanProductsService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'WC_LOAN_PRODUCTS.NAME', sortable: true },
@@ -122,10 +125,19 @@ export class WcLoanProductsListComponent implements OnInit {
   }
 
   onDelete(row: GetWorkingCapitalLoanProductsResponse): void {
-    if (!row.id || !window.confirm('Delete this working-capital loan product?')) return;
-    this.productService.deleteWorkingCapitalLoanProductsProductId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete loan product', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('WC_LOAN_PRODUCTS.DELETE'),
+        message: this.translate.instant('WC_LOAN_PRODUCTS.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.productService.deleteWorkingCapitalLoanProductsProductId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete loan product', err),
+        });
+      });
   }
 }

--- a/src/app/features/working-capital/near-breach/wc-near-breach-list.component.spec.ts
+++ b/src/app/features/working-capital/near-breach/wc-near-breach-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('WcNearBreachListComponent', () => {
   let component: WcNearBreachListComponent;
   let fixture: ComponentFixture<WcNearBreachListComponent>;
   let serviceSpy: jasmine.SpyObj<WorkingCapitalNearBreachService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('WorkingCapitalNearBreachService', [
@@ -37,6 +39,8 @@ describe('WcNearBreachListComponent', () => {
       'deleteWorkingCapitalNearBreachBreachId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getWorkingCapitalNearBreach.and.returnValue(
       of([{ id: 1, name: 'Warn A', threshold: 80 }]) as unknown as ReturnType<
         WorkingCapitalNearBreachService['getWorkingCapitalNearBreach']
@@ -48,6 +52,7 @@ describe('WcNearBreachListComponent', () => {
       providers: [
         { provide: WorkingCapitalNearBreachService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -68,8 +73,8 @@ describe('WcNearBreachListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/working-capital/near-breach/edit', 7]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteWorkingCapitalNearBreachBreachId.and.returnValue(
       of({}) as unknown as ReturnType<
         WorkingCapitalNearBreachService['deleteWorkingCapitalNearBreachBreachId']
@@ -77,8 +82,16 @@ describe('WcNearBreachListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteWorkingCapitalNearBreachBreachId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getWorkingCapitalNearBreach).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
+    component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
+    expect(serviceSpy.deleteWorkingCapitalNearBreachBreachId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/working-capital/near-breach/wc-near-breach-list.component.ts
+++ b/src/app/features/working-capital/near-breach/wc-near-breach-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { WorkingCapitalNearBreachService, WorkingCapitalNearBreachData } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists working-capital near-breach (early-warning) threshold definitions.
@@ -78,6 +79,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class WcNearBreachListComponent implements OnInit {
   private readonly service = inject(WorkingCapitalNearBreachService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'WC_NEAR_BREACH.NAME', sortable: true },
@@ -113,10 +116,19 @@ export class WcNearBreachListComponent implements OnInit {
   }
 
   onDelete(row: WorkingCapitalNearBreachData): void {
-    if (!row.id || !window.confirm('Delete this near-breach definition?')) return;
-    this.service.deleteWorkingCapitalNearBreachBreachId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete near-breach', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('WC_NEAR_BREACH.DELETE'),
+        message: this.translate.instant('WC_NEAR_BREACH.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.service.deleteWorkingCapitalNearBreachBreachId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete near-breach', err),
+        });
+      });
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1284,7 +1284,9 @@
     "PREFIX_TYPE": "Prefix Type",
     "SAVE": "Save",
     "CANCEL": "Cancel",
-    "DELETE_CONFIRM": "Are you sure you want to delete this format?"
+    "DELETE": "Delete",
+    "DELETE_CONFIRM": "Are you sure you want to delete this format?",
+    "CONFIRM_DELETE": "Delete the account number format for “{{name}}”? Already issued identifiers keep their current shape."
   },
   "ACCOUNTING": {
     "CREATE_GL_ACCOUNT": "Create GL Account",
@@ -1442,7 +1444,9 @@
     "FREQUENCY": "Frequency",
     "FREQUENCY_TYPE": "Frequency Type",
     "CREATE": "Create Breach Definition",
-    "EDIT": "Edit Breach Definition"
+    "EDIT": "Edit Breach Definition",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete breach definition “{{name}}”?"
   },
   "WC_NEAR_BREACH": {
     "NAME": "Name",
@@ -1450,7 +1454,9 @@
     "FREQUENCY": "Frequency",
     "FREQUENCY_TYPE": "Frequency Type",
     "CREATE": "Create Near-Breach Definition",
-    "EDIT": "Edit Near-Breach Definition"
+    "EDIT": "Edit Near-Breach Definition",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete near-breach definition “{{name}}”?"
   },
   "WC_LOAN_PRODUCTS": {
     "CREATE": "Create Loan Product",
@@ -1478,7 +1484,9 @@
     "FUND": "Fund",
     "START_DATE": "Start Date",
     "CLOSE_DATE": "Close Date",
-    "EXTERNAL_ID": "External ID"
+    "EXTERNAL_ID": "External ID",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete working-capital loan product “{{name}}”?"
   },
   "WC_LOANS": {
     "CREATE": "Create Working Capital Loan",
@@ -1799,14 +1807,18 @@
     "CREATE": "Create Provisioning Category",
     "EDIT": "Edit Provisioning Category",
     "NAME": "Category Name",
-    "DESCRIPTION": "Description"
+    "DESCRIPTION": "Description",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete provisioning category “{{name}}”?"
   },
   "PROVISIONING_CRITERIA": {
     "CREATE": "Create Provisioning Criteria",
     "EDIT": "Edit Provisioning Criteria",
     "NAME": "Criteria Name",
     "CREATED_BY": "Created By",
-    "DEFINITIONS_NOTE": "Per-category provisioning definitions and loan-product mappings are managed through the API and are preserved when editing the criteria name."
+    "DEFINITIONS_NOTE": "Per-category provisioning definitions and loan-product mappings are managed through the API and are preserved when editing the criteria name.",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete provisioning criteria “{{name}}”?"
   },
   "PROVISIONING_ENTRIES": {
     "CREATE": "Create Entry",


### PR DESCRIPTION
## What and why

Part of #232. Six remaining list screens still confirmed deletes with `window.confirm` — unstyled, English-only, and blocking. They now use `DialogService.confirm` like `codes-list`, with translated copy, `destructive: true`, and the delete skipped when the dialog resolves false.

Calendars and meetings are left for @AmandaKeay as agreed.

Confirm copy is factual (row name only). Provisioning messages do not claim unverified backend consequences; the account-number-format line notes that already issued identifiers keep their current shape.

## Verification

- `npm run lint`
- `npm run i18n:check`
- Prettier on the touched files
- `ng test` for the six list specs: 24/24 passing (including cancel does not call DELETE)
- UI exercised against TestBed mocks, not a live Fineract backend

## Screenshots

Not applicable — same list screens; only the confirm dialog implementation changed.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. (unit coverage of confirm/cancel; no e2e for these lists existed)
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.