### PR TITLE
chore: roll up five unsigned contributor PRs onto signed commits

### DIFF
--- a/src/app/features/accounting/charges/charges-list.component.spec.ts
+++ b/src/app/features/accounting/charges/charges-list.component.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { ChargesListComponent } from './charges-list.component';
+import { ChargesService } from '../../../api';
+import { provideIonicTesting } from '../../../testing/ionic-testing';
+import { provideTranslateTesting } from '../../../testing/i18n-testing';
+
+describe('ChargesListComponent', () => {
+  let component: ChargesListComponent;
+  let fixture: ComponentFixture<ChargesListComponent>;
+  let serviceSpy: jasmine.SpyObj<ChargesService>;
+
+  const charges = [{ id: 1, name: 'Processing fee', amount: 10 }];
+
+  beforeEach(async () => {
+    serviceSpy = jasmine.createSpyObj('ChargesService', ['getCharges']);
+    serviceSpy.getCharges.and.returnValue(
+      of(charges) as unknown as ReturnType<ChargesService['getCharges']>,
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [ChargesListComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideIonicTesting(),
+        ...provideTranslateTesting(),
+        { provide: ChargesService, useValue: serviceSpy },
+        { provide: Router, useValue: jasmine.createSpyObj('Router', ['navigate']) },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChargesListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('loads charges on init', () => {
+    expect(serviceSpy.getCharges).toHaveBeenCalledTimes(1);
+    expect(component.charges()).toEqual(charges);
+    expect(component.hasError()).toBeFalse();
+  });
+
+  it('shows a load error instead of an empty table', () => {
+    serviceSpy.getCharges.and.returnValue(
+      throwError(() => new Error('boom')) as unknown as ReturnType<ChargesService['getCharges']>,
+    );
+
+    component.onRetry();
+    fixture.detectChanges();
+
+    expect(component.hasError()).toBeTrue();
+    expect(component.charges()).toEqual([]);
+    expect(fixture.nativeElement.querySelector('[data-testid="data-table-error"]')).not.toBeNull();
+  });
+
+  it('clears the error after a successful retry', () => {
+    serviceSpy.getCharges.and.returnValue(
+      throwError(() => new Error('boom')) as unknown as ReturnType<ChargesService['getCharges']>,
+    );
+    component.onRetry();
+    expect(component.hasError()).toBeTrue();
+
+    serviceSpy.getCharges.and.returnValue(
+      of(charges) as unknown as ReturnType<ChargesService['getCharges']>,
+    );
+
+    component.onRetry();
+
+    expect(component.hasError()).toBeFalse();
+    expect(component.charges()).toEqual(charges);
+  });
+});

--- a/src/app/features/accounting/charges/charges-list.component.ts
+++ b/src/app/features/accounting/charges/charges-list.component.ts
@@ -54,9 +54,11 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
       [columns]="columns"
       [data]="charges()"
       [totalRecords]="charges().length"
+      [hasError]="hasError()"
       [showSearch]="true"
       [localLogic]="true"
       (create)="onCreateCharge()"
+      (retry)="onRetry()"
     >
       <ng-template appCellTemplate="amount" let-charge>
         @if (
@@ -104,6 +106,7 @@ export class ChargesListComponent implements OnInit {
   ];
 
   readonly charges = signal<ChargeData[]>([]);
+  readonly hasError = signal(false);
 
   ngOnInit(): void {
     this.loadCharges();
@@ -112,10 +115,18 @@ export class ChargesListComponent implements OnInit {
   private loadCharges(): void {
     this.chargesService.getCharges().subscribe({
       next: (data) => {
+        this.hasError.set(false);
         this.charges.set(data || []);
       },
-      error: (err) => console.error('Failed to load charges', err),
+      error: () => {
+        this.hasError.set(true);
+        this.charges.set([]);
+      },
     });
+  }
+
+  onRetry(): void {
+    this.loadCharges();
   }
 
   onCreateCharge(): void {

--- a/src/app/features/accounting/provisioning-categories/provisioning-categories-list.component.ts
+++ b/src/app/features/accounting/provisioning-categories/provisioning-categories-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { ProvisioningCategoryService, ProvisioningCategoryData } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists provisioning categories. Categories are small master-data records
@@ -79,6 +80,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class ProvisioningCategoriesListComponent implements OnInit {
   private readonly categoryService = inject(ProvisioningCategoryService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'categoryName', label: 'PROVISIONING_CATEGORIES.NAME', sortable: true },
@@ -112,10 +115,21 @@ export class ProvisioningCategoriesListComponent implements OnInit {
   }
 
   onDelete(row: ProvisioningCategoryData): void {
-    if (!row.id || !window.confirm('Delete this provisioning category?')) return;
-    this.categoryService.deleteProvisioningcategoryCategoryId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete provisioning category', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('PROVISIONING_CATEGORIES.DELETE'),
+        message: this.translate.instant('PROVISIONING_CATEGORIES.CONFIRM_DELETE', {
+          name: row.categoryName,
+        }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.categoryService.deleteProvisioningcategoryCategoryId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete provisioning category', err),
+        });
+      });
   }
 }

--- a/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.spec.ts
+++ b/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('ProvisioningCriteriaListComponent', () => {
   let component: ProvisioningCriteriaListComponent;
   let fixture: ComponentFixture<ProvisioningCriteriaListComponent>;
   let serviceSpy: jasmine.SpyObj<ProvisioningCriteriaService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('ProvisioningCriteriaService', [
@@ -37,6 +39,8 @@ describe('ProvisioningCriteriaListComponent', () => {
       'deleteProvisioningcriteriaCriteriaId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getProvisioningcriteria.and.returnValue(
       of([{ criteriaId: 1, criteriaName: 'Default', createdBy: 'admin' }]) as unknown as ReturnType<
         ProvisioningCriteriaService['getProvisioningcriteria']
@@ -48,6 +52,7 @@ describe('ProvisioningCriteriaListComponent', () => {
       providers: [
         { provide: ProvisioningCriteriaService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -68,8 +73,8 @@ describe('ProvisioningCriteriaListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/accounting/provisioning-criteria/edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteProvisioningcriteriaCriteriaId.and.returnValue(
       of({}) as unknown as ReturnType<
         ProvisioningCriteriaService['deleteProvisioningcriteriaCriteriaId']
@@ -77,14 +82,16 @@ describe('ProvisioningCriteriaListComponent', () => {
     );
 
     component.onDelete({ criteriaId: 5, criteriaName: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteProvisioningcriteriaCriteriaId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getProvisioningcriteria).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ criteriaId: 5, criteriaName: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteProvisioningcriteriaCriteriaId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.ts
+++ b/src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { ProvisioningCriteriaService, GetProvisioningCriteriaResponse } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists provisioning criteria. The list response carries the criteria name and
@@ -79,6 +80,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class ProvisioningCriteriaListComponent implements OnInit {
   private readonly criteriaService = inject(ProvisioningCriteriaService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'criteriaName', label: 'PROVISIONING_CRITERIA.NAME', sortable: true },
@@ -112,10 +115,21 @@ export class ProvisioningCriteriaListComponent implements OnInit {
   }
 
   onDelete(row: GetProvisioningCriteriaResponse): void {
-    if (!row.criteriaId || !window.confirm('Delete this provisioning criteria?')) return;
-    this.criteriaService.deleteProvisioningcriteriaCriteriaId(row.criteriaId).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete provisioning criteria', err),
-    });
+    if (!row.criteriaId) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('PROVISIONING_CRITERIA.DELETE'),
+        message: this.translate.instant('PROVISIONING_CRITERIA.CONFIRM_DELETE', {
+          name: row.criteriaName,
+        }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.criteriaService.deleteProvisioningcriteriaCriteriaId(row.criteriaId!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete provisioning criteria', err),
+        });
+      });
   }
 }

--- a/src/app/features/interop/interop-health.component.spec.ts
+++ b/src/app/features/interop/interop-health.component.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { Subject } from 'rxjs';
+
+import { InteropHealthComponent } from './interop-health.component';
+import { InterOperationService } from '../../api';
+import { provideIonicTesting } from '../../testing/ionic-testing';
+import { provideTranslateTesting } from '../../testing/i18n-testing';
+
+const SPINNER_SELECTOR = 'ion-spinner';
+
+describe('InteropHealthComponent', () => {
+  let fixture: ComponentFixture<InteropHealthComponent>;
+  let component: InteropHealthComponent;
+  let interopService: jasmine.SpyObj<InterOperationService>;
+  let healthResponse: Subject<unknown>;
+
+  beforeEach(async () => {
+    healthResponse = new Subject<unknown>();
+    interopService = jasmine.createSpyObj('InterOperationService', ['getInteroperationHealth']);
+    interopService.getInteroperationHealth.and.returnValue(healthResponse as never);
+
+    await TestBed.configureTestingModule({
+      imports: [InteropHealthComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideIonicTesting(),
+        ...provideTranslateTesting(),
+        { provide: InterOperationService, useValue: interopService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InteropHealthComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  function checkHealth(): HTMLButtonElement {
+    const button = fixture.nativeElement.querySelector('ion-button') as HTMLButtonElement;
+    button.click();
+    fixture.detectChanges();
+    return button;
+  }
+
+  it('requests health and exposes the pending state', () => {
+    const button = checkHealth();
+
+    expect(interopService.getInteroperationHealth).toHaveBeenCalledOnceWith();
+    expect(component.isLoading()).toBeTrue();
+    expect(button.disabled).toBeTrue();
+    expect(fixture.nativeElement.querySelector(SPINNER_SELECTOR)).not.toBeNull();
+  });
+
+  it('renders the health response returned by the platform', () => {
+    const button = checkHealth();
+
+    healthResponse.next({ status: 'UP', version: '1.2.3' });
+    healthResponse.complete();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('pre')?.textContent).toContain('"status": "UP"');
+    expect(component.isLoading()).toBeFalse();
+    expect(button.disabled).toBeFalse();
+    expect(fixture.nativeElement.querySelector(SPINNER_SELECTOR)).toBeNull();
+  });
+
+  it('re-enables the health check after a failed request', () => {
+    const button = checkHealth();
+
+    healthResponse.error(new Error('unavailable'));
+    fixture.detectChanges();
+
+    expect(component.health()).toBeNull();
+    expect(component.isLoading()).toBeFalse();
+    expect(button.disabled).toBeFalse();
+    expect(fixture.nativeElement.querySelector(SPINNER_SELECTOR)).toBeNull();
+  });
+});

--- a/src/app/features/organization/account-number-formats/account-number-formats-list.component.spec.ts
+++ b/src/app/features/organization/account-number-formats/account-number-formats-list.component.spec.ts
@@ -18,83 +18,85 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ProvisioningCategoriesListComponent } from './provisioning-categories-list.component';
-import { ProvisioningCategoryService } from '../../../api';
+import { AccountNumberFormatsListComponent } from './account-number-formats-list.component';
+import { AccountNumberFormatService } from '../../../api';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
-import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { DialogService } from '../../../core/services/dialog.service';
+import { provideTranslateTesting } from '../../../testing/i18n-testing';
 
-describe('ProvisioningCategoriesListComponent', () => {
-  let component: ProvisioningCategoriesListComponent;
-  let fixture: ComponentFixture<ProvisioningCategoriesListComponent>;
-  let serviceSpy: jasmine.SpyObj<ProvisioningCategoryService>;
+describe('AccountNumberFormatsListComponent', () => {
+  let component: AccountNumberFormatsListComponent;
+  let fixture: ComponentFixture<AccountNumberFormatsListComponent>;
+  let serviceSpy: jasmine.SpyObj<AccountNumberFormatService>;
   let routerSpy: jasmine.SpyObj<Router>;
   let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
-    serviceSpy = jasmine.createSpyObj('ProvisioningCategoryService', [
-      'getProvisioningcategory',
-      'deleteProvisioningcategoryCategoryId',
+    serviceSpy = jasmine.createSpyObj('AccountNumberFormatService', [
+      'getAccountnumberformats',
+      'deleteAccountnumberformatsAccountNumberFormatId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
     dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
     dialogService.confirm.and.resolveTo(true);
-    serviceSpy.getProvisioningcategory.and.returnValue(
+    serviceSpy.getAccountnumberformats.and.returnValue(
       of([
-        { id: 1, categoryName: 'STANDARD', categoryDescription: 'Standard' },
-      ]) as unknown as ReturnType<ProvisioningCategoryService['getProvisioningcategory']>,
+        { id: 1, accountType: { id: 1, value: 'CLIENT' }, prefixType: { id: 2, value: 'OFFICE' } },
+      ]) as unknown as ReturnType<AccountNumberFormatService['getAccountnumberformats']>,
     );
 
     await TestBed.configureTestingModule({
-      imports: [ProvisioningCategoriesListComponent, TranslateModule.forRoot()],
+      imports: [AccountNumberFormatsListComponent],
       providers: [
-        { provide: ProvisioningCategoryService, useValue: serviceSpy },
+        { provide: AccountNumberFormatService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
         { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
+        ...provideTranslateTesting(),
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(ProvisioningCategoriesListComponent);
+    fixture = TestBed.createComponent(AccountNumberFormatsListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should load categories on init', () => {
+  it('should load formats on init', () => {
     expect(component).toBeTruthy();
-    expect(serviceSpy.getProvisioningcategory).toHaveBeenCalled();
-    expect(component.categories()).toHaveSize(1);
+    expect(serviceSpy.getAccountnumberformats).toHaveBeenCalled();
+    expect(component.formats()).toHaveSize(1);
   });
 
-  it('should navigate to edit with the category id', () => {
-    component.onEdit({ id: 3, categoryName: 'X' });
+  it('should navigate to edit with the format id', () => {
+    component.onEdit({ id: 3, accountType: { id: 1, value: 'LOAN' } });
     expect(routerSpy.navigate).toHaveBeenCalledWith([
-      '/accounting/provisioning-categories/edit',
+      '/organization/account-number-formats/edit',
       3,
     ]);
   });
 
-  it('should delete after confirmation and reload', async () => {
+  it('should delete after confirmation and drop the row', async () => {
     dialogService.confirm.and.resolveTo(true);
-    serviceSpy.deleteProvisioningcategoryCategoryId.and.returnValue(
+    serviceSpy.deleteAccountnumberformatsAccountNumberFormatId.and.returnValue(
       of({}) as unknown as ReturnType<
-        ProvisioningCategoryService['deleteProvisioningcategoryCategoryId']
+        AccountNumberFormatService['deleteAccountnumberformatsAccountNumberFormatId']
       >,
     );
 
-    component.onDelete({ id: 5, categoryName: 'Y' });
+    component.onDelete({ id: 1, accountType: { id: 1, value: 'CLIENT' } });
     await fixture.whenStable();
 
-    expect(serviceSpy.deleteProvisioningcategoryCategoryId).toHaveBeenCalledWith(5);
-    expect(serviceSpy.getProvisioningcategory).toHaveBeenCalledTimes(2);
+    expect(serviceSpy.deleteAccountnumberformatsAccountNumberFormatId).toHaveBeenCalledWith(1);
+    expect(component.formats()).toHaveSize(0);
   });
 
   it('should not delete when cancelled', async () => {
     dialogService.confirm.and.resolveTo(false);
-    component.onDelete({ id: 5, categoryName: 'Y' });
+    component.onDelete({ id: 1, accountType: { id: 1, value: 'CLIENT' } });
     await fixture.whenStable();
-    expect(serviceSpy.deleteProvisioningcategoryCategoryId).not.toHaveBeenCalled();
+    expect(serviceSpy.deleteAccountnumberformatsAccountNumberFormatId).not.toHaveBeenCalled();
+    expect(component.formats()).toHaveSize(1);
   });
 });

--- a/src/app/features/organization/account-number-formats/account-number-formats-list.component.ts
+++ b/src/app/features/organization/account-number-formats/account-number-formats-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { AccountNumberFormatService, GetAccountNumberFormatsIdResponse } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 @Component({
   selector: 'app-account-number-formats-list',
@@ -82,6 +83,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class AccountNumberFormatsListComponent implements OnInit {
   private readonly accountNumberFormatService = inject(AccountNumberFormatService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'accountType', label: 'ACCOUNT_NUMBER_FORMATS.ACCOUNT_TYPE', sortable: true },
@@ -116,19 +119,26 @@ export class AccountNumberFormatsListComponent implements OnInit {
 
   onDelete(row: GetAccountNumberFormatsIdResponse): void {
     if (!row.id) return;
-    const confirmed = window.confirm(
-      `Delete account number format for "${row.accountType?.value ?? row.id}"?`,
-    );
-    if (!confirmed) return;
-    this.accountNumberFormatService
-      .deleteAccountnumberformatsAccountNumberFormatId(row.id)
-      .subscribe({
-        next: () => {
-          this.formats.set(this.formats().filter((f) => f.id !== row.id));
-        },
-        error: (err: unknown) => {
-          console.error('Failed to delete account number format', err);
-        },
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('ACCOUNT_NUMBER_FORMATS.DELETE'),
+        message: this.translate.instant('ACCOUNT_NUMBER_FORMATS.CONFIRM_DELETE', {
+          name: row.accountType?.value ?? row.id,
+        }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.accountNumberFormatService
+          .deleteAccountnumberformatsAccountNumberFormatId(row.id!)
+          .subscribe({
+            next: () => {
+              this.formats.set(this.formats().filter((f) => f.id !== row.id));
+            },
+            error: (err: unknown) => {
+              console.error('Failed to delete account number format', err);
+            },
+          });
       });
   }
 }

--- a/src/app/features/organization/offices/office-form.component.spec.ts
+++ b/src/app/features/organization/offices/office-form.component.spec.ts
@@ -36,6 +36,7 @@ describe('OfficeFormComponent', () => {
   const OFFICES_PATH = '/organization/offices';
   const NEW_OFFICE = 'New Office';
   const TEST_OFFICE = 'Test Office';
+  const TEST_OPENING_DATE = '2026-06-16';
 
   beforeEach(async () => {
     officesServiceSpy = jasmine.createSpyObj('OfficesService', [
@@ -197,16 +198,17 @@ describe('OfficeFormComponent', () => {
       expect(component.officeId).toBe(12);
       expect(officesServiceSpy.getOfficesOfficeId).toHaveBeenCalledWith(12);
       expect(component.office().name).toBe(TEST_OFFICE);
+      expect(component.openingDate()).toBe(TEST_OPENING_DATE);
 
       officesServiceSpy.putOfficesOfficeId.and.returnValue(of({}) as unknown as Observable<never>);
-      component.openingDate.set('2026-06-16');
+      component.openingDate.set(TEST_OPENING_DATE);
       component.onSubmit();
 
       expect(officesServiceSpy.putOfficesOfficeId).toHaveBeenCalledWith(
         12,
         jasmine.objectContaining({
           name: TEST_OFFICE,
-          openingDate: '2026-06-16',
+          openingDate: TEST_OPENING_DATE,
         }),
       );
     });

--- a/src/app/features/organization/offices/office-form.component.ts
+++ b/src/app/features/organization/offices/office-form.component.ts
@@ -38,7 +38,7 @@ import {
   IonSelectOption,
   IonSpinner,
 } from '@ionic/angular/standalone';
-import { toIsoDate } from '../../../core/utils/date-formatter';
+import { formatArrayDate, toIsoDate } from '../../../core/utils/date-formatter';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 import {
   OfficesService,
@@ -217,9 +217,8 @@ export class OfficeFormComponent implements OnInit {
   loadOfficeData() {
     if (!this.officeId) return;
     this.officesService.getOfficesOfficeId(this.officeId).subscribe((data) => {
-      const dateArray = data.openingDate as unknown as number[];
-      if (dateArray) {
-        this.openingDate.set(toIsoDate(new Date(dateArray[0], dateArray[1] - 1, dateArray[2])));
+      if (data.openingDate) {
+        this.openingDate.set(formatArrayDate(data.openingDate));
       }
       this.office.set({
         name: data.name,

--- a/src/app/features/organization/staff/staff-form.component.spec.ts
+++ b/src/app/features/organization/staff/staff-form.component.spec.ts
@@ -74,6 +74,18 @@ describe('StaffFormComponent', () => {
     expect(officesServiceSpy.getOffices).toHaveBeenCalled();
   });
 
+  it('should format the joining date returned by the API', () => {
+    staffServiceSpy.getStaffStaffId.and.returnValue(
+      of({ joiningDate: [2026, 1, 5] }) as unknown as ReturnType<StaffService['getStaffStaffId']>,
+    );
+    component.staffId = 7;
+
+    component.loadStaffData();
+
+    expect(staffServiceSpy.getStaffStaffId).toHaveBeenCalledWith(7);
+    expect(component.joiningDate()).toBe('2026-01-05');
+  });
+
   it('should create staff with a StaffCreateRequest payload on submit', () => {
     staffServiceSpy.postStaff.and.returnValue(
       of({}) as unknown as ReturnType<StaffService['postStaff']>,

--- a/src/app/features/organization/staff/staff-form.component.ts
+++ b/src/app/features/organization/staff/staff-form.component.ts
@@ -46,6 +46,7 @@ import {
   GetOfficesResponse,
 } from '../../../api';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -301,8 +302,7 @@ export class StaffFormComponent implements OnInit {
         emailAddress: (data as Record<string, unknown>)['emailAddress'] as string | undefined,
       });
       if (data.joiningDate) {
-        const jd = data.joiningDate as unknown as number[];
-        this.joiningDate.set(toIsoDate(new Date(jd[0], jd[1] - 1, jd[2])));
+        this.joiningDate.set(formatArrayDate(data.joiningDate));
       }
     });
   }

--- a/src/app/features/products/savings-account-form.component.ts
+++ b/src/app/features/products/savings-account-form.component.ts
@@ -50,6 +50,7 @@ import {
   SavingsAccountData,
 } from '../../api';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -295,9 +296,7 @@ export class SavingsAccountFormComponent implements OnInit {
       next: (data: SavingsAccountData) => {
         const dateArray = data.timeline?.submittedOnDate as unknown as number[];
         if (dateArray) {
-          this.submittedOnDate.set(
-            toIsoDate(new Date(dateArray[0], dateArray[1] - 1, dateArray[2])),
-          );
+          this.submittedOnDate.set(formatArrayDate(dateArray));
         }
         this.account.set({
           clientId: data.clientId,

--- a/src/app/features/working-capital/breach/wc-breach-list.component.spec.ts
+++ b/src/app/features/working-capital/breach/wc-breach-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('WcBreachListComponent', () => {
   let component: WcBreachListComponent;
   let fixture: ComponentFixture<WcBreachListComponent>;
   let serviceSpy: jasmine.SpyObj<WorkingCapitalBreachService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('WorkingCapitalBreachService', [
@@ -37,6 +39,8 @@ describe('WcBreachListComponent', () => {
       'deleteWorkingCapitalBreachBreachesBreachId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getWorkingCapitalBreachBreaches.and.returnValue(
       of([{ id: 1, name: 'Covenant A', breachAmount: 1000 }]) as unknown as ReturnType<
         WorkingCapitalBreachService['getWorkingCapitalBreachBreaches']
@@ -48,6 +52,7 @@ describe('WcBreachListComponent', () => {
       providers: [
         { provide: WorkingCapitalBreachService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -68,8 +73,8 @@ describe('WcBreachListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/working-capital/breach/edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteWorkingCapitalBreachBreachesBreachId.and.returnValue(
       of({}) as unknown as ReturnType<
         WorkingCapitalBreachService['deleteWorkingCapitalBreachBreachesBreachId']
@@ -77,14 +82,16 @@ describe('WcBreachListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteWorkingCapitalBreachBreachesBreachId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getWorkingCapitalBreachBreaches).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteWorkingCapitalBreachBreachesBreachId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/working-capital/breach/wc-breach-list.component.ts
+++ b/src/app/features/working-capital/breach/wc-breach-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { WorkingCapitalBreachService, WorkingCapitalBreachData } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists working-capital covenant breach definitions. Breaches are small master-data
@@ -82,6 +83,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class WcBreachListComponent implements OnInit {
   private readonly breachService = inject(WorkingCapitalBreachService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'WC_BREACH.NAME', sortable: true },
@@ -118,10 +121,19 @@ export class WcBreachListComponent implements OnInit {
   }
 
   onDelete(row: WorkingCapitalBreachData): void {
-    if (!row.id || !window.confirm('Delete this breach definition?')) return;
-    this.breachService.deleteWorkingCapitalBreachBreachesBreachId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete breach', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('WC_BREACH.DELETE'),
+        message: this.translate.instant('WC_BREACH.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.breachService.deleteWorkingCapitalBreachBreachesBreachId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete breach', err),
+        });
+      });
   }
 }

--- a/src/app/features/working-capital/loan-products/wc-loan-products-list.component.spec.ts
+++ b/src/app/features/working-capital/loan-products/wc-loan-products-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('WcLoanProductsListComponent', () => {
   let component: WcLoanProductsListComponent;
   let fixture: ComponentFixture<WcLoanProductsListComponent>;
   let serviceSpy: jasmine.SpyObj<WorkingCapitalLoanProductsService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('WorkingCapitalLoanProductsService', [
@@ -37,6 +39,8 @@ describe('WcLoanProductsListComponent', () => {
       'deleteWorkingCapitalLoanProductsProductId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getWorkingCapitalLoanProducts.and.returnValue(
       of([
         { id: 1, name: 'WC Product A', shortName: 'WCA', principal: 5000 },
@@ -50,6 +54,7 @@ describe('WcLoanProductsListComponent', () => {
       providers: [
         { provide: WorkingCapitalLoanProductsService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -70,8 +75,8 @@ describe('WcLoanProductsListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/working-capital/loan-products/edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteWorkingCapitalLoanProductsProductId.and.returnValue(
       of({}) as unknown as ReturnType<
         WorkingCapitalLoanProductsService['deleteWorkingCapitalLoanProductsProductId']
@@ -79,14 +84,16 @@ describe('WcLoanProductsListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteWorkingCapitalLoanProductsProductId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getWorkingCapitalLoanProducts).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteWorkingCapitalLoanProductsProductId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/working-capital/loan-products/wc-loan-products-list.component.ts
+++ b/src/app/features/working-capital/loan-products/wc-loan-products-list.component.ts
@@ -19,11 +19,12 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 import {
   WorkingCapitalLoanProductsService,
   GetWorkingCapitalLoanProductsResponse,
@@ -88,6 +89,8 @@ import {
 export class WcLoanProductsListComponent implements OnInit {
   private readonly productService = inject(WorkingCapitalLoanProductsService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'WC_LOAN_PRODUCTS.NAME', sortable: true },
@@ -123,10 +126,19 @@ export class WcLoanProductsListComponent implements OnInit {
   }
 
   onDelete(row: GetWorkingCapitalLoanProductsResponse): void {
-    if (!row.id || !window.confirm('Delete this working-capital loan product?')) return;
-    this.productService.deleteWorkingCapitalLoanProductsProductId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete loan product', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('WC_LOAN_PRODUCTS.DELETE'),
+        message: this.translate.instant('WC_LOAN_PRODUCTS.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.productService.deleteWorkingCapitalLoanProductsProductId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete loan product', err),
+        });
+      });
   }
 }

--- a/src/app/features/working-capital/near-breach/wc-near-breach-list.component.spec.ts
+++ b/src/app/features/working-capital/near-breach/wc-near-breach-list.component.spec.ts
@@ -24,12 +24,14 @@ import { Router } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('WcNearBreachListComponent', () => {
   let component: WcNearBreachListComponent;
   let fixture: ComponentFixture<WcNearBreachListComponent>;
   let serviceSpy: jasmine.SpyObj<WorkingCapitalNearBreachService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('WorkingCapitalNearBreachService', [
@@ -37,6 +39,8 @@ describe('WcNearBreachListComponent', () => {
       'deleteWorkingCapitalNearBreachBreachId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getWorkingCapitalNearBreach.and.returnValue(
       of([{ id: 1, name: 'Warn A', threshold: 80 }]) as unknown as ReturnType<
         WorkingCapitalNearBreachService['getWorkingCapitalNearBreach']
@@ -48,6 +52,7 @@ describe('WcNearBreachListComponent', () => {
       providers: [
         { provide: WorkingCapitalNearBreachService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         provideNoopAnimations(),
       ],
     }).compileComponents();
@@ -68,8 +73,8 @@ describe('WcNearBreachListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/working-capital/near-breach/edit', 7]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.deleteWorkingCapitalNearBreachBreachId.and.returnValue(
       of({}) as unknown as ReturnType<
         WorkingCapitalNearBreachService['deleteWorkingCapitalNearBreachBreachId']
@@ -77,8 +82,16 @@ describe('WcNearBreachListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteWorkingCapitalNearBreachBreachId).toHaveBeenCalledWith(5);
     expect(serviceSpy.getWorkingCapitalNearBreach).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
+    component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
+    expect(serviceSpy.deleteWorkingCapitalNearBreachBreachId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/working-capital/near-breach/wc-near-breach-list.component.ts
+++ b/src/app/features/working-capital/near-breach/wc-near-breach-list.component.ts
@@ -19,12 +19,13 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { WorkingCapitalNearBreachService, WorkingCapitalNearBreachData } from '../../../api';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
+import { DialogService } from '../../../core/services/dialog.service';
 
 /**
  * Lists working-capital near-breach (early-warning) threshold definitions.
@@ -79,6 +80,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class WcNearBreachListComponent implements OnInit {
   private readonly service = inject(WorkingCapitalNearBreachService);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'WC_NEAR_BREACH.NAME', sortable: true },
@@ -114,10 +117,19 @@ export class WcNearBreachListComponent implements OnInit {
   }
 
   onDelete(row: WorkingCapitalNearBreachData): void {
-    if (!row.id || !window.confirm('Delete this near-breach definition?')) return;
-    this.service.deleteWorkingCapitalNearBreachBreachId(row.id).subscribe({
-      next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete near-breach', err),
-    });
+    if (!row.id) return;
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('WC_NEAR_BREACH.DELETE'),
+        message: this.translate.instant('WC_NEAR_BREACH.CONFIRM_DELETE', { name: row.name }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.service.deleteWorkingCapitalNearBreachBreachId(row.id!).subscribe({
+          next: () => this.load(),
+          error: (err: unknown) => console.error('Failed to delete near-breach', err),
+        });
+      });
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1330,7 +1330,9 @@
     "PREFIX_TYPE": "Prefix Type",
     "SAVE": "Save",
     "CANCEL": "Cancel",
-    "DELETE_CONFIRM": "Are you sure you want to delete this format?"
+    "DELETE": "Delete",
+    "DELETE_CONFIRM": "Are you sure you want to delete this format?",
+    "CONFIRM_DELETE": "Delete the account number format for “{{name}}”? Already issued identifiers keep their current shape."
   },
   "ACCOUNTING": {
     "CREATE_GL_ACCOUNT": "Create GL Account",
@@ -1505,7 +1507,9 @@
     "FREQUENCY": "Frequency",
     "FREQUENCY_TYPE": "Frequency Type",
     "CREATE": "Create Breach Definition",
-    "EDIT": "Edit Breach Definition"
+    "EDIT": "Edit Breach Definition",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete breach definition “{{name}}”?"
   },
   "WC_NEAR_BREACH": {
     "NAME": "Name",
@@ -1513,7 +1517,9 @@
     "FREQUENCY": "Frequency",
     "FREQUENCY_TYPE": "Frequency Type",
     "CREATE": "Create Near-Breach Definition",
-    "EDIT": "Edit Near-Breach Definition"
+    "EDIT": "Edit Near-Breach Definition",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete near-breach definition “{{name}}”?"
   },
   "WC_LOAN_PRODUCTS": {
     "CREATE": "Create Loan Product",
@@ -1541,7 +1547,9 @@
     "FUND": "Fund",
     "START_DATE": "Start Date",
     "CLOSE_DATE": "Close Date",
-    "EXTERNAL_ID": "External ID"
+    "EXTERNAL_ID": "External ID",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete working-capital loan product “{{name}}”?"
   },
   "WC_LOANS": {
     "CREATE": "Create Working Capital Loan",
@@ -1862,14 +1870,18 @@
     "CREATE": "Create Provisioning Category",
     "EDIT": "Edit Provisioning Category",
     "NAME": "Category Name",
-    "DESCRIPTION": "Description"
+    "DESCRIPTION": "Description",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete provisioning category “{{name}}”?"
   },
   "PROVISIONING_CRITERIA": {
     "CREATE": "Create Provisioning Criteria",
     "EDIT": "Edit Provisioning Criteria",
     "NAME": "Criteria Name",
     "CREATED_BY": "Created By",
-    "DEFINITIONS_NOTE": "Per-category provisioning definitions and loan-product mappings are managed through the API and are preserved when editing the criteria name."
+    "DEFINITIONS_NOTE": "Per-category provisioning definitions and loan-product mappings are managed through the API and are preserved when editing the criteria name.",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete provisioning criteria “{{name}}”?"
   },
   "PROVISIONING_ENTRIES": {
     "CREATE": "Create Entry",


### PR DESCRIPTION
Rolls up the open contributor PRs whose commits carry no GPG signature, cherry-picked onto current `main` and re-signed. Every commit keeps its original author — only the committer and signature are mine, so credit and the ASF paper trail are unaffected.

Opened as a draft to get CI on the combined set. Unit tests are still running locally as I open this.

## Included

| PR | Author | Commit |
|---|---|---|
| #332 | @YinkaMetrics | `test(interop): cover health check states` |
| #333 | @YinkaMetrics | `refactor(organization): use formatArrayDate helper` |
| #334 | @YinkaMetrics | `fix(charges): show load errors and retry` |
| #345 | @Berserk-hub150 | `refactor(products): use formatArrayDate helper` |
| #366 | @HurrairaBaloch | `fix(ux): replace native confirm on accounting, organization and working-capital deletes` |

All five cherry-picked onto `main` without conflict. `lint`, `i18n:check` and `format:check` are clean on the combined branch.

## Excluded, and why

Three unsigned PRs do not apply to current `main` and are not mechanical to fix. None of these are a judgement on the change itself — they need their authors, not me:

- **#260** (@Guflly) — already on `main`. `messageFor` in `src/app/core/interceptors/error.interceptor.ts` now performs exactly this distinction via `isDomainRuleViolation`, matching on `validation.msg.domain.rule.violation` plus a populated `errors[]`. The PR and `main` arrived at the same logic independently. This should be closed as already fixed rather than merged, and #260 deserves a thank-you for getting there first.
- **#331** (@Iyamokuma) — conflicts in `src/app/layout/header.component.ts` and `navigation-config.service.spec.ts`. Both areas moved on `main` since the PR was opened. Needs a rebase by the author.
- **#335** (@YinkaMetrics) — conflicts in `products.routes.ts`. `main` has since added a `recurring-deposits/:accountId/transactions/create` route with its own guard, permission and title; this PR replaces that path with `:command`. How the guard and title carry over to the parameterised route is a design call, not a merge resolution.

The remaining open PRs (#365, #325, #311, #312, #313, #316, #207) are all signed already — the `E` status when checking locally is just an unavailable public key, not a missing signature.

## Note on shape

Five unrelated changes in one PR is not how these should normally land, and it makes a revert coarser than it ought to be. If you would rather, each commit here is standalone and cherry-picks cleanly on its own.