### PR TITLE
fix(a11y): give every clients route its own title

### DIFF
--- a/src/app/features/clients/clients.routes.spec.ts
+++ b/src/app/features/clients/clients.routes.spec.ts
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { TitleStrategy, provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { CLIENTS_ROUTES } from './clients.routes';
+import { TranslatedTitleStrategy } from '../../core/router/translated-title.strategy';
+import { FakeI18nAdapter, provideFakeAdapters } from '../../testing/adapters';
+
+const APP_NAME_KEY = 'app.shortTitle';
+const APP_NAME = 'Fineract';
+const SECTION_KEY = 'nav.clients';
+const SECTION_NAME = 'Clients';
+
+/** Stands in for the lazily loaded page components, which this spec does not exercise. */
+@Component({ standalone: true, template: '' })
+class RouteStub {}
+
+/**
+ * A dotted key such as `CLIENTS.ADD_NOTE`, rather than a phrase.
+ *
+ * Checked segment by segment rather than with one pattern: a single regex for this shape
+ * needs a quantifier inside a quantifier, which `security/detect-unsafe-regex` flags, and
+ * a suppression would cost more to read than the loop does.
+ */
+function isTranslationKey(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+
+  const segments = value.split('.');
+  return (
+    segments.length > 1 && /^[A-Za-z]/.test(value) && segments.every((part) => /^\w+$/.test(part))
+  );
+}
+
+describe('CLIENTS_ROUTES', () => {
+  let i18n: FakeI18nAdapter;
+
+  beforeEach(() => {
+    // The guards are not under test here, and permissionGuard would reject every
+    // navigation without an authenticated user.
+    const routes = CLIENTS_ROUTES.map(({ path, title }) => ({
+      path,
+      title,
+      component: RouteStub,
+    }));
+
+    const adapters = provideFakeAdapters();
+    i18n = adapters.i18n;
+    i18n.catalogue.set(APP_NAME_KEY, APP_NAME);
+    i18n.catalogue.set(SECTION_KEY, SECTION_NAME);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...adapters.providers,
+        { provide: TitleStrategy, useClass: TranslatedTitleStrategy },
+        provideRouter([{ path: 'clients', title: SECTION_KEY, children: routes }]),
+      ],
+    });
+  });
+
+  /**
+   * The regression this file exists for. A route with no `title` still gets a tab, because
+   * Angular's `buildTitle` walks up to the section, so a missing title looks correct on
+   * screen and is only wrong in the one place nobody is looking. Every page under `clients`
+   * would silently read "Clients".
+   */
+  it('gives every route its own title', () => {
+    const untitled = CLIENTS_ROUTES.filter((route) => !route.title).map((route) => route.path);
+
+    expect(untitled).toEqual([]);
+  });
+
+  it('titles routes with translation keys rather than phrases', () => {
+    const notKeys = CLIENTS_ROUTES.filter((route) => !isTranslationKey(route.title)).map(
+      (route) => route.path,
+    );
+
+    expect(notKeys).toEqual([]);
+  });
+
+  /**
+   * The shapes the convention has to answer, and the reason `clients` was the file to settle
+   * it on: an empty path, a record-scoped page, and a two-level nested sub-resource. The last
+   * is the one that inherits from the section rather than its own parent if a title is missed.
+   */
+  const cases = [
+    { url: '/clients', key: SECTION_KEY, name: SECTION_NAME },
+    { url: '/clients/view/7', key: 'CLIENTS.DETAILS', name: 'Client Details' },
+    { url: '/clients/create', key: 'CLIENTS.CREATE_CLIENT', name: 'Create Client' },
+    {
+      url: '/clients/7/identifiers/edit/3',
+      key: 'CLIENTS.EDIT_IDENTIFIER',
+      name: 'Edit Identifier',
+    },
+    {
+      url: '/clients/7/collaterals/create',
+      key: 'CLIENT_COLLATERAL.CREATE',
+      name: 'Add Collateral',
+    },
+  ];
+
+  cases.forEach(({ url, key, name }) => {
+    it(`titles ${url} from its own route rather than the section`, async () => {
+      i18n.catalogue.set(key, name);
+      const harness = await RouterTestingHarness.create();
+
+      await harness.navigateByUrl(url);
+
+      expect(TestBed.inject(Title).getTitle()).toBe(`${name} · ${APP_NAME}`);
+    });
+  });
+});

--- a/src/app/features/clients/clients.routes.ts
+++ b/src/app/features/clients/clients.routes.ts
@@ -26,12 +26,14 @@ export const CLIENTS_ROUTES: Routes = [
     path: '',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CLIENT' },
+    title: 'nav.clients',
     loadComponent: () => import('./clients-list.component').then((m) => m.ClientsListComponent),
   },
   {
     path: 'search',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CLIENT' },
+    title: 'CLIENT_SEARCH_V2.TITLE',
     loadComponent: () =>
       import('./client-search-v2.component').then((m) => m.ClientSearchV2Component),
   },
@@ -39,24 +41,28 @@ export const CLIENTS_ROUTES: Routes = [
     path: 'create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CLIENT' },
+    title: 'CLIENTS.CREATE_CLIENT',
     loadComponent: () => import('./client-form.component').then((m) => m.ClientFormComponent),
   },
   {
     path: 'edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CLIENT' },
+    title: 'CLIENTS.EDIT_CLIENT',
     loadComponent: () => import('./client-form.component').then((m) => m.ClientFormComponent),
   },
   {
     path: 'view/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CLIENT' },
+    title: 'CLIENTS.DETAILS',
     loadComponent: () => import('./client-view.component').then((m) => m.ClientViewComponent),
   },
   {
     path: ':clientId/identifiers/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CLIENTIDENTIFIER' },
+    title: 'CLIENTS.ADD_IDENTIFIER',
     loadComponent: () =>
       import('./kyc/client-identifier-form.component').then((m) => m.ClientIdentifierFormComponent),
   },
@@ -64,6 +70,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/identifiers/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CLIENTIDENTIFIER' },
+    title: 'CLIENTS.EDIT_IDENTIFIER',
     loadComponent: () =>
       import('./kyc/client-identifier-form.component').then((m) => m.ClientIdentifierFormComponent),
   },
@@ -71,6 +78,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/addresses/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_ADDRESS' },
+    title: 'CLIENTS.ADD_ADDRESS',
     loadComponent: () =>
       import('./kyc/client-address-form.component').then((m) => m.ClientAddressFormComponent),
   },
@@ -78,6 +86,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/addresses/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_ADDRESS' },
+    title: 'CLIENTS.EDIT_ADDRESS',
     loadComponent: () =>
       import('./kyc/client-address-form.component').then((m) => m.ClientAddressFormComponent),
   },
@@ -85,6 +94,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/family-members/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_FAMILYMEMBERS' },
+    title: 'CLIENTS.ADD_FAMILY_MEMBER',
     loadComponent: () =>
       import('./kyc/client-family-member-form.component').then(
         (m) => m.ClientFamilyMemberFormComponent,
@@ -94,6 +104,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/family-members/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_FAMILYMEMBERS' },
+    title: 'CLIENTS.EDIT_FAMILY_MEMBER',
     loadComponent: () =>
       import('./kyc/client-family-member-form.component').then(
         (m) => m.ClientFamilyMemberFormComponent,
@@ -103,6 +114,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/notes/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CLIENTNOTE' },
+    title: 'CLIENTS.ADD_NOTE',
     loadComponent: () =>
       import('./kyc/client-note-form.component').then((m) => m.ClientNoteFormComponent),
   },
@@ -110,6 +122,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/notes/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CLIENTNOTE' },
+    title: 'CLIENTS.EDIT_NOTE',
     loadComponent: () =>
       import('./kyc/client-note-form.component').then((m) => m.ClientNoteFormComponent),
   },
@@ -117,6 +130,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/documents/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_DOCUMENT' },
+    title: 'CLIENTS.ADD_DOCUMENT',
     loadComponent: () =>
       import('./kyc/client-document-form.component').then((m) => m.ClientDocumentFormComponent),
   },
@@ -124,6 +138,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/documents/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_DOCUMENT' },
+    title: 'CLIENTS.EDIT_DOCUMENT',
     loadComponent: () =>
       import('./kyc/client-document-form.component').then((m) => m.ClientDocumentFormComponent),
   },
@@ -131,6 +146,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/charges',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CLIENTCHARGE' },
+    title: 'CLIENT_CHARGES.TITLE',
     loadComponent: () =>
       import('./charges/client-charges-list.component').then((m) => m.ClientChargesListComponent),
   },
@@ -138,11 +154,13 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/charges/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CLIENTCHARGE' },
+    title: 'CLIENT_CHARGES.CREATE',
     loadComponent: () =>
       import('./charges/client-charge-form.component').then((m) => m.ClientChargeFormComponent),
   },
   {
     path: ':clientId/collaterals',
+    title: 'CLIENT_COLLATERAL.TITLE',
     loadComponent: () =>
       import('./collateral/client-collateral-list.component').then(
         (m) => m.ClientCollateralListComponent,
@@ -152,6 +170,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/collaterals/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CLIENT_COLLATERAL_PRODUCT' },
+    title: 'CLIENT_COLLATERAL.CREATE',
     loadComponent: () =>
       import('./collateral/client-collateral-form.component').then(
         (m) => m.ClientCollateralFormComponent,
@@ -161,6 +180,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/collaterals/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CLIENT_COLLATERAL_PRODUCT' },
+    title: 'CLIENT_COLLATERAL.EDIT',
     loadComponent: () =>
       import('./collateral/client-collateral-form.component').then(
         (m) => m.ClientCollateralFormComponent,
@@ -170,6 +190,7 @@ export const CLIENTS_ROUTES: Routes = [
     path: ':clientId/transactions',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CLIENT' },
+    title: 'CLIENT_TRANSACTIONS.TITLE',
     loadComponent: () =>
       import('./transactions/client-transactions-list.component').then(
         (m) => m.ClientTransactionsListComponent,


### PR DESCRIPTION
## What and why

The 21 routes in `clients.routes.ts` all inherited their tab from the section above them, so every page under `clients` read `Clients · Fineract`. Measured in a browser against this branch's own parent, all 21 of them:

```
/clients                          Clients · Fineract
/clients/create                   Clients · Fineract
/clients/view/1                   Clients · Fineract
/clients/1/identifiers/edit/1     Clients · Fineract
/clients/1/collaterals/create     Clients · Fineract
...21 of 21 identical
```

This is the first of the 21 files in #355. It is deliberately one feature area, so the naming convention can be settled here and reviewed once rather than 20 more times. `clients` was the right file to settle it on because it contains every shape the convention has to answer: an empty path, a record-scoped page, a page whose heading is a record's name, and two-level nested sub-resources.

Refs #355

## The convention

In the order the rules apply:

1. **The section root takes the same `nav.*` key its section entry uses in `app.routes.ts`**, restated rather than inherited, so the file reads on its own. `''` gets `nav.clients`, exactly as `groups.routes.ts` restates `nav.groups`.
2. **Every other route takes the key its page already uses for its own visible heading**, so the tab and the page agree.
3. **Where the heading is a record's name and cannot be a static key, the route takes a generic key for the screen type.** Only `view/:id` needs this. It uses `CLIENTS.DETAILS`, matching `GROUPS.GROUP_DETAILS`.

**No new translation keys.** All 21 already existed, because rule 2 selects a key the page had to have in order to render its own heading. That is a property of the convention rather than luck about this file, and it is the main argument for it: a correct title costs nothing to translate and cannot drift from the heading it was taken from.

| Route | Key | Tab |
|---|---|---|
| `''` | `nav.clients` | Clients |
| `search` | `CLIENT_SEARCH_V2.TITLE` | Advanced Client Search |
| `create` | `CLIENTS.CREATE_CLIENT` | Create Client |
| `edit/:id` | `CLIENTS.EDIT_CLIENT` | Edit Client |
| `view/:id` | `CLIENTS.DETAILS` | Client Details |
| `:clientId/identifiers/create` | `CLIENTS.ADD_IDENTIFIER` | Add Identifier |
| `:clientId/identifiers/edit/:id` | `CLIENTS.EDIT_IDENTIFIER` | Edit Identifier |
| `:clientId/addresses/create` | `CLIENTS.ADD_ADDRESS` | Add Address |
| `:clientId/addresses/edit/:id` | `CLIENTS.EDIT_ADDRESS` | Edit Address |
| `:clientId/family-members/create` | `CLIENTS.ADD_FAMILY_MEMBER` | Add Family Member |
| `:clientId/family-members/edit/:id` | `CLIENTS.EDIT_FAMILY_MEMBER` | Edit Family Member |
| `:clientId/notes/create` | `CLIENTS.ADD_NOTE` | Add Note |
| `:clientId/notes/edit/:id` | `CLIENTS.EDIT_NOTE` | Edit Note |
| `:clientId/documents/create` | `CLIENTS.ADD_DOCUMENT` | Add Document |
| `:clientId/documents/edit/:id` | `CLIENTS.EDIT_DOCUMENT` | Edit Document |
| `:clientId/charges` | `CLIENT_CHARGES.TITLE` | Client Charges |
| `:clientId/charges/create` | `CLIENT_CHARGES.CREATE` | Add Charge |
| `:clientId/collaterals` | `CLIENT_COLLATERAL.TITLE` | Client Collateral |
| `:clientId/collaterals/create` | `CLIENT_COLLATERAL.CREATE` | Add Collateral |
| `:clientId/collaterals/edit/:id` | `CLIENT_COLLATERAL.EDIT` | Edit Collateral |
| `:clientId/transactions` | `CLIENT_TRANSACTIONS.TITLE` | Client Transactions |

## Verification

**In a browser, against the real `en.json`.** A unit spec with a fake catalogue can only prove the wiring, not that the tabs read correctly, so both states were measured with Playwright against the `mocked` project. All 21 routes, after:

```
/clients                          Clients · Fineract
/clients/search                   Advanced Client Search · Fineract
/clients/create                   Create Client · Fineract
/clients/edit/1                   Edit Client · Fineract
/clients/view/1                   Client Details · Fineract
/clients/1/identifiers/create     Add Identifier · Fineract
/clients/1/identifiers/edit/1     Edit Identifier · Fineract
/clients/1/addresses/create       Add Address · Fineract
/clients/1/addresses/edit/1       Edit Address · Fineract
/clients/1/family-members/create  Add Family Member · Fineract
/clients/1/family-members/edit/1  Edit Family Member · Fineract
/clients/1/notes/create           Add Note · Fineract
/clients/1/notes/edit/1           Edit Note · Fineract
/clients/1/documents/create       Add Document · Fineract
/clients/1/documents/edit/1       Edit Document · Fineract
/clients/1/charges                Client Charges · Fineract
/clients/1/charges/create         Add Charge · Fineract
/clients/1/collaterals            Client Collateral · Fineract
/clients/1/collaterals/create     Add Collateral · Fineract
/clients/1/collaterals/edit/1     Edit Collateral · Fineract
/clients/1/transactions           Client Transactions · Fineract
```

The before block at the top of this description was produced by the same run with only `clients.routes.ts` reverted to this branch's parent, so the two are directly comparable. That harness was throwaway and is not in the diff; say the word if you would rather it shipped as a permanent e2e spec.

One thing worth recording, since it would have produced a confidently wrong result. Reading `document.title` straight after `page.goto` proves nothing here, and neither does waiting for it to differ from `index.html`'s: the strategy writes the app name first and the translations arrive after, so an early read catches the raw `app.shortTitle` key or a bare `Fineract`. The settled state for a titled route is `Page · Fineract`, so the check waits for the separator.

| | |
|---|---|
| `npx ng test fineract-backoffice-ui` | **1100 of 1100 SUCCESS**, real headless Chromium |
| `clients.routes.spec.ts` alone | 7 of 7 SUCCESS |
| `npm run lint` | exit 0, no new warnings |
| `npm run lint:prune` | exit 0 |
| `npm run format:check` | exit 0 |
| `node scripts/check-translations.mjs` | exit 0, 1532 keys checked |

**The guard was tested in three directions**, since a spec over data that only ever passes proves nothing:

| Change | Result |
|---|---|
| delete the title on `:clientId/identifiers/edit/:id` | 3 failed, naming the route |
| replace a key with the phrase `'Client Details'` | 1 failed, the key-shape test |
| point `collaterals/create` at `CLIENT_COLLATERAL.EDIT` | 1 failed, `CLIENT_COLLATERAL.EDIT · Fineract` where `Add Collateral · Fineract` was expected |
| restore | 7 of 7 SUCCESS |

Not exercised against a real Fineract. This adds a `title` to route definitions and changes no request, no behaviour and nothing rendered in the page body.

## Screenshots

Not applicable. The change is in the browser tab, and the measured titles above are the evidence a screenshot of the page body would not be.

## Two things noticed while in the file, neither changed here

**`:clientId/collaterals` has no guard.** It is the only route in the file with no `canActivate` and no `data.permissions`, where its two siblings `collaterals/create` and `collaterals/edit/:id` both carry `authGuard, permissionGuard`. That looks like an oversight rather than a decision, but it is a permissions question and not a titles one, so I have left it alone. Happy to open a separate issue, or a one-line PR if you already know what it should declare.

**The clients list heading and its nav entry disagree.** `clients-list.component.ts` renders `MODULES.CLIENTS_CONTRACTS` ("Clients & Contracts") while the nav item and now the tab say "Clients". I followed rule 1 rather than rule 2 there, on the grounds that a tab which does not match the nav item that opened it is worse for findability than one which does not match the heading. Worth flagging because it is the one place in the file where the two rules disagree.

## The question this PR is really asking

If the convention above is right, the remaining 20 files are mechanical and I will work through them in the grouping you prefer. If any of the three rules is wrong, this is the cheapest possible place to say so.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. No new component or service code.
- [x] User-facing strings use translation keys. Every title is a key, and no new keys were needed.
- [x] I added or updated tests appropriate to this change.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. No workflow changes. The browser measurement above was run against the `mocked` project; a real backend would exercise nothing this change touches.
- [x] Commits are signed.
