### PR TITLE
fix(idle): prevent hard logout timer reset on activity during warning

### DIFF
--- a/src/app/core/services/idle.service.spec.ts
+++ b/src/app/core/services/idle.service.spec.ts
@@ -18,7 +18,8 @@
  */
 
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subject } from 'rxjs';
 import { IdleService } from './idle.service';
 import { AuthService } from './auth.service';
 import { DialogService } from './dialog.service';
@@ -28,11 +29,16 @@ describe('IdleService', () => {
   let service: IdleService;
   let authServiceSpy: jasmine.SpyObj<AuthService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let routerEvents: Subject<unknown>;
   let overlay: FakeOverlayAdapter;
 
   beforeEach(() => {
     authServiceSpy = jasmine.createSpyObj('AuthService', ['logout', 'isAuthenticated']);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    routerEvents = new Subject<unknown>();
+    // `Router.events` is a real Observable, not a spied method — the constructor subscribes
+    // to it directly, so the double has to supply one rather than leave it undefined.
+    (routerSpy as unknown as { events: Subject<unknown> }).events = routerEvents;
     const fakes = provideFakeAdapters();
     overlay = fakes.overlay;
 
@@ -89,6 +95,72 @@ describe('IdleService', () => {
 
     expect(authServiceSpy.logout).toHaveBeenCalled();
     expect(routerSpy.navigate).toHaveBeenCalled();
+
+    service.ngOnDestroy();
+  }));
+
+  it('keeps the hard logout timer running when activity is reported while the warning is still being presented', fakeAsync(() => {
+    authServiceSpy.isAuthenticated.and.returnValue(true);
+
+    // Simulates the window between the warning timer firing and `dialogService.present()`
+    // actually resolving — the exact gap in which `dialogRef` used to sit unset, making the
+    // "don't reset while a warning is up" guard ineffective: an activity event landing here
+    // used to call `resetTimer()`, which clears the hard logout timer `showInactivityWarning()`
+    // had just set and reschedules a fresh 13-minute wait, leaving the visible warning up with
+    // nothing left to time it out.
+    let resolvePresent!: (handle: {
+      result: Promise<unknown>;
+      dismiss: () => Promise<void>;
+    }) => void;
+    spyOn(overlay, 'presentModal').and.returnValue(
+      new Promise((resolve) => {
+        resolvePresent = resolve;
+      }),
+    );
+
+    service = TestBed.inject(IdleService);
+
+    tick(13 * 60 * 1000 + 1000);
+    expect(overlay.presentModal).toHaveBeenCalledTimes(1);
+
+    // An activity event lands before the modal has actually presented.
+    window.dispatchEvent(new Event('mousemove'));
+    tick(1);
+
+    // The modal now presents, and the user never answers it.
+    resolvePresent({ result: new Promise(() => undefined), dismiss: () => Promise.resolve() });
+    tick();
+
+    // If the stray activity event had reset the timer, this would not be enough time to
+    // reach the hard logout — it would take another ~13 minutes instead.
+    tick(2 * 60 * 1000 + 1000);
+
+    expect(authServiceSpy.logout).toHaveBeenCalled();
+    expect(overlay.presentModal).toHaveBeenCalledTimes(1);
+
+    service.ngOnDestroy();
+  }));
+
+  it('closes the warning dialog once navigation actually lands on the login page', fakeAsync(() => {
+    authServiceSpy.isAuthenticated.and.returnValue(true);
+    // The user never answers, so nothing else would close this dialog before the hard
+    // logout timer does — the router subscription below has to be what closes it instead.
+    const dismissSpy = jasmine.createSpy('dismiss').and.resolveTo(undefined);
+    spyOn(overlay, 'presentModal').and.resolveTo({
+      result: new Promise(() => undefined),
+      dismiss: dismissSpy,
+    });
+
+    service = TestBed.inject(IdleService);
+
+    tick(13 * 60 * 1000 + 1000);
+    expect(overlay.presentModal).toHaveBeenCalled();
+    expect(dismissSpy).not.toHaveBeenCalled();
+
+    routerEvents.next(new NavigationEnd(1, '/login?reason=inactivity', '/login?reason=inactivity'));
+    tick();
+
+    expect(dismissSpy).toHaveBeenCalled();
 
     service.ngOnDestroy();
   }));

--- a/src/app/core/services/idle.service.ts
+++ b/src/app/core/services/idle.service.ts
@@ -18,9 +18,10 @@
  */
 
 import { Injectable, inject, NgZone, OnDestroy, effect } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AuthService } from './auth.service';
-import { Router } from '@angular/router';
-import { fromEvent, merge, Subscription, throttleTime } from 'rxjs';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, fromEvent, merge, Subscription, throttleTime } from 'rxjs';
 import { ModalHandle } from '../adapters';
 import { DialogService } from './dialog.service';
 import { InactivityDialogComponent } from '../../layout/inactivity-dialog.component';
@@ -44,6 +45,18 @@ export class IdleService implements OnDestroy {
   private idleSubscription?: Subscription;
   private timeoutId: ReturnType<typeof setTimeout> | null = null;
   private dialogRef: ModalHandle<boolean> | null = null;
+  /**
+   * True from the instant the warning is requested, not from when it finishes presenting.
+   *
+   * `dialogRef` alone cannot guard the activity-event handler below: it is only assigned
+   * once `dialogService.present()`'s promise resolves, which leaves a window — a throttled
+   * activity event landing in the moment between the timer firing and the modal actually
+   * being on screen — where that handler saw `dialogRef` still unset and called
+   * `resetTimer()`. That clears the hard logout timeout `showInactivityWarning()` had just
+   * armed and reschedules a fresh 13-minute wait, leaving the now-visible warning dialog
+   * with nothing left to time it out — indefinitely, if the user never answers it.
+   */
+  private presentingWarning = false;
 
   // Configuration
   /** Total time of inactivity allowed before forced logout (15 minutes) */
@@ -60,6 +73,22 @@ export class IdleService implements OnDestroy {
         this.stopMonitoring();
       }
     });
+
+    // Belt-and-suspenders: whatever ends up sending the user to the login page — the
+    // logout timer below, a 401 elsewhere in the app — must never leave this warning on
+    // screen once they have actually landed there. `stopMonitoring()` already runs when
+    // `isAuthenticated` flips to `false`, but this does not depend on that signal update,
+    // the dismiss it triggers, or this service's own timer logic ever having run at all.
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntilDestroyed(),
+      )
+      .subscribe((event) => {
+        if ((event as NavigationEnd).urlAfterRedirects.startsWith('/login')) {
+          this.closeDialog();
+        }
+      });
   }
 
   /**
@@ -81,8 +110,8 @@ export class IdleService implements OnDestroy {
       ).pipe(throttleTime(5000));
 
       this.idleSubscription = activityEvents$.subscribe(() => {
-        // Only reset the timer if the warning dialog is not currently open
-        if (!this.dialogRef) {
+        // Only reset the timer if the warning dialog is not currently open (or being opened).
+        if (!this.presentingWarning) {
           this.resetTimer();
         }
       });
@@ -128,7 +157,8 @@ export class IdleService implements OnDestroy {
    */
   private showInactivityWarning(): void {
     this.ngZone.run(() => {
-      if (this.dialogRef) return;
+      if (this.presentingWarning) return;
+      this.presentingWarning = true;
 
       // The warning must not be dismissable by backdrop or escape — ignoring it has to
       // fall through to the logout timer below, not silently cancel the countdown.
@@ -142,6 +172,7 @@ export class IdleService implements OnDestroy {
 
           return handle.result.then((shouldExtend) => {
             this.dialogRef = null;
+            this.presentingWarning = false;
             if (shouldExtend) {
               this.resetTimer();
             } else {
@@ -175,6 +206,7 @@ export class IdleService implements OnDestroy {
    * Safely closes the warning dialog if it is open.
    */
   private closeDialog(): void {
+    this.presentingWarning = false;
     if (this.dialogRef) {
       void this.dialogRef.dismiss();
       this.dialogRef = null;

--- a/src/app/features/clients/clients-list.component.ts
+++ b/src/app/features/clients/clients-list.component.ts
@@ -93,9 +93,7 @@ import {
             [(ngModel)]="activeFilters.status"
             (ionChange)="onFilterChange()"
           >
-            <ion-select-option [value]="undefined">{{
-              'COMMON.ALL' | translate
-            }}</ion-select-option>
+            <ion-select-option value="">{{ 'COMMON.ALL' | translate }}</ion-select-option>
             <ion-select-option value="active">{{ 'COMMON.ACTIVE' | translate }}</ion-select-option>
             <ion-select-option value="pending">{{
               'COMMON.PENDING' | translate
@@ -178,7 +176,10 @@ export class ClientsListComponent {
   readonly clients = signal<GetClientsPageItemsResponse[]>([]);
   readonly totalRecords = signal(0);
 
-  activeFilters: { status?: string } = {};
+  // Empty string, not `undefined`, so it round-trips through `<ion-select>`'s ngModel
+  // binding as a real match for the "All" option's own `value=""` rather than leaving the
+  // select showing nothing selected.
+  activeFilters: { status?: string } = { status: '' };
 
   private searchSubject = new Subject<string>();
   private sortSubject = new Subject<SortEvent>();
@@ -211,7 +212,10 @@ export class ClientsListComponent {
             : undefined;
 
           const displayName = this.currentFilter ? `%${this.currentFilter}%` : undefined;
-          const status = this.activeFilters.status;
+          // Fineract's /clients endpoint rejects `status=` and `status=All` outright (a 400,
+          // "The Status value '...' is not supported") — the param must be omitted entirely
+          // to mean "any status", so the "All" sentinel is never forwarded as-is.
+          const status = this.activeFilters.status || undefined;
 
           return this.clientService
             .getClients(

--- a/src/app/features/loans/loans-list.component.ts
+++ b/src/app/features/loans/loans-list.component.ts
@@ -95,9 +95,7 @@ import {
             [(ngModel)]="activeFilters.status"
             (ionChange)="onFilterChange()"
           >
-            <ion-select-option [value]="undefined">{{
-              'COMMON.ALL' | translate
-            }}</ion-select-option>
+            <ion-select-option value="">{{ 'COMMON.ALL' | translate }}</ion-select-option>
             <ion-select-option value="300">{{ 'COMMON.ACTIVE' | translate }}</ion-select-option>
             <ion-select-option value="100">{{ 'COMMON.PENDING' | translate }}</ion-select-option>
             <ion-select-option value="600">{{ 'COMMON.CLOSED' | translate }}</ion-select-option>
@@ -204,7 +202,10 @@ export class LoansListComponent {
   readonly loans = signal<GetLoansLoanIdResponse[]>([]);
   readonly totalRecords = signal(0);
 
-  activeFilters: { status?: string } = {};
+  // Empty string, not `undefined`, so it round-trips through `<ion-select>`'s ngModel
+  // binding as a real match for the "All" option's own `value=""` rather than leaving the
+  // select showing nothing selected.
+  activeFilters: { status?: string } = { status: '' };
 
   private searchSubject = new Subject<string>();
   private sortSubject = new Subject<SortEvent>();
@@ -237,7 +238,10 @@ export class LoansListComponent {
             : undefined;
 
           const searchVal = this.currentFilter || undefined;
-          const status = this.activeFilters.status;
+          // Fineract's /loans endpoint rejects `status=` and `status=All` outright (a 400,
+          // "The Status value '...' is not supported") — the param must be omitted entirely
+          // to mean "any status", so the "All" sentinel is never forwarded as-is.
+          const status = this.activeFilters.status || undefined;
 
           return this.loansService
             .getLoans(

--- a/src/app/shared/directives/tooltip-registry.service.ts
+++ b/src/app/shared/directives/tooltip-registry.service.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from '@angular/core';
+
+/** The minimal surface {@link TooltipRegistryService} needs from a shown tooltip. */
+export interface DismissableTooltip {
+  hide(): void;
+}
+
+/**
+ * Keeps track of the one {@link TooltipDirective} instance currently showing its tooltip.
+ *
+ * Hover and focus are independent DOM event streams: a mouse can be over one help icon while
+ * keyboard focus sits on another (e.g. tabbing while the pointer hasn't moved), and each
+ * `TooltipDirective` instance only knows about its own host element. Without a shared
+ * arbiter, two directives can each legitimately believe they are the active one and both
+ * leave a bubble appended to `document.body` — which is exactly what the login page's API
+ * Endpoint field and a stale field-level tooltip stacking on top of it looked like.
+ * Registering here before showing guarantees at most one tooltip is ever on screen.
+ */
+@Injectable({ providedIn: 'root' })
+export class TooltipRegistryService {
+  private active?: DismissableTooltip;
+
+  /** Hides whichever tooltip is currently showing, then records `next` as the active one. */
+  activate(next: DismissableTooltip): void {
+    if (this.active && this.active !== next) {
+      this.active.hide();
+    }
+    this.active = next;
+  }
+
+  /** Clears the active slot, but only if `tooltip` is still the one holding it. */
+  deactivate(tooltip: DismissableTooltip): void {
+    if (this.active === tooltip) {
+      this.active = undefined;
+    }
+  }
+}

--- a/src/app/shared/directives/tooltip.directive.spec.ts
+++ b/src/app/shared/directives/tooltip.directive.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TooltipDirective } from './tooltip.directive';
+
+@Component({
+  template: `
+    <button id="first" [appTooltip]="'First host'">First</button>
+    <button id="second" [appTooltip]="'Second host'">Second</button>
+  `,
+  standalone: true,
+  imports: [TooltipDirective],
+})
+class TestComponent {}
+
+const SHOW_DELAY = 300;
+const TOOLTIP_SELECTOR = '.app-tooltip';
+
+describe('TooltipDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  function tooltipCount(): number {
+    return document.querySelectorAll(TOOLTIP_SELECTOR).length;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TestComponent] });
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    jasmine.clock().install();
+  });
+
+  afterEach(() => {
+    // Directives destroyed by the fixture already clean up after themselves; this only
+    // catches anything a failing assertion left behind, so later specs start from zero.
+    document.querySelectorAll(TOOLTIP_SELECTOR).forEach((el) => el.remove());
+    jasmine.clock().uninstall();
+  });
+
+  function host(id: string): HTMLElement {
+    return fixture.debugElement.query(By.css(id)).nativeElement as HTMLElement;
+  }
+
+  it('does not leave an orphaned bubble when mouseenter and focusin both fire before the delay elapses', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    el.dispatchEvent(new Event('focusin'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+
+    expect(tooltipCount()).toBe(1);
+  });
+
+  it('removes the tooltip on mouseleave', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+    expect(tooltipCount()).toBe(1);
+
+    el.dispatchEvent(new Event('mouseleave'));
+    expect(tooltipCount()).toBe(0);
+  });
+
+  it('never shows two tooltips at once, even when a second host is triggered while the first is still up', () => {
+    const first = host('#first');
+    const second = host('#second');
+
+    first.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+    expect(tooltipCount()).toBe(1);
+
+    // The pointer moves to the second host without the first ever reporting mouseleave —
+    // e.g. focus lands there via keyboard while the mouse is still over the first element.
+    second.dispatchEvent(new Event('focusin'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+
+    expect(tooltipCount()).toBe(1);
+    expect(document.querySelector(TOOLTIP_SELECTOR)?.textContent).toBe('Second host');
+  });
+
+  it('cleans up its tooltip when the host is destroyed while still showing it', () => {
+    const el = host('#first');
+
+    el.dispatchEvent(new Event('mouseenter'));
+    jasmine.clock().tick(SHOW_DELAY + 1);
+    expect(tooltipCount()).toBe(1);
+
+    fixture.destroy();
+
+    expect(tooltipCount()).toBe(0);
+  });
+});

--- a/src/app/shared/directives/tooltip.directive.ts
+++ b/src/app/shared/directives/tooltip.directive.ts
@@ -18,6 +18,7 @@
  */
 
 import { inject, input, Directive, ElementRef, OnDestroy, Renderer2 } from '@angular/core';
+import { TooltipRegistryService } from './tooltip-registry.service';
 
 /** Distance between the host and the tooltip, in pixels. */
 const OFFSET = 8;
@@ -37,6 +38,8 @@ let nextId = 0;
  *
  * The tooltip is appended to the body rather than the host, so it is never clipped by a
  * card's overflow, and it is wired up with aria-describedby so screen readers announce it.
+ * {@link TooltipRegistryService} guarantees at most one instance of it is visible at once,
+ * even when hover and focus land on two different hosts in quick succession.
  *
  * Usage: `<ion-button [appTooltip]="'HELP.SEARCH_DESC' | translate">`
  */
@@ -55,6 +58,7 @@ let nextId = 0;
 export class TooltipDirective implements OnDestroy {
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly renderer = inject(Renderer2);
+  private readonly registry = inject(TooltipRegistryService);
 
   private tooltip?: HTMLElement;
   private timer?: ReturnType<typeof setTimeout>;
@@ -69,9 +73,19 @@ export class TooltipDirective implements OnDestroy {
   readonly text = input('', { alias: 'appTooltip' });
 
   show(): void {
+    // `mouseenter` and `focusin` can both fire for the same interaction (e.g. clicking the
+    // host focuses it right after the pointer enters). Without clearing the previous timer
+    // here, the first one is orphaned: its callback still fires later, creates its own
+    // element, and overwrites `this.tooltip`'s reference to it — leaking a bubble that
+    // `hide()` can never find again, permanently stuck on `document.body`.
+    clearTimeout(this.timer);
     if (!this.text() || this.tooltip) return;
 
     this.timer = setTimeout(() => {
+      // Only one tooltip may be on screen at a time — showing this one dismisses whichever
+      // other host (hovered, then left focused by a stray tab-through) still had one up.
+      this.registry.activate(this);
+
       const el = this.renderer.createElement('div') as HTMLElement;
       this.id = `tooltip-${++nextId}`;
 
@@ -91,6 +105,8 @@ export class TooltipDirective implements OnDestroy {
 
   hide(): void {
     clearTimeout(this.timer);
+    this.timer = undefined;
+    this.registry.deactivate(this);
     if (!this.tooltip) return;
 
     this.renderer.removeChild(document.body, this.tooltip);


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

<!-- Commits must be signed to merge — see CONTRIBUTING.md#commit-signing if you haven't set this up. -->

## What and why

<!-- One or two sentences explaining what changed and why. -->

Closes #

## Verification

<!-- List what you ran and what you checked. Note whether the UI was exercised with mocks, a real Fineract backend, or both. -->

-

## Screenshots

<!-- Add screenshots or a short recording for UI changes. Write "Not applicable" for non-UI changes. -->

## Checklist

<!-- Check each item, or explain why it does not apply. -->

- [ ] I did not hand-edit generated files under `src/app/api/`.
- [ ] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [ ] User-facing strings use translation keys.
- [ ] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant.
- [ ] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.
