### PR TITLE
fix(a11y): give every products route its own title

### DIFF
--- a/src/app/features/products/products.routes.spec.ts
+++ b/src/app/features/products/products.routes.spec.ts
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { TitleStrategy, provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { PRODUCTS_ROUTES } from './products.routes';
+import { TranslatedTitleStrategy } from '../../core/router/translated-title.strategy';
+import { FakeI18nAdapter, provideFakeAdapters } from '../../testing/adapters';
+
+const APP_NAME_KEY = 'app.shortTitle';
+const APP_NAME = 'Fineract';
+const SECTION_KEY = 'nav.products';
+const SECTION_NAME = 'Products';
+
+/** Stands in for the lazily loaded page components, which this spec does not exercise. */
+@Component({ standalone: true, template: '' })
+class RouteStub {}
+
+/**
+ * A dotted key such as `PRODUCTS.CREATE_LOAN_PRODUCT`, rather than a phrase.
+ *
+ * Checked segment by segment rather than with one pattern: a single regex for this shape
+ * needs a quantifier inside a quantifier, which `security/detect-unsafe-regex` flags.
+ */
+function isTranslationKey(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+
+  const segments = value.split('.');
+  return (
+    segments.length > 1 && /^[A-Za-z]/.test(value) && segments.every((part) => /^\w+$/.test(part))
+  );
+}
+
+describe('PRODUCTS_ROUTES', () => {
+  let i18n: FakeI18nAdapter;
+
+  beforeEach(() => {
+    // The guards are not under test here, and permissionGuard would reject every
+    // navigation without an authenticated user.
+    const routes = PRODUCTS_ROUTES.map(({ path, title }) => ({
+      path,
+      title,
+      component: RouteStub,
+    }));
+
+    const adapters = provideFakeAdapters();
+    i18n = adapters.i18n;
+    i18n.catalogue.set(APP_NAME_KEY, APP_NAME);
+    i18n.catalogue.set(SECTION_KEY, SECTION_NAME);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...adapters.providers,
+        { provide: TitleStrategy, useClass: TranslatedTitleStrategy },
+        provideRouter([{ path: 'products', title: SECTION_KEY, children: routes }]),
+      ],
+    });
+  });
+
+  /**
+   * The regression this file exists for. A route with no `title` still gets a tab, because
+   * Angular's `buildTitle` walks up to the section, so a missing title looks correct on
+   * screen and is only wrong in the one place nobody is looking.
+   */
+  it('gives every route its own title', () => {
+    const untitled = PRODUCTS_ROUTES.filter((route) => !route.title).map((route) => route.path);
+
+    expect(untitled).toEqual([]);
+  });
+
+  it('titles routes with translation keys rather than phrases', () => {
+    const notKeys = PRODUCTS_ROUTES.filter((route) => !isTranslationKey(route.title)).map(
+      (route) => route.path,
+    );
+
+    expect(notKeys).toEqual([]);
+  });
+
+  /**
+   * The test this file exists for that `clients` did not need, and the one that encodes what
+   * 65 routes taught us. Titling is only worth doing if the tabs come out distinguishable,
+   * and the tempting shortcut here is to follow each page's own heading key. Five of these
+   * routes are record views whose heading is a `COMMON.DETAILS` or `COMMON.OVERVIEW`, so
+   * following the heading would give four different screens the tab "Details" and reproduce
+   * the exact problem the issue is about, one level down.
+   */
+  it('gives no two routes the same title', () => {
+    const seen = new Map<string, string[]>();
+    for (const route of PRODUCTS_ROUTES) {
+      const key = String(route.title);
+      seen.set(key, [...(seen.get(key) ?? []), String(route.path)]);
+    }
+
+    const collisions = [...seen.entries()].filter(([, paths]) => paths.length > 1);
+
+    expect(collisions).toEqual([]);
+  });
+
+  /**
+   * The shapes `products` adds beyond `clients`: a `:command` segment whose page heading is
+   * chosen at runtime, an account-action route that is entirely command-driven, and the
+   * deeper entity-scoped sub-resources. A static `title` cannot branch on a parameter, so
+   * each of these takes a generic key naming the screen type.
+   */
+  const cases = [
+    { url: '/products', key: SECTION_KEY, name: SECTION_NAME },
+    { url: '/products/loan', key: 'nav.loanProducts', name: 'Loan Products' },
+    { url: '/products/loan/view/7', key: 'nav.loanProductDetails', name: 'Loan Product Details' },
+    {
+      url: '/products/savings-accounts/view/7',
+      key: 'SAVINGS.ACCOUNT_DETAILS',
+      name: 'Savings Account Details',
+    },
+    {
+      url: '/products/savings-accounts/7/transactions/deposit',
+      key: 'SAVINGS.TRANSACTION',
+      name: 'Savings Transaction',
+    },
+    {
+      url: '/products/savings/7/action/approve',
+      key: 'ACTIONS.ACCOUNT_ACTION',
+      name: 'Account Action',
+    },
+    {
+      url: '/products/shares/7/dividends/create',
+      key: 'SHARE_DIVIDENDS.CREATE',
+      name: 'Declare Dividend',
+    },
+    {
+      url: '/products/interest-rate-charts/7/slabs',
+      key: 'INTEREST_RATE_CHARTS.SLABS',
+      name: 'Slabs',
+    },
+  ];
+
+  cases.forEach(({ url, key, name }) => {
+    it(`titles ${url} from its own route rather than the section`, async () => {
+      i18n.catalogue.set(key, name);
+      const harness = await RouterTestingHarness.create();
+
+      await harness.navigateByUrl(url);
+
+      expect(TestBed.inject(Title).getTitle()).toBe(`${name} · ${APP_NAME}`);
+    });
+  });
+});

--- a/src/app/features/products/products.routes.ts
+++ b/src/app/features/products/products.routes.ts
@@ -26,6 +26,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_LOANPRODUCT' },
+    title: 'nav.loanProducts',
     loadComponent: () =>
       import('./loan-products-list.component').then((m) => m.LoanProductsListComponent),
   },
@@ -33,6 +34,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_LOANPRODUCT' },
+    title: 'PRODUCTS.CREATE_LOAN_PRODUCT',
     loadComponent: () =>
       import('./loan-product-form.component').then((m) => m.LoanProductFormComponent),
   },
@@ -40,6 +42,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_LOANPRODUCT' },
+    title: 'PRODUCTS.EDIT_LOAN_PRODUCT',
     loadComponent: () =>
       import('./loan-product-form.component').then((m) => m.LoanProductFormComponent),
   },
@@ -47,6 +50,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan/view/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_LOANPRODUCT' },
+    title: 'nav.loanProductDetails',
     loadComponent: () =>
       import('./loan-product-view.component').then((m) => m.LoanProductViewComponent),
   },
@@ -54,6 +58,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SAVINGSPRODUCT' },
+    title: 'nav.savingsProducts',
     loadComponent: () =>
       import('./savings-products-list.component').then((m) => m.SavingsProductsListComponent),
   },
@@ -61,6 +66,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_SAVINGSPRODUCT' },
+    title: 'PRODUCTS.CREATE_SAVINGS_PRODUCT',
     loadComponent: () =>
       import('./savings-product-form.component').then((m) => m.SavingsProductFormComponent),
   },
@@ -68,6 +74,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_SAVINGSPRODUCT' },
+    title: 'PRODUCTS.EDIT_SAVINGS_PRODUCT',
     loadComponent: () =>
       import('./savings-product-form.component').then((m) => m.SavingsProductFormComponent),
   },
@@ -75,6 +82,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_FIXEDDEPOSITPRODUCT' },
+    title: 'nav.fixedDepositProducts',
     loadComponent: () =>
       import('./fixed-deposits/fixed-deposit-products-list.component').then(
         (m) => m.FixedDepositProductsListComponent,
@@ -84,6 +92,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_FIXEDDEPOSITPRODUCT' },
+    title: 'PRODUCTS.CREATE_FIXED_DEPOSIT_PRODUCT',
     loadComponent: () =>
       import('./fixed-deposits/fixed-deposit-product-form.component').then(
         (m) => m.FixedDepositProductFormComponent,
@@ -93,6 +102,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_FIXEDDEPOSITPRODUCT' },
+    title: 'PRODUCTS.EDIT_FIXED_DEPOSIT_PRODUCT',
     loadComponent: () =>
       import('./fixed-deposits/fixed-deposit-product-form.component').then(
         (m) => m.FixedDepositProductFormComponent,
@@ -102,6 +112,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_RECURRINGDEPOSITPRODUCT' },
+    title: 'nav.recurringDepositProducts',
     loadComponent: () =>
       import('./recurring-deposits/recurring-deposit-products-list.component').then(
         (m) => m.RecurringDepositProductsListComponent,
@@ -111,6 +122,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_RECURRINGDEPOSITPRODUCT' },
+    title: 'PRODUCTS.CREATE_RECURRING_DEPOSIT_PRODUCT',
     loadComponent: () =>
       import('./recurring-deposits/recurring-deposit-product-form.component').then(
         (m) => m.RecurringDepositProductFormComponent,
@@ -120,6 +132,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_RECURRINGDEPOSITPRODUCT' },
+    title: 'PRODUCTS.EDIT_RECURRING_DEPOSIT_PRODUCT',
     loadComponent: () =>
       import('./recurring-deposits/recurring-deposit-product-form.component').then(
         (m) => m.RecurringDepositProductFormComponent,
@@ -127,6 +140,7 @@ export const PRODUCTS_ROUTES: Routes = [
   },
   {
     path: 'share',
+    title: 'nav.shareProducts',
     loadComponent: () =>
       import('./shares/share-products-list.component').then((m) => m.ShareProductsListComponent),
   },
@@ -134,6 +148,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'share/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_SHAREPRODUCT' },
+    title: 'PRODUCTS.CREATE_SHARE_PRODUCT',
     loadComponent: () =>
       import('./shares/share-product-form.component').then((m) => m.ShareProductFormComponent),
   },
@@ -141,6 +156,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'share/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_SHAREPRODUCT' },
+    title: 'PRODUCTS.EDIT_SHARE_PRODUCT',
     loadComponent: () =>
       import('./shares/share-product-form.component').then((m) => m.ShareProductFormComponent),
   },
@@ -148,6 +164,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'tax-components',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_TAXCOMPONENT' },
+    title: 'nav.taxComponents',
     loadComponent: () =>
       import('./tax-components/tax-components-list.component').then(
         (m) => m.TaxComponentsListComponent,
@@ -157,6 +174,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'tax-components/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_TAXCOMPONENT' },
+    title: 'TAX_COMPONENTS.CREATE',
     loadComponent: () =>
       import('./tax-components/tax-component-form.component').then(
         (m) => m.TaxComponentFormComponent,
@@ -166,6 +184,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'tax-components/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_TAXCOMPONENT' },
+    title: 'TAX_COMPONENTS.EDIT',
     loadComponent: () =>
       import('./tax-components/tax-component-form.component').then(
         (m) => m.TaxComponentFormComponent,
@@ -175,6 +194,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'tax-groups',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_TAXGROUP' },
+    title: 'nav.taxGroups',
     loadComponent: () =>
       import('./tax-groups/tax-groups-list.component').then((m) => m.TaxGroupsListComponent),
   },
@@ -182,6 +202,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'tax-groups/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_TAXGROUP' },
+    title: 'TAX_GROUPS.CREATE',
     loadComponent: () =>
       import('./tax-groups/tax-group-form.component').then((m) => m.TaxGroupFormComponent),
   },
@@ -189,6 +210,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'tax-groups/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_TAXGROUP' },
+    title: 'TAX_GROUPS.EDIT',
     loadComponent: () =>
       import('./tax-groups/tax-group-form.component').then((m) => m.TaxGroupFormComponent),
   },
@@ -196,6 +218,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'floating-rates',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_FLOATINGRATE' },
+    title: 'nav.floatingRates',
     loadComponent: () =>
       import('./floating-rates/floating-rates-list.component').then(
         (m) => m.FloatingRatesListComponent,
@@ -205,6 +228,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'floating-rates/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_FLOATINGRATE' },
+    title: 'FLOATING_RATES.CREATE',
     loadComponent: () =>
       import('./floating-rates/floating-rate-form.component').then(
         (m) => m.FloatingRateFormComponent,
@@ -214,6 +238,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'floating-rates/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_FLOATINGRATE' },
+    title: 'FLOATING_RATES.EDIT',
     loadComponent: () =>
       import('./floating-rates/floating-rate-form.component').then(
         (m) => m.FloatingRateFormComponent,
@@ -223,6 +248,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SAVINGSACCOUNT' },
+    title: 'nav.savingsAccounts',
     loadComponent: () =>
       import('./savings-accounts-list.component').then((m) => m.SavingsAccountsListComponent),
   },
@@ -230,6 +256,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_SAVINGSACCOUNT' },
+    title: 'SAVINGS.CREATE_ACCOUNT',
     loadComponent: () =>
       import('./savings-account-form.component').then((m) => m.SavingsAccountFormComponent),
   },
@@ -237,6 +264,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_SAVINGSACCOUNT' },
+    title: 'SAVINGS.EDIT_ACCOUNT',
     loadComponent: () =>
       import('./savings-account-form.component').then((m) => m.SavingsAccountFormComponent),
   },
@@ -244,6 +272,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts/view/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SAVINGSACCOUNT' },
+    title: 'SAVINGS.ACCOUNT_DETAILS',
     loadComponent: () =>
       import('./savings-account-view.component').then((m) => m.SavingsAccountViewComponent),
   },
@@ -251,6 +280,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts/:accountId/transactions/:command',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_SAVINGSACCOUNT' },
+    title: 'SAVINGS.TRANSACTION',
     loadComponent: () =>
       import('./savings-account-transaction-form.component').then(
         (m) => m.SavingsAccountTransactionFormComponent,
@@ -260,6 +290,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed-deposits',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_FIXEDDEPOSITACCOUNT' },
+    title: 'nav.fixedDeposits',
     loadComponent: () =>
       import('./fixed-deposits/fixed-deposits-list.component').then(
         (m) => m.FixedDepositAccountsListComponent,
@@ -269,6 +300,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed-deposits/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_FIXEDDEPOSITACCOUNT' },
+    title: 'FIXED_DEPOSITS.CREATE',
     loadComponent: () =>
       import('./fixed-deposits/fixed-deposit-form.component').then(
         (m) => m.FixedDepositAccountFormComponent,
@@ -278,6 +310,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed-deposits/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_FIXEDDEPOSITACCOUNT' },
+    title: 'FIXED_DEPOSITS.EDIT',
     loadComponent: () =>
       import('./fixed-deposits/fixed-deposit-form.component').then(
         (m) => m.FixedDepositAccountFormComponent,
@@ -287,6 +320,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed-deposits/view/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_FIXEDDEPOSITACCOUNT' },
+    title: 'FIXED_DEPOSITS.ACCOUNT_DETAILS',
     loadComponent: () =>
       import('./deposit-account-view.component').then((m) => m.DepositAccountViewComponent),
   },
@@ -294,6 +328,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring-deposits',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_RECURRINGDEPOSITACCOUNT' },
+    title: 'nav.recurringDeposits',
     loadComponent: () =>
       import('./recurring-deposits/recurring-deposits-list.component').then(
         (m) => m.RecurringDepositsListComponent,
@@ -303,6 +338,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring-deposits/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_RECURRINGDEPOSITACCOUNT' },
+    title: 'RECURRING_DEPOSITS.CREATE',
     loadComponent: () =>
       import('./recurring-deposits/recurring-deposit-form.component').then(
         (m) => m.RecurringDepositAccountFormComponent,
@@ -312,6 +348,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring-deposits/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_RECURRINGDEPOSITACCOUNT' },
+    title: 'RECURRING_DEPOSITS.EDIT',
     loadComponent: () =>
       import('./recurring-deposits/recurring-deposit-form.component').then(
         (m) => m.RecurringDepositAccountFormComponent,
@@ -321,11 +358,13 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring-deposits/view/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_RECURRINGDEPOSITACCOUNT' },
+    title: 'RECURRING_DEPOSITS.ACCOUNT_DETAILS',
     loadComponent: () =>
       import('./deposit-account-view.component').then((m) => m.DepositAccountViewComponent),
   },
   {
     path: 'shares',
+    title: 'nav.shares',
     loadComponent: () =>
       import('./shares/share-accounts-list.component').then((m) => m.ShareAccountsListComponent),
   },
@@ -333,11 +372,13 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'shares/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_SHAREACCOUNT' },
+    title: 'SHARE_ACCOUNTS.CREATE',
     loadComponent: () =>
       import('./shares/share-account-form.component').then((m) => m.ShareAccountFormComponent),
   },
   {
     path: 'shares/view/:id',
+    title: 'SHARE_ACCOUNTS.ACCOUNT_DETAILS',
     loadComponent: () =>
       import('./shares/share-account-view.component').then((m) => m.ShareAccountViewComponent),
   },
@@ -345,11 +386,13 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'shares/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_SHAREACCOUNT' },
+    title: 'SHARE_ACCOUNTS.EDIT',
     loadComponent: () =>
       import('./shares/share-account-form.component').then((m) => m.ShareAccountFormComponent),
   },
   {
     path: ':accountType/:accountId/action/:command',
+    title: 'ACTIONS.ACCOUNT_ACTION',
     loadComponent: () =>
       import('./account-action-form.component').then((m) => m.AccountActionFormComponent),
   },
@@ -357,22 +400,26 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'rates',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_RATE' },
+    title: 'nav.rates',
     loadComponent: () => import('./rates/rates-list.component').then((m) => m.RatesListComponent),
   },
   {
     path: 'rates/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_RATE' },
+    title: 'RATES.CREATE',
     loadComponent: () => import('./rates/rate-form.component').then((m) => m.RateFormComponent),
   },
   {
     path: 'rates/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_RATE' },
+    title: 'RATES.EDIT',
     loadComponent: () => import('./rates/rate-form.component').then((m) => m.RateFormComponent),
   },
   {
     path: 'interest-rate-charts',
+    title: 'nav.interestRateCharts',
     loadComponent: () =>
       import('./interest-rate-charts/interest-rate-charts-list.component').then(
         (m) => m.InterestRateChartsListComponent,
@@ -382,6 +429,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'interest-rate-charts/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_INTERESTRATECHART' },
+    title: 'INTEREST_RATE_CHARTS.CREATE',
     loadComponent: () =>
       import('./interest-rate-charts/interest-rate-chart-form.component').then(
         (m) => m.InterestRateChartFormComponent,
@@ -391,6 +439,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'interest-rate-charts/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_INTERESTRATECHART' },
+    title: 'INTEREST_RATE_CHARTS.EDIT',
     loadComponent: () =>
       import('./interest-rate-charts/interest-rate-chart-form.component').then(
         (m) => m.InterestRateChartFormComponent,
@@ -400,6 +449,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'interest-rate-charts/:chartId/slabs',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CHARTSLAB' },
+    title: 'INTEREST_RATE_CHARTS.SLABS',
     loadComponent: () =>
       import('./interest-rate-charts/interest-rate-chart-slabs.component').then(
         (m) => m.InterestRateChartSlabsComponent,
@@ -409,6 +459,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan/:productId/product-mix',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_PRODUCTMIX' },
+    title: 'PRODUCT_MIX.TITLE',
     loadComponent: () =>
       import('./product-mix/product-mix.component').then((m) => m.ProductMixComponent),
   },
@@ -416,6 +467,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts/:savingsAccountId/charges',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SAVINGSACCOUNT' },
+    title: 'SAVINGS_CHARGES.TITLE',
     loadComponent: () =>
       import('./savings-charges/savings-charges-list.component').then(
         (m) => m.SavingsChargesListComponent,
@@ -425,6 +477,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts/:savingsAccountId/charges/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_SAVINGSACCOUNT' },
+    title: 'SAVINGS_CHARGES.CREATE',
     loadComponent: () =>
       import('./savings-charges/savings-charge-form.component').then(
         (m) => m.SavingsChargeFormComponent,
@@ -434,6 +487,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'shares/:productId/dividends',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_DIVIDEND_SHAREPRODUCT' },
+    title: 'SHARE_DIVIDENDS.TITLE',
     loadComponent: () =>
       import('./share-dividends/share-dividends-list.component').then(
         (m) => m.ShareDividendsListComponent,
@@ -443,6 +497,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'shares/:productId/dividends/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_DIVIDEND_SHAREPRODUCT' },
+    title: 'SHARE_DIVIDENDS.CREATE',
     loadComponent: () =>
       import('./share-dividends/share-dividend-form.component').then(
         (m) => m.ShareDividendFormComponent,
@@ -452,6 +507,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed-deposits/:accountId/transactions',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_FIXEDDEPOSITACCOUNT' },
+    title: 'FIXED_DEPOSIT_TRANSACTIONS.TITLE',
     loadComponent: () =>
       import('./fixed-deposit-transactions/fixed-deposit-transactions-list.component').then(
         (m) => m.FixedDepositTransactionsListComponent,
@@ -463,6 +519,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'fixed-deposits/:accountId/transactions/deposit',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_FIXEDDEPOSITACCOUNT' },
+    title: 'FIXED_DEPOSIT_TRANSACTIONS.DEPOSIT',
     loadComponent: () =>
       import('./fixed-deposit-transactions/fixed-deposit-transaction-form.component').then(
         (m) => m.FixedDepositTransactionFormComponent,
@@ -472,6 +529,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'recurring-deposits/:accountId/transactions/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_RECURRINGDEPOSITACCOUNT' },
+    title: 'RECURRING_DEPOSIT_TRANSACTIONS.CREATE',
     loadComponent: () =>
       import('./recurring-deposit-transactions/recurring-deposit-transaction-form.component').then(
         (m) => m.RecurringDepositTransactionFormComponent,
@@ -481,6 +539,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'savings-accounts/:savingsId/on-hold-transactions',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SAVINGSACCOUNT' },
+    title: 'ON_HOLD_TRANSACTIONS.TITLE',
     loadComponent: () =>
       import('./on-hold-transactions/on-hold-transactions-list.component').then(
         (m) => m.OnHoldTransactionsListComponent,
@@ -490,6 +549,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan-originators',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_LOAN_ORIGINATOR' },
+    title: 'nav.loanOriginators',
     loadComponent: () =>
       import('./loan-originators/loan-originators-list.component').then(
         (m) => m.LoanOriginatorsListComponent,
@@ -499,6 +559,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan-originators/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_LOAN_ORIGINATOR' },
+    title: 'LOAN_ORIGINATORS.CREATE',
     loadComponent: () =>
       import('./loan-originators/loan-originator-form.component').then(
         (m) => m.LoanOriginatorFormComponent,
@@ -508,6 +569,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'loan-originators/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_LOAN_ORIGINATOR' },
+    title: 'LOAN_ORIGINATORS.EDIT',
     loadComponent: () =>
       import('./loan-originators/loan-originator-form.component').then(
         (m) => m.LoanOriginatorFormComponent,
@@ -515,6 +577,7 @@ export const PRODUCTS_ROUTES: Routes = [
   },
   {
     path: 'collateral-management',
+    title: 'nav.collateralManagement',
     loadComponent: () =>
       import('./collateral-management/collateral-management-list.component').then(
         (m) => m.CollateralManagementListComponent,
@@ -524,6 +587,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'collateral-management/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_COLLATERAL_PRODUCT' },
+    title: 'COLLATERAL_MANAGEMENT.CREATE',
     loadComponent: () =>
       import('./collateral-management/collateral-management-form.component').then(
         (m) => m.CollateralManagementFormComponent,
@@ -533,6 +597,7 @@ export const PRODUCTS_ROUTES: Routes = [
     path: 'collateral-management/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_COLLATERAL_PRODUCT' },
+    title: 'COLLATERAL_MANAGEMENT.EDIT',
     loadComponent: () =>
       import('./collateral-management/collateral-management-form.component').then(
         (m) => m.CollateralManagementFormComponent,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -331,7 +331,8 @@
     "WITHDRAWAL_DATE": "Withdrawal Date",
     "WITHDRAWAL_REASON": "Withdrawal Reason",
     "WITHDRAWN_BY_CLIENT": "Withdrawn by client",
-    "WITHDRAW_CLIENT": "Withdraw Client"
+    "WITHDRAW_CLIENT": "Withdraw Client",
+    "ACCOUNT_ACTION": "Account Action"
   },
   "PRODUCTS": {
     "LOAN_PRODUCTS": "Loan Products",
@@ -893,7 +894,9 @@
     "STANDING_INSTRUCTIONS": "Standing Instructions",
     "NO_STANDING_INSTRUCTIONS": "No standing instructions transfer from this account.",
     "TRANSFER_IN": "Into this account",
-    "TRANSFER_OUT": "Out of this account"
+    "TRANSFER_OUT": "Out of this account",
+    "ACCOUNT_DETAILS": "Savings Account Details",
+    "TRANSACTION": "Savings Transaction"
   },
   "USERS": {
     "CREATE": "Create User",
@@ -1378,18 +1381,21 @@
     "SHARES": "Shares",
     "SHARES_HELD": "Shares held",
     "TOTAL_SHARES": "Total Shares",
-    "UNIT_PRICE": "Unit price"
+    "UNIT_PRICE": "Unit price",
+    "ACCOUNT_DETAILS": "Share Account Details"
   },
   "RECURRING_DEPOSITS": {
     "CREATE": "Create Recurring Deposit Account",
     "EDIT": "Edit Recurring Deposit Account",
     "INHERIT_CALENDAR": "Inherit Calendar",
     "RECURRING_FREQUENCY": "Recurring Frequency",
-    "FREQUENCY_TYPE": "Frequency Type"
+    "FREQUENCY_TYPE": "Frequency Type",
+    "ACCOUNT_DETAILS": "Recurring Deposit Account Details"
   },
   "FIXED_DEPOSITS": {
     "CREATE": "Create Fixed Deposit Account",
-    "EDIT": "Edit Fixed Deposit Account"
+    "EDIT": "Edit Fixed Deposit Account",
+    "ACCOUNT_DETAILS": "Fixed Deposit Account Details"
   },
   "GUIDE": {
     "DASHBOARD_WELCOME_TITLE": "Welcome to Fineract Backoffice",


### PR DESCRIPTION
## What and why

PR 2 of the five agreed on #355. All 65 routes in `products.routes.ts` inherited their tab from the section above them, so every page under `products` read `Products · Fineract`.

This applies the convention settled in #380:

1. The section root restates the `nav.*` key from its `app.routes.ts` entry.
2. Every other route takes the key its page already uses for its own visible heading.
3. Where the heading is a record's name and cannot be a static key, the route takes a generic key naming the screen type.

Refs #355

## The part worth reviewing: this file needed six new keys

`clients` needed none and `system` needs none. `products` needs six, and the reason is a rule about **route shapes** rather than about feature areas, which is the correction I flagged on #380 before it merged.

Five of the six are record views. Rule 2 says take the page's own heading key, and for these that key is `COMMON.DETAILS` or `COMMON.OVERVIEW`, because the visible heading is the record's name and the card above it is generically labelled. Following the rule literally would have given four different screens the tab `Details · Fineract`, reproducing this issue's own problem one level down:

| Route | Title | |
|---|---|---|
| `loan/view/:id` | `nav.loanProductDetails` | existed |
| `savings-accounts/view/:id` | `SAVINGS.ACCOUNT_DETAILS` | new |
| `fixed-deposits/view/:id` | `FIXED_DEPOSITS.ACCOUNT_DETAILS` | new |
| `recurring-deposits/view/:id` | `RECURRING_DEPOSITS.ACCOUNT_DETAILS` | new |
| `shares/view/:id` | `SHARE_ACCOUNTS.ACCOUNT_DETAILS` | new |

The sixth is `ACTIONS.ACCOUNT_ACTION`, for `:accountType/:accountId/action/:command`. That component picks its heading from a command-to-key map at runtime, so no static title can name it. **This is the same shape as the `tellers` `:command` route you asked about on #355**, and `products` has two of them, so the case is now answered in code rather than in prose.

All six are added to `en.json` only. `i18n.js` sets `fallbackLng: "en"`, so the other locales fall back rather than break.

## Verification

| | |
|---|---|
| `npx ng test fineract-backoffice-ui` | **1104 of 1104 SUCCESS**, real headless Chromium |
| `products.routes.spec.ts` alone | 11 of 11 |
| `npm run lint` | exit 0, no new warnings |
| `npm run lint:prune` | exit 0 |
| `npm run format:check` | exit 0 |
| `node scripts/check-translations.mjs` | exit 0, 2206 keys |

**The spec was verified in the failing direction as well.** It carries the two guards from #380 plus one that file did not need:

| Change | Result |
|---|---|
| delete the title on `savings-accounts/view/:id` | 3 failed, naming the route |
| point two view routes at the same `COMMON.DETAILS` | **1 failed, the new uniqueness test** |
| replace a key with the phrase `'Rates'` | 1 failed, the key-shape test |
| restore | 11 of 11 |

That third guard, **no two routes may share a title**, is the one `clients` did not need. Titling 65 routes is only worth doing if the tabs come out distinguishable, and it is what fails if someone later takes the `COMMON.DETAILS` shortcut.

## Screenshots

Not applicable. The change is in the browser tab.

## Two things noticed, neither changed here

**`products/recurring` and `products/share` render the wrong labels.** They are the *product* lists but their headings use `nav.recurringDeposits` and `nav.shares`, which are the *account* labels. Their titles use the correct `nav.recurringDepositProducts` and `nav.shareProducts`, so on those two the tab is right and the on-screen heading is wrong. Worth a separate fix if you agree.

**Three list components carry hardcoded English headings** rather than translation keys: `fixed-deposits-list`, `recurring-deposits-list` and `share-accounts-list` render `title="Fixed Deposit Accounts"` and similar. `check-translations.mjs` cannot catch this, because it only validates strings that are already keys. A real i18n bug but not a titling one, so those three routes take the correct `nav.*` keys and I have left the headings alone. Happy to file it separately.

`products.routes.ts` stays flat, as you asked.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary. No new component or service code.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change.
- [x] UI workflow changes include suitable e2e coverage. No workflow changes.
- [x] Commits are signed.
