### PR TITLE
fix(a11y): give every system route its own title

### DIFF
--- a/src/app/features/system/system.routes.spec.ts
+++ b/src/app/features/system/system.routes.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { TitleStrategy, provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { SYSTEM_ROUTES } from './system.routes';
+import { TranslatedTitleStrategy } from '../../core/router/translated-title.strategy';
+import { FakeI18nAdapter, provideFakeAdapters } from '../../testing/adapters';
+
+const APP_NAME_KEY = 'app.shortTitle';
+const APP_NAME = 'Fineract';
+const SECTION_KEY = 'nav.system';
+const SECTION_NAME = 'System';
+
+/** Stands in for the lazily loaded page components, which this spec does not exercise. */
+@Component({ standalone: true, template: '' })
+class RouteStub {}
+
+/**
+ * A dotted key such as `CODES.CREATE_TITLE`, rather than a phrase.
+ *
+ * Checked segment by segment rather than with one pattern: a single regex for this shape
+ * needs a quantifier inside a quantifier, which `security/detect-unsafe-regex` flags.
+ */
+function isTranslationKey(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+
+  const segments = value.split('.');
+  return (
+    segments.length > 1 && /^[A-Za-z]/.test(value) && segments.every((part) => /^\w+$/.test(part))
+  );
+}
+
+describe('SYSTEM_ROUTES', () => {
+  let i18n: FakeI18nAdapter;
+
+  beforeEach(() => {
+    // The guards are not under test here, and permissionGuard would reject every
+    // navigation without an authenticated user.
+    const routes = SYSTEM_ROUTES.map(({ path, title }) => ({
+      path,
+      title,
+      component: RouteStub,
+    }));
+
+    const adapters = provideFakeAdapters();
+    i18n = adapters.i18n;
+    i18n.catalogue.set(APP_NAME_KEY, APP_NAME);
+    i18n.catalogue.set(SECTION_KEY, SECTION_NAME);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ...adapters.providers,
+        { provide: TitleStrategy, useClass: TranslatedTitleStrategy },
+        provideRouter([{ path: 'system', title: SECTION_KEY, children: routes }]),
+      ],
+    });
+  });
+
+  /**
+   * The regression this file exists for. A route with no `title` still gets a tab, because
+   * Angular's `buildTitle` walks up to the section, so a missing title looks correct on
+   * screen and is only wrong in the one place nobody is looking. This section is the worst
+   * place for that: 49 administrative screens that all read "System".
+   */
+  it('gives every route its own title', () => {
+    const untitled = SYSTEM_ROUTES.filter((route) => !route.title).map((route) => route.path);
+
+    expect(untitled).toEqual([]);
+  });
+
+  it('titles routes with translation keys rather than phrases', () => {
+    const notKeys = SYSTEM_ROUTES.filter((route) => !isTranslationKey(route.title)).map(
+      (route) => route.path,
+    );
+
+    expect(notKeys).toEqual([]);
+  });
+
+  it('gives no two routes the same title', () => {
+    const seen = new Map<string, string[]>();
+    for (const route of SYSTEM_ROUTES) {
+      const key = String(route.title);
+      seen.set(key, [...(seen.get(key) ?? []), String(route.path)]);
+    }
+
+    const collisions = [...seen.entries()].filter(([, paths]) => paths.length > 1);
+
+    expect(collisions).toEqual([]);
+  });
+
+  /**
+   * The shapes this file contributes. `codes/:codeId/values` is the one that needed a
+   * judgement: its heading is the code's own name, bound at runtime, so the route takes the
+   * generic `CODE_VALUES.TITLE` in the same way a record view does. The rest are ordinary
+   * configuration screens, which is why this file needed no new translation keys at all.
+   */
+  const cases = [
+    { url: '/system', key: SECTION_KEY, name: SECTION_NAME },
+    { url: '/system/codes', key: 'CODES.TITLE', name: 'Codes' },
+    { url: '/system/codes/7/values', key: 'CODE_VALUES.TITLE', name: 'Code Values' },
+    {
+      url: '/system/codes/7/values/edit/3',
+      key: 'CODE_VALUES.EDIT_TITLE',
+      name: 'Edit Code Value',
+    },
+    {
+      url: '/system/scheduler-jobs/7/history',
+      key: 'SCHEDULER_JOBS.RUN_HISTORY',
+      name: 'Run History',
+    },
+    {
+      url: '/system/data-tables/edit/m_client',
+      key: 'SYSTEM.EDIT_DATA_TABLE',
+      name: 'Edit Data Table',
+    },
+    { url: '/system/permissions', key: 'PERMISSIONS.TITLE', name: 'Maker-Checker Permissions' },
+  ];
+
+  cases.forEach(({ url, key, name }) => {
+    it(`titles ${url} from its own route rather than the section`, async () => {
+      i18n.catalogue.set(key, name);
+      const harness = await RouterTestingHarness.create();
+
+      await harness.navigateByUrl(url);
+
+      expect(TestBed.inject(Title).getTitle()).toBe(`${name} · ${APP_NAME}`);
+    });
+  });
+});

--- a/src/app/features/system/system.routes.ts
+++ b/src/app/features/system/system.routes.ts
@@ -26,6 +26,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'data-tables',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_DATATABLE' },
+    title: 'SYSTEM.DATA_TABLES',
     loadComponent: () =>
       import('./data-tables/datatables-list.component').then((m) => m.DatatablesListComponent),
   },
@@ -33,6 +34,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'data-tables/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_DATATABLE' },
+    title: 'SYSTEM.CREATE_DATA_TABLE',
     loadComponent: () =>
       import('./data-tables/datatables-form.component').then((m) => m.DatatablesFormComponent),
   },
@@ -40,6 +42,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'data-tables/edit/:name',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_DATATABLE' },
+    title: 'SYSTEM.EDIT_DATA_TABLE',
     loadComponent: () =>
       import('./data-tables/datatables-form.component').then((m) => m.DatatablesFormComponent),
   },
@@ -47,24 +50,28 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'codes',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CODE' },
+    title: 'CODES.TITLE',
     loadComponent: () => import('./codes/codes-list.component').then((m) => m.CodesListComponent),
   },
   {
     path: 'codes/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CODE' },
+    title: 'CODES.CREATE_TITLE',
     loadComponent: () => import('./codes/code-form.component').then((m) => m.CodeFormComponent),
   },
   {
     path: 'codes/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CODE' },
+    title: 'CODES.EDIT_TITLE',
     loadComponent: () => import('./codes/code-form.component').then((m) => m.CodeFormComponent),
   },
   {
     path: 'codes/:codeId/values',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CODEVALUE' },
+    title: 'CODE_VALUES.TITLE',
     loadComponent: () =>
       import('./codes/code-values-list.component').then((m) => m.CodeValuesListComponent),
   },
@@ -72,6 +79,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'codes/:codeId/values/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CODEVALUE' },
+    title: 'CODE_VALUES.CREATE_TITLE',
     loadComponent: () =>
       import('./codes/code-value-form.component').then((m) => m.CodeValueFormComponent),
   },
@@ -79,6 +87,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'codes/:codeId/values/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CODEVALUE' },
+    title: 'CODE_VALUES.EDIT_TITLE',
     loadComponent: () =>
       import('./codes/code-value-form.component').then((m) => m.CodeValueFormComponent),
   },
@@ -86,6 +95,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'business-dates',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_BUSINESS_DATE' },
+    title: 'BUSINESS_DATES.TITLE',
     loadComponent: () =>
       import('./business-dates/business-dates.component').then((m) => m.BusinessDatesComponent),
   },
@@ -93,6 +103,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'templates',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_TEMPLATE' },
+    title: 'TEMPLATES.TITLE',
     loadComponent: () =>
       import('./templates/templates-list.component').then((m) => m.TemplatesListComponent),
   },
@@ -100,6 +111,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'templates/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_TEMPLATE' },
+    title: 'TEMPLATES.CREATE_TITLE',
     loadComponent: () =>
       import('./templates/template-form.component').then((m) => m.TemplateFormComponent),
   },
@@ -107,6 +119,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'templates/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_TEMPLATE' },
+    title: 'TEMPLATES.EDIT_TITLE',
     loadComponent: () =>
       import('./templates/template-form.component').then((m) => m.TemplateFormComponent),
   },
@@ -114,6 +127,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'bulk-import',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_IMPORT' },
+    title: 'SYSTEM.BULK_IMPORT',
     loadComponent: () =>
       import('./bulk-import/bulk-import.component').then((m) => m.BulkImportComponent),
   },
@@ -121,6 +135,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'delinquency',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_DELINQUENCY_BUCKET' },
+    title: 'nav.delinquency',
     loadComponent: () =>
       import('./delinquency/delinquency-management.component').then(
         (m) => m.DelinquencyManagementComponent,
@@ -130,6 +145,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'credit-bureau-config',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CREDITBUREAU_CONFIGURATION' },
+    title: 'CREDIT_BUREAU_CONFIG.TITLE',
     loadComponent: () =>
       import('./credit-bureau-config/credit-bureau-config.component').then(
         (m) => m.CreditBureauConfigComponent,
@@ -139,6 +155,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'report-definitions',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_REPORT' },
+    title: 'nav.reportDefinitions',
     loadComponent: () =>
       import('./report-definitions/report-definitions-list.component').then(
         (m) => m.ReportDefinitionsListComponent,
@@ -148,6 +165,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'report-definitions/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_REPORT' },
+    title: 'REPORT_DEFINITIONS.CREATE',
     loadComponent: () =>
       import('./report-definitions/report-definition-form.component').then(
         (m) => m.ReportDefinitionFormComponent,
@@ -157,6 +175,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'report-definitions/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_REPORT' },
+    title: 'REPORT_DEFINITIONS.EDIT',
     loadComponent: () =>
       import('./report-definitions/report-definition-form.component').then(
         (m) => m.ReportDefinitionFormComponent,
@@ -166,22 +185,26 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'hooks',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_HOOK' },
+    title: 'nav.hooks',
     loadComponent: () => import('./hooks/hooks-list.component').then((m) => m.HooksListComponent),
   },
   {
     path: 'hooks/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_HOOK' },
+    title: 'HOOKS.CREATE',
     loadComponent: () => import('./hooks/hooks-form.component').then((m) => m.HooksFormComponent),
   },
   {
     path: 'hooks/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_HOOK' },
+    title: 'HOOKS.EDIT',
     loadComponent: () => import('./hooks/hooks-form.component').then((m) => m.HooksFormComponent),
   },
   {
     path: 'adhoc-query',
+    title: 'nav.adhocQuery',
     loadComponent: () =>
       import('./adhoc-query/adhoc-query-list.component').then((m) => m.AdhocQueryListComponent),
   },
@@ -189,6 +212,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'adhoc-query/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_ADHOC' },
+    title: 'ADHOC_QUERY.CREATE',
     loadComponent: () =>
       import('./adhoc-query/adhoc-query-form.component').then((m) => m.AdhocQueryFormComponent),
   },
@@ -196,6 +220,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'adhoc-query/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_ADHOC' },
+    title: 'ADHOC_QUERY.EDIT',
     loadComponent: () =>
       import('./adhoc-query/adhoc-query-form.component').then((m) => m.AdhocQueryFormComponent),
   },
@@ -203,24 +228,28 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'sms',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SMS' },
+    title: 'nav.sms',
     loadComponent: () => import('./sms/sms-list.component').then((m) => m.SmsListComponent),
   },
   {
     path: 'sms/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_SMS' },
+    title: 'SMS.CREATE',
     loadComponent: () => import('./sms/sms-form.component').then((m) => m.SmsFormComponent),
   },
   {
     path: 'sms/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_SMS' },
+    title: 'SMS.EDIT',
     loadComponent: () => import('./sms/sms-form.component').then((m) => m.SmsFormComponent),
   },
   {
     path: 'report-mailing-jobs',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_REPORTMAILINGJOB' },
+    title: 'nav.reportMailingJobs',
     loadComponent: () =>
       import('./report-mailing-jobs/report-mailing-jobs-list.component').then(
         (m) => m.ReportMailingJobsListComponent,
@@ -230,6 +259,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'report-mailing-jobs/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_REPORTMAILINGJOB' },
+    title: 'REPORT_MAILING_JOBS.CREATE',
     loadComponent: () =>
       import('./report-mailing-jobs/report-mailing-jobs-form.component').then(
         (m) => m.ReportMailingJobsFormComponent,
@@ -239,6 +269,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'report-mailing-jobs/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_REPORTMAILINGJOB' },
+    title: 'REPORT_MAILING_JOBS.EDIT',
     loadComponent: () =>
       import('./report-mailing-jobs/report-mailing-jobs-form.component').then(
         (m) => m.ReportMailingJobsFormComponent,
@@ -248,6 +279,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'entity-data-table-checks',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_ENTITY_DATATABLE_CHECK' },
+    title: 'nav.entityDataTableChecks',
     loadComponent: () =>
       import('./entity-data-table-checks/entity-data-table-checks-list.component').then(
         (m) => m.EntityDataTableChecksListComponent,
@@ -257,6 +289,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'entity-data-table-checks/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_ENTITY_DATATABLE_CHECK' },
+    title: 'ENTITY_DATA_TABLE_CHECKS.CREATE',
     loadComponent: () =>
       import('./entity-data-table-checks/entity-data-table-checks-form.component').then(
         (m) => m.EntityDataTableChecksFormComponent,
@@ -264,6 +297,7 @@ export const SYSTEM_ROUTES: Routes = [
   },
   {
     path: 'entity-mapping',
+    title: 'nav.entityMapping',
     loadComponent: () =>
       import('./entity-mapping/entity-mapping-list.component').then(
         (m) => m.EntityMappingListComponent,
@@ -273,6 +307,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'entity-mapping/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_ENTITYMAPPING' },
+    title: 'ENTITY_MAPPING.CREATE',
     loadComponent: () =>
       import('./entity-mapping/entity-mapping-form.component').then(
         (m) => m.EntityMappingFormComponent,
@@ -282,6 +317,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'entity-mapping/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_ENTITYMAPPING' },
+    title: 'ENTITY_MAPPING.EDIT',
     loadComponent: () =>
       import('./entity-mapping/entity-mapping-form.component').then(
         (m) => m.EntityMappingFormComponent,
@@ -291,6 +327,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'business-steps',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_BATCH_BUSINESS_STEP' },
+    title: 'BUSINESS_STEPS.TITLE',
     loadComponent: () =>
       import('./business-steps/business-steps.component').then((m) => m.BusinessStepsComponent),
   },
@@ -298,12 +335,14 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'cache',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CACHE' },
+    title: 'CACHE.TITLE',
     loadComponent: () => import('./cache/cache.component').then((m) => m.CacheComponent),
   },
   {
     path: 'external-events',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_EXTERNAL_EVENT_CONFIGURATION' },
+    title: 'nav.externalEvents',
     loadComponent: () =>
       import('./external-events/external-events.component').then((m) => m.ExternalEventsComponent),
   },
@@ -311,6 +350,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'external-services',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_EXTERNALSERVICES' },
+    title: 'EXTERNAL_SERVICES.TITLE',
     loadComponent: () =>
       import('./external-services/external-services.component').then(
         (m) => m.ExternalServicesComponent,
@@ -320,6 +360,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'password-preferences',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_PASSWORD_PREFERENCES' },
+    title: 'PASSWORD_PREFERENCES.TITLE',
     loadComponent: () =>
       import('./password-preferences/password-preferences.component').then(
         (m) => m.PasswordPreferencesComponent,
@@ -329,6 +370,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'notifications-config',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_EMAIL_CONFIGURATION' },
+    title: 'NOTIFICATIONS_CONFIG.TITLE',
     loadComponent: () =>
       import('./notifications-config/notifications-config.component').then(
         (m) => m.NotificationsConfigComponent,
@@ -336,6 +378,7 @@ export const SYSTEM_ROUTES: Routes = [
   },
   {
     path: 'instance-mode',
+    title: 'INSTANCE_MODE.TITLE',
     loadComponent: () =>
       import('./instance-mode/instance-mode.component').then((m) => m.InstanceModeComponent),
   },
@@ -343,6 +386,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'scheduler-jobs',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SCHEDULER' },
+    title: 'nav.schedulerJobs',
     loadComponent: () =>
       import('./scheduler-jobs/scheduler-jobs-list.component').then(
         (m) => m.SchedulerJobsListComponent,
@@ -352,6 +396,7 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'scheduler-jobs/:id/history',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_SCHEDULER' },
+    title: 'SCHEDULER_JOBS.RUN_HISTORY',
     loadComponent: () =>
       import('./scheduler-jobs/scheduler-job-history.component').then(
         (m) => m.SchedulerJobHistoryComponent,
@@ -361,16 +406,19 @@ export const SYSTEM_ROUTES: Routes = [
     path: 'permissions',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_PERMISSION' },
+    title: 'PERMISSIONS.TITLE',
     loadComponent: () =>
       import('./permissions/permissions.component').then((m) => m.PermissionsListComponent),
   },
   {
     path: 'oidc-config',
+    title: 'OIDC_CONFIG.TITLE',
     loadComponent: () =>
       import('./oidc-config/oidc-config.component').then((m) => m.OidcConfigComponent),
   },
   {
     path: 'field-configuration',
+    title: 'FIELD_CONFIG.TITLE',
     loadComponent: () =>
       import('./field-configuration/field-configuration.component').then(
         (m) => m.FieldConfigurationComponent,
@@ -378,6 +426,7 @@ export const SYSTEM_ROUTES: Routes = [
   },
   {
     path: 'loan-product-details',
+    title: 'LOAN_PRODUCT_DETAILS.TITLE',
     loadComponent: () =>
       import('./loan-product-details/loan-product-details.component').then(
         (m) => m.LoanProductDetailsComponent,


### PR DESCRIPTION
## What and why

PR 3 of the five agreed on #355. All 49 routes in `system.routes.ts` inherited their tab from the section above them, so every administrative screen read `System · Fineract`. That is the worst place in the app for it: 49 different configuration pages sharing one tab.

Applies the convention settled in #380.

Refs #355

## No new translation keys, and the reason generalises

`products` needed six. This file needs none across 49 routes, and the difference is not luck about which files these are:

| File | Routes | New keys |
|---|---|---|
| `clients` | 21 | 0 |
| **`system`** | **49** | **0** |
| `products` | 65 | 6 |

**`system` has no `view/:id` route at all.** Every screen here is a list, a configuration page or a create/edit form, and each of those already renders its own name, so rule 2 always finds a key. A record view is the one shape where the visible heading is the *record* rather than the *screen*, which is exactly when there is nothing to reuse.

So the accurate statement of the property is: **a file needs new keys if and only if it contains routes whose heading is bound at runtime.** That is checkable in advance, and it is what I will write back to #355.

## The one judgement call

`codes/:codeId/values` binds its heading to `[title]="codeName()"`, the code's own name at runtime, so no static title can name it. It takes the existing generic `CODE_VALUES.TITLE`, the same treatment a record view gets, arrived at from a different direction.

Two smaller notes on the mapping:

- `delinquency` renders two data tables with no page-level heading, so it takes `nav.delinquency` rather than either table's title.
- `business-dates` carries its heading in an `<h2>` rather than a card title, worth mentioning only because it is the one place in the section where the heading is not where the surrounding files put it.

## Verification

| | |
|---|---|
| `npx ng test fineract-backoffice-ui` | **1103 of 1103 SUCCESS**, real headless Chromium |
| `system.routes.spec.ts` alone | 10 of 10 |
| `npm run lint` | exit 0 |
| `npm run lint:prune` | exit 0 |
| `npm run format:check` | exit 0 |
| `node scripts/check-translations.mjs` | exit 0 |

**Verified in the failing direction too**, since a spec over data that only ever passes proves nothing:

| Change | Result |
|---|---|
| delete the title on `codes/:codeId/values` | 3 failed, naming the route |
| point `cache` and `permissions` at the same key | 1 failed, the uniqueness test |
| replace `nav.hooks` with the phrase `'Hooks'` | 1 failed, the key-shape test |
| restore | 10 of 10 |

## Screenshots

Not applicable. The change is in the browser tab.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary. No new component or service code.
- [x] User-facing strings use translation keys. No new keys were needed.
- [x] I added or updated tests appropriate to this change.
- [x] UI workflow changes include suitable e2e coverage. No workflow changes.
- [x] Commits are signed.
