### PR TITLE
feat(search): expand global search to settings and navigation pages

### DIFF
--- a/e2e/global-search-nav-shortcuts.spec.ts
+++ b/e2e/global-search-nav-shortcuts.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Cover for #330 — global search reaching settings and navigation pages, not just entities.
+ *
+ * The behaviour worth pinning end to end is the part that cannot be seen from a unit test of
+ * `searchRoutes`: that a shortcut for a page the user can reach appears in the header dropdown
+ * alongside entity hits, that selecting it lands on that page, and that a page the user has no
+ * permission for is absent — the last one being a permission leak if it ever regresses, since
+ * the label alone tells an operator the screen exists.
+ *
+ * Mocked throughout; the navigation tree is built client-side, so no Fineract is needed.
+ */
+
+import { test, expect, Page } from './fixtures';
+
+const TENANT = 'default';
+const USER = 'mifos';
+const PASSWORD = 'password';
+
+/** Matches the `debounceTime(300)` in HeaderComponent, with room for the round trip. */
+const DEBOUNCE_MS = 300;
+
+async function mockSession(page: Page, permissions: string[]) {
+  // Registered first: Playwright matches handlers most-recently-registered first, so a
+  // catch-all added later would also answer /authentication and strip the permissions
+  // this spec is entirely about.
+  await page.route(/\/api\/v1\//, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+
+  await page.route('**/config.json*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ fineractApiUrl: '/api/v1', defaultTenant: TENANT }),
+    });
+  });
+
+  await page.route('**/api/v1/authentication**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        username: USER,
+        userId: 1,
+        base64EncodedAuthenticationKey: 'YmFzZTY0',
+        authenticated: true,
+        officeId: 1,
+        officeName: 'Head Office',
+        roles: [{ id: 1, name: 'Role', description: 'Role' }],
+        permissions,
+      }),
+    });
+  });
+
+  await page.route(/\/api\/v1\/businessdate/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ type: 'BUSINESS_DATE', date: [2026, 8, 16] }]),
+    });
+  });
+
+  // Entity search is not what this spec is about; an empty result set leaves only the
+  // navigation shortcuts on screen, which is exactly what is being asserted.
+  await page.route(/\/api\/v1\/search\?/, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+}
+
+async function login(page: Page, permissions: string[] = ['ALL_FUNCTIONS']) {
+  await mockSession(page, permissions);
+  await page.goto('/login');
+  await page.locator('#tenantId').fill(TENANT);
+  await page.locator('#username').fill(USER);
+  await page.locator('#password').fill(PASSWORD);
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL('/dashboard');
+}
+
+const searchBox = (page: Page) => page.getByTestId('global-search').locator('input');
+const results = (page: Page) => page.getByTestId('global-search-results');
+const offices = (page: Page) => page.getByTestId('search-result-nav-organization-offices');
+
+test.describe('Global search navigation shortcuts', () => {
+  test('offers a settings page the entity search cannot return', async ({ page }) => {
+    await login(page);
+
+    await searchBox(page).fill('Offices');
+
+    // The premise of #330: entity search answers nothing for "Offices", so before this
+    // the dropdown stayed empty and the page was only reachable through the sidebar.
+    await expect(results(page)).toBeVisible();
+    await expect(offices(page)).toBeVisible();
+  });
+
+  test('navigates to the page behind a shortcut', async ({ page }) => {
+    await login(page);
+
+    await searchBox(page).fill('Offices');
+    await expect(offices(page)).toBeVisible();
+    await offices(page).click();
+
+    await expect(page).toHaveURL('/organization/offices');
+  });
+
+  test('withholds a shortcut the user has no permission to reach', async ({ page }) => {
+    await login(page, ['READ_CLIENT']);
+
+    await searchBox(page).fill('Users');
+    await page.waitForTimeout(DEBOUNCE_MS * 3);
+
+    // A visible label is itself a disclosure — it tells an operator the screen exists and
+    // invites a click that can only end at /forbidden.
+    await expect(page.getByTestId('search-result-nav-security-users')).toBeHidden();
+  });
+});

--- a/src/app/core/services/navigation-config.service.spec.ts
+++ b/src/app/core/services/navigation-config.service.spec.ts
@@ -26,6 +26,7 @@ import {
   NavigationConfigService,
   NavItemConfig,
   filterNavItems,
+  flattenNavRoutes,
 } from './navigation-config.service';
 import type { AppConfig } from './config.service';
 import { provideTestConfig } from '../../testing/config';
@@ -89,6 +90,52 @@ describe('filterNavItems (pure function)', () => {
     ];
     const isVisible = (item: NavItemConfig) => item.requiredPermissions === undefined;
     expect(filterNavItems(items, isVisible)).toEqual([]);
+  });
+});
+
+describe('flattenNavRoutes (pure function)', () => {
+  const ORG_LABEL_KEY = 'nav.organization';
+  const OFFICES_LABEL_KEY = 'nav.offices';
+  const OFFICES_ROUTE = '/organization/offices';
+
+  it('collects leaf routes and preserves the parent group label key', () => {
+    const items: NavItemConfig[] = [
+      {
+        labelKey: ORG_LABEL_KEY,
+        children: [
+          { route: OFFICES_ROUTE, labelKey: OFFICES_LABEL_KEY },
+          { route: '/organization/staff', labelKey: 'nav.staff' },
+        ],
+      },
+    ];
+
+    expect(flattenNavRoutes(items)).toEqual([
+      {
+        route: OFFICES_ROUTE,
+        labelKey: OFFICES_LABEL_KEY,
+        groupLabelKey: ORG_LABEL_KEY,
+      },
+      {
+        route: '/organization/staff',
+        labelKey: 'nav.staff',
+        groupLabelKey: ORG_LABEL_KEY,
+      },
+    ]);
+  });
+
+  it('skips dividers and group headers without routes', () => {
+    const items: NavItemConfig[] = [
+      { labelKey: '', divider: true },
+      { labelKey: 'nav.products', children: [{ route: '/products/loan', labelKey: 'nav.loanProducts' }] },
+    ];
+
+    expect(flattenNavRoutes(items)).toEqual([
+      {
+        route: '/products/loan',
+        labelKey: 'nav.loanProducts',
+        groupLabelKey: 'nav.products',
+      },
+    ]);
   });
 });
 
@@ -483,6 +530,27 @@ describe('NavigationConfigService', () => {
 
       expect(findRoute(service.filteredNavItems(), COB_TOOLS_ROUTE)).toBeFalse();
       expect(findRoute(service.filteredNavItems(), SECURITY_USERS_ROUTE)).toBeTrue();
+    });
+  });
+
+  describe('searchRoutes', () => {
+    it('returns matching navigation shortcuts from the filtered tree', () => {
+      setPermissions(['ALL_FUNCTIONS']);
+      const results = service.searchRoutes('offices');
+      expect(results.some((result) => result.route === '/organization/offices')).toBeTrue();
+      expect(results[0]?.label).toBeTruthy();
+    });
+
+    it('excludes routes the user cannot access', () => {
+      setPermissions([]);
+      const results = service.searchRoutes('users');
+      expect(results.some((result) => result.route === '/security/users')).toBeFalse();
+    });
+
+    it('does not return the global search page itself', () => {
+      setPermissions(['ALL_FUNCTIONS']);
+      const results = service.searchRoutes('search');
+      expect(results.some((result) => result.route === '/search')).toBeFalse();
     });
   });
 });

--- a/src/app/core/services/navigation-config.service.spec.ts
+++ b/src/app/core/services/navigation-config.service.spec.ts
@@ -30,6 +30,7 @@ import {
 } from './navigation-config.service';
 import type { AppConfig } from './config.service';
 import { provideTestConfig } from '../../testing/config';
+import { provideFakeAdapters } from '../../testing/adapters';
 
 describe('filterNavItems (pure function)', () => {
   const alwaysVisible = () => true;
@@ -126,7 +127,10 @@ describe('flattenNavRoutes (pure function)', () => {
   it('skips dividers and group headers without routes', () => {
     const items: NavItemConfig[] = [
       { labelKey: '', divider: true },
-      { labelKey: 'nav.products', children: [{ route: '/products/loan', labelKey: 'nav.loanProducts' }] },
+      {
+        labelKey: 'nav.products',
+        children: [{ route: '/products/loan', labelKey: 'nav.loanProducts' }],
+      },
     ];
 
     expect(flattenNavRoutes(items)).toEqual([
@@ -182,6 +186,9 @@ describe('NavigationConfigService', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         provideTestConfig({ rbacEnabled: true, ...config }),
+        // searchRoutes matches on the translated label, because that is what the user
+        // typed; the fake adapter echoes the key, which is enough to exercise the match.
+        ...provideFakeAdapters().providers,
       ],
     });
     service = TestBed.inject(NavigationConfigService);
@@ -551,6 +558,31 @@ describe('NavigationConfigService', () => {
       setPermissions(['ALL_FUNCTIONS']);
       const results = service.searchRoutes('search');
       expect(results.some((result) => result.route === '/search')).toBeFalse();
+    });
+
+    /**
+     * Matching the section name is useful — typing "organization" should surface that
+     * section's pages — but it must never outrank a page named for the query itself,
+     * or a small limit gets filled with siblings before the page the user asked for.
+     */
+    it('ranks a page whose own name matches above one matched by its section', () => {
+      setPermissions(['ALL_FUNCTIONS']);
+
+      const results = service.searchRoutes('offices');
+      const officesIndex = results.findIndex((result) => result.route === '/organization/offices');
+      const siblingIndex = results.findIndex(
+        (result) => result.groupLabel && !result.label.toLowerCase().includes('offices'),
+      );
+
+      expect(officesIndex).toBe(0);
+      if (siblingIndex !== -1) {
+        expect(officesIndex).toBeLessThan(siblingIndex);
+      }
+    });
+
+    it('honours the limit', () => {
+      setPermissions(['ALL_FUNCTIONS']);
+      expect(service.searchRoutes('a', 3).length).toBeLessThanOrEqual(3);
     });
   });
 });

--- a/src/app/core/services/navigation-config.service.ts
+++ b/src/app/core/services/navigation-config.service.ts
@@ -18,6 +18,7 @@
  */
 
 import { InjectionToken, Injectable, Signal, computed, inject } from '@angular/core';
+import { I18N } from '../adapters';
 import { AuthService } from './auth.service';
 import { InstitutionConfigService, InstitutionFeature } from './institution-config.service';
 import { ConfigService, NavOverrides } from './config.service';
@@ -65,6 +66,36 @@ export interface NavItemConfig {
    * profile. Hidden unless the deployment sets `developerToolsEnabled`.
    */
   developerTool?: boolean;
+}
+
+/** A permission-filtered navigation leaf suitable for global search. */
+export interface NavSearchResult {
+  route: string;
+  label: string;
+  groupLabel?: string;
+  icon?: string;
+}
+
+/**
+ * Flattens a navigation tree into searchable leaf routes, carrying the parent
+ * group's label key for display context (e.g. "Organization › Offices").
+ */
+export function flattenNavRoutes(
+  items: readonly NavItemConfig[],
+  groupLabelKey?: string,
+): { route: string; labelKey: string; groupLabelKey?: string; icon?: string }[] {
+  return items.flatMap((item) => {
+    if (item.divider) {
+      return [];
+    }
+    if (item.children) {
+      return flattenNavRoutes(item.children, item.labelKey);
+    }
+    if (!item.route) {
+      return [];
+    }
+    return [{ route: item.route, labelKey: item.labelKey, groupLabelKey, icon: item.icon }];
+  });
 }
 
 /**
@@ -882,6 +913,7 @@ export class NavigationConfigService {
   private readonly institutionConfig = inject(InstitutionConfigService);
   private readonly config = inject(ConfigService);
   private readonly overrides = inject(NAV_OVERRIDES);
+  private readonly i18n = inject(I18N);
 
   /** The full, unfiltered navigation tree. */
   readonly navConfig: readonly NavItemConfig[] = NAV_CONFIG;
@@ -936,5 +968,30 @@ export class NavigationConfigService {
     }
 
     return true;
+  }
+
+  /**
+   * Returns navigation shortcuts whose translated labels match the query.
+   * Results are already filtered by the current user's permissions and institution config.
+   */
+  searchRoutes(query: string, limit = 15): NavSearchResult[] {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return [];
+    }
+
+    return flattenNavRoutes(this.filteredNavItems())
+      .filter((entry) => entry.route !== '/search')
+      .map((entry) => ({
+        route: entry.route,
+        label: this.i18n.translate(entry.labelKey),
+        groupLabel: entry.groupLabelKey ? this.i18n.translate(entry.groupLabelKey) : undefined,
+        icon: entry.icon,
+      }))
+      .filter((result) => {
+        const haystack = [result.label, result.groupLabel].filter(Boolean).join(' ').toLowerCase();
+        return haystack.includes(normalizedQuery);
+      })
+      .slice(0, limit);
   }
 }

--- a/src/app/core/services/navigation-config.service.ts
+++ b/src/app/core/services/navigation-config.service.ts
@@ -94,7 +94,16 @@ export function flattenNavRoutes(
     if (!item.route) {
       return [];
     }
-    return [{ route: item.route, labelKey: item.labelKey, groupLabelKey, icon: item.icon }];
+    // `icon` is omitted rather than set to undefined so a leaf without one has the shape
+    // its callers and specs describe, instead of a key that is present but empty.
+    return [
+      {
+        route: item.route,
+        labelKey: item.labelKey,
+        groupLabelKey,
+        ...(item.icon ? { icon: item.icon } : {}),
+      },
+    ];
   });
 }
 
@@ -980,18 +989,29 @@ export class NavigationConfigService {
       return [];
     }
 
-    return flattenNavRoutes(this.filteredNavItems())
+    const candidates = flattenNavRoutes(this.filteredNavItems())
       .filter((entry) => entry.route !== '/search')
       .map((entry) => ({
         route: entry.route,
         label: this.i18n.translate(entry.labelKey),
         groupLabel: entry.groupLabelKey ? this.i18n.translate(entry.groupLabelKey) : undefined,
         icon: entry.icon,
-      }))
-      .filter((result) => {
-        const haystack = [result.label, result.groupLabel].filter(Boolean).join(' ').toLowerCase();
-        return haystack.includes(normalizedQuery);
-      })
-      .slice(0, limit);
+      }));
+
+    // Partitioned rather than scored and sorted, because the only ordering that matters is
+    // this one: a page whose own name matches comes before a page matched only through its
+    // section. Ranking them together would let "organization" fill the whole result list
+    // with every leaf beneath Organization — and in the header, where the limit is small,
+    // that pushes the entity hits off the bottom.
+    const named = candidates.filter((result) =>
+      result.label.toLowerCase().includes(normalizedQuery),
+    );
+    const bySection = candidates.filter(
+      (result) =>
+        !result.label.toLowerCase().includes(normalizedQuery) &&
+        result.groupLabel?.toLowerCase().includes(normalizedQuery),
+    );
+
+    return [...named, ...bySection].slice(0, limit);
   }
 }

--- a/src/app/features/search/global-search.component.ts
+++ b/src/app/features/search/global-search.component.ts
@@ -22,6 +22,7 @@ import { Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { SearchAPIService, GetSearchResponse } from '../../api';
+import { NavigationConfigService, NavSearchResult } from '../../core/services/navigation-config.service';
 import { CdkTableModule } from '@angular/cdk/table';
 import {
   IonButton,
@@ -73,6 +74,7 @@ import {
               [(ngModel)]="query"
               name="query"
               required
+              (keyup.enter)="onSearch()"
             ></ion-input>
           </ion-item>
 
@@ -106,11 +108,42 @@ import {
           </div>
         }
 
-        @if (!isLoading() && searched() && results().length === 0) {
+        @if (!isLoading() && searched() && results().length === 0 && navResults().length === 0) {
           <p class="no-results">{{ 'SEARCH.NO_RESULTS' | translate }}</p>
         }
 
+        @if (!isLoading() && navResults().length > 0) {
+          <h3 class="results-section-title">{{ 'SEARCH.PAGES_SECTION' | translate }}</h3>
+          <table cdk-table [dataSource]="navResults()" class="results-table nav-results-table">
+            <ng-container cdkColumnDef="pageType">
+              <th cdk-header-cell *cdkHeaderCellDef>{{ 'SEARCH.ENTITY_TYPE' | translate }}</th>
+              <td cdk-cell *cdkCellDef="let row">{{ 'SEARCH.PAGE_TYPE' | translate }}</td>
+            </ng-container>
+
+            <ng-container cdkColumnDef="pageName">
+              <th cdk-header-cell *cdkHeaderCellDef>{{ 'SEARCH.ENTITY_NAME' | translate }}</th>
+              <td cdk-cell *cdkCellDef="let row">{{ row.label }}</td>
+            </ng-container>
+
+            <ng-container cdkColumnDef="pageSection">
+              <th cdk-header-cell *cdkHeaderCellDef>{{ 'SEARCH.SECTION' | translate }}</th>
+              <td cdk-cell *cdkCellDef="let row">{{ row.groupLabel }}</td>
+            </ng-container>
+
+            <tr cdk-header-row *cdkHeaderRowDef="navDisplayedColumns"></tr>
+            <tr
+              cdk-row
+              *cdkRowDef="let row; columns: navDisplayedColumns"
+              class="clickable-row"
+              (click)="onNavResultClick(row)"
+            ></tr>
+          </table>
+        }
+
         @if (!isLoading() && results().length > 0) {
+          @if (navResults().length > 0) {
+            <h3 class="results-section-title">{{ 'SEARCH.ENTITIES_SECTION' | translate }}</h3>
+          }
           <table cdk-table [dataSource]="results()" class="results-table">
             <ng-container cdkColumnDef="entityType">
               <th cdk-header-cell *cdkHeaderCellDef>{{ 'SEARCH.ENTITY_TYPE' | translate }}</th>
@@ -174,6 +207,14 @@ import {
       .results-table {
         width: 100%;
       }
+      .nav-results-table {
+        margin-bottom: 24px;
+      }
+      .results-section-title {
+        margin: 24px 0 12px;
+        font-size: 1rem;
+        font-weight: 600;
+      }
       .clickable-row {
         cursor: pointer;
       }
@@ -185,6 +226,7 @@ import {
 })
 export class GlobalSearchComponent implements OnInit {
   private searchApiService = inject(SearchAPIService);
+  private navigationConfig = inject(NavigationConfigService);
   private router = inject(Router);
 
   query = '';
@@ -194,6 +236,7 @@ export class GlobalSearchComponent implements OnInit {
   readonly searched = signal(false);
   readonly allowedSearchTypes = signal<string[]>([]);
   readonly results = signal<GetSearchResponse[]>([]);
+  readonly navResults = signal<NavSearchResult[]>([]);
   displayedColumns = [
     'entityType',
     'entityName',
@@ -201,6 +244,7 @@ export class GlobalSearchComponent implements OnInit {
     'entityExternalId',
     'parentName',
   ];
+  navDisplayedColumns = ['pageType', 'pageName', 'pageSection'];
 
   ngOnInit(): void {
     this.searchApiService.getSearchTemplate().subscribe({
@@ -216,6 +260,7 @@ export class GlobalSearchComponent implements OnInit {
     if (!this.query) return;
     this.isLoading.set(true);
     this.searched.set(false);
+    this.navResults.set(this.navigationConfig.searchRoutes(this.query));
     const resource = this.selectedResource || undefined;
     this.searchApiService.getSearch(this.query, resource, this.exactMatch).subscribe({
       next: (data) => {
@@ -229,6 +274,10 @@ export class GlobalSearchComponent implements OnInit {
         this.searched.set(true);
       },
     });
+  }
+
+  onNavResultClick(result: NavSearchResult): void {
+    this.router.navigateByUrl(result.route);
   }
 
   onRowClick(row: GetSearchResponse): void {

--- a/src/app/features/search/global-search.component.ts
+++ b/src/app/features/search/global-search.component.ts
@@ -22,7 +22,10 @@ import { Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { SearchAPIService, GetSearchResponse } from '../../api';
-import { NavigationConfigService, NavSearchResult } from '../../core/services/navigation-config.service';
+import {
+  NavigationConfigService,
+  NavSearchResult,
+} from '../../core/services/navigation-config.service';
 import { CdkTableModule } from '@angular/cdk/table';
 import {
   IonButton,

--- a/src/app/layout/header.component.spec.ts
+++ b/src/app/layout/header.component.spec.ts
@@ -20,6 +20,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HeaderComponent } from './header.component';
 import { AuthService } from '../core/services/auth.service';
+import { NavigationConfigService } from '../core/services/navigation-config.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
 import { signal } from '@angular/core';
@@ -28,6 +29,7 @@ describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
   let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let navigationConfigSpy: jasmine.SpyObj<NavigationConfigService>;
   let translateService: TranslateService;
   let routerSpy: jasmine.SpyObj<Router>;
 
@@ -36,12 +38,15 @@ describe('HeaderComponent', () => {
       username: signal('mifos'),
       officeName: signal('Head Office'),
     });
+    navigationConfigSpy = jasmine.createSpyObj('NavigationConfigService', ['searchRoutes']);
+    navigationConfigSpy.searchRoutes.and.returnValue([]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), HeaderComponent],
       providers: [
         { provide: AuthService, useValue: authServiceSpy },
+        { provide: NavigationConfigService, useValue: navigationConfigSpy },
         { provide: Router, useValue: routerSpy },
       ],
     }).compileComponents();

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -24,12 +24,21 @@ import { AuthService } from '../core/services/auth.service';
 import { Router, RouterModule } from '@angular/router';
 import { IonIcon, IonItem, IonLabel, IonList, IonSearchbar } from '@ionic/angular/standalone';
 import { FormsModule } from '@angular/forms';
-import { Subject, debounceTime, distinctUntilChanged, switchMap, of } from 'rxjs';
+import { Subject, debounceTime, distinctUntilChanged, switchMap, of, map, catchError } from 'rxjs';
 import { GuidanceService } from '../core/services/guidance.service';
 import { SidebarService } from '../core/services/sidebar.service';
 import { ThemeService } from '../core/services/theme.service';
 import { SearchAPIService, GetSearchResponse, BusinessDateManagementService } from '../api';
+import {
+  NavigationConfigService,
+  NavSearchResult,
+} from '../core/services/navigation-config.service';
 import { TooltipDirective } from '../shared/directives/tooltip.directive';
+
+/** Combined header search result — entity records or navigation shortcuts. */
+type HeaderSearchResult =
+  | { kind: 'entity'; entity: GetSearchResponse }
+  | { kind: 'nav'; nav: NavSearchResult };
 
 /**
  * Top-level application header component.
@@ -83,19 +92,27 @@ import { TooltipDirective } from '../shared/directives/tooltip.directive';
         <!-- Ionic has no autocomplete, so results render as a dropdown under the searchbar. -->
         @if (showResults() && searchResults().length > 0) {
           <ion-list class="search-results" role="listbox" data-testid="global-search-results">
-            @for (result of searchResults(); track result.entityId) {
+            @for (result of searchResults(); track resultTrackBy(result)) {
               <ion-item
                 button
                 role="option"
-                [attr.data-testid]="'search-result-' + result.entityId"
+                [attr.data-testid]="resultTestId(result)"
                 (click)="onResultSelected(result)"
               >
                 <ion-label>
                   <div class="search-result-item">
-                    <span class="result-type">{{ result.entityType }}</span>
-                    <span class="result-name">{{ result.entityName }}</span>
-                    @if (result.entityAccountNo) {
-                      <span class="result-acc">#{{ result.entityAccountNo }}</span>
+                    @if (result.kind === 'nav') {
+                      <span class="result-type">{{ 'SEARCH.PAGE_TYPE' | translate }}</span>
+                      <span class="result-name">{{ result.nav.label }}</span>
+                      @if (result.nav.groupLabel) {
+                        <span class="result-acc">{{ result.nav.groupLabel }}</span>
+                      }
+                    } @else {
+                      <span class="result-type">{{ result.entity.entityType }}</span>
+                      <span class="result-name">{{ result.entity.entityName }}</span>
+                      @if (result.entity.entityAccountNo) {
+                        <span class="result-acc">#{{ result.entity.entityAccountNo }}</span>
+                      }
                     }
                   </div>
                 </ion-label>
@@ -392,10 +409,11 @@ export class HeaderComponent implements OnInit {
   protected readonly themeService = inject(ThemeService);
   private readonly router = inject(Router);
   private readonly searchService = inject(SearchAPIService);
+  private readonly navigationConfig = inject(NavigationConfigService);
   private readonly businessDateService = inject(BusinessDateManagementService);
 
   searchQuery = '';
-  readonly searchResults = signal<GetSearchResponse[]>([]);
+  readonly searchResults = signal<HeaderSearchResult[]>([]);
   protected readonly showResults = signal(false);
   private searchSubject = new Subject<string>();
 
@@ -410,7 +428,16 @@ export class HeaderComponent implements OnInit {
         distinctUntilChanged(),
         switchMap((query) => {
           if (!query || query.length < 2) return of([]);
-          return this.searchService.getSearch(query, 'clients,loans,savings');
+          const navResults = this.navigationConfig.searchRoutes(query, 8).map(
+            (nav): HeaderSearchResult => ({ kind: 'nav', nav }),
+          );
+          return this.searchService.getSearch(query, 'clients,loans,savings').pipe(
+            map((entities) => [
+              ...navResults,
+              ...entities.map((entity): HeaderSearchResult => ({ kind: 'entity', entity })),
+            ]),
+            catchError(() => of(navResults)),
+          );
         }),
       )
       .subscribe((results) => {
@@ -453,30 +480,48 @@ export class HeaderComponent implements OnInit {
     setTimeout(() => this.showResults.set(false), 150);
   }
 
-  onResultSelected(result: GetSearchResponse) {
+  onResultSelected(result: HeaderSearchResult) {
     this.searchQuery = '';
     this.showResults.set(false);
 
-    switch (result.entityType) {
+    if (result.kind === 'nav') {
+      this.router.navigateByUrl(result.nav.route);
+      return;
+    }
+
+    const entity = result.entity;
+    switch (entity.entityType) {
       case 'CLIENT': {
-        this.router.navigate(['/clients/view', result.entityId]);
+        this.router.navigate(['/clients/view', entity.entityId]);
 
         break;
       }
       case 'LOAN': {
-        this.router.navigate(['/loans/view', result.entityId]);
+        this.router.navigate(['/loans/view', entity.entityId]);
 
         break;
       }
       case 'SAVINGSACCOUNT': {
         // Savings accounts are routed under products; there is no top-level /savings,
         // so the old target fell through to the wildcard and showed Not Found.
-        this.router.navigate(['/products/savings-accounts/view', result.entityId]);
+        this.router.navigate(['/products/savings-accounts/view', entity.entityId]);
 
         break;
       }
       // No default
     }
+  }
+
+  resultTrackBy(result: HeaderSearchResult): string {
+    return result.kind === 'nav'
+      ? `nav:${result.nav.route}`
+      : `entity:${result.entity.entityType}:${result.entity.entityId}`;
+  }
+
+  resultTestId(result: HeaderSearchResult): string {
+    return result.kind === 'nav'
+      ? `search-result-nav-${result.nav.route}`
+      : `search-result-${result.entity.entityId}`;
   }
 
   /**

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -37,8 +37,7 @@ import { TooltipDirective } from '../shared/directives/tooltip.directive';
 
 /** Combined header search result — entity records or navigation shortcuts. */
 type HeaderSearchResult =
-  | { kind: 'entity'; entity: GetSearchResponse }
-  | { kind: 'nav'; nav: NavSearchResult };
+  { kind: 'entity'; entity: GetSearchResponse } | { kind: 'nav'; nav: NavSearchResult };
 
 /**
  * Top-level application header component.
@@ -428,9 +427,9 @@ export class HeaderComponent implements OnInit {
         distinctUntilChanged(),
         switchMap((query) => {
           if (!query || query.length < 2) return of([]);
-          const navResults = this.navigationConfig.searchRoutes(query, 8).map(
-            (nav): HeaderSearchResult => ({ kind: 'nav', nav }),
-          );
+          const navResults = this.navigationConfig
+            .searchRoutes(query, 8)
+            .map((nav): HeaderSearchResult => ({ kind: 'nav', nav }));
           return this.searchService.getSearch(query, 'clients,loans,savings').pipe(
             map((entities) => [
               ...navResults,
@@ -519,8 +518,10 @@ export class HeaderComponent implements OnInit {
   }
 
   resultTestId(result: HeaderSearchResult): string {
+    // Slugged rather than raw: a route is full of slashes, and a testid containing them
+    // is awkward to select on from a spec.
     return result.kind === 'nav'
-      ? `search-result-nav-${result.nav.route}`
+      ? `search-result-nav-${result.nav.route.replaceAll('/', '-').replace(/^-/, '')}`
       : `search-result-${result.entity.entityId}`;
   }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2205,7 +2205,11 @@
     "ACCOUNT_NO": "Account No",
     "EXTERNAL_ID": "External ID",
     "PARENT": "Parent",
-    "NO_RESULTS": "No results found."
+    "NO_RESULTS": "No results found.",
+    "PAGES_SECTION": "Settings & Pages",
+    "ENTITIES_SECTION": "Entities",
+    "PAGE_TYPE": "Page",
+    "SECTION": "Section"
   },
   "EMAIL_CAMPAIGNS": {
     "TITLE": "Email Campaigns",


### PR DESCRIPTION
Closes #330.

Typing "Offices" or "Chart of Accounts" into the global search now returns the page itself, alongside the entity results, permission-filtered against the navigation tree the sidebar already builds. Both surfaces are covered: the header dropdown and `/search`.

## Credit

The first commit is @Iyamokuma's from #331, cherry-picked onto current `main` and re-signed. They are still its author — only the committer and the signature changed. The design is theirs: flatten the already-filtered nav tree into leaf routes, carry the parent section label for context, and match on the translated label. That is the right shape and I did not change it.

The second commit is mine and does four things it needed before it could land.

## What the follow-up commit fixes

**Two would have failed CI on #331 as it stands:**

- `NavigationConfigService` now injects `I18N`, which broke **all 36 existing specs for that service** — the TestBed has no `TranslateService` provider. They now get `provideFakeAdapters()`, whose I18n fake echoes the key, which is enough to exercise a label match.
- `flattenNavRoutes` emitted `icon: undefined` for a leaf without an icon, which failed **the two specs the same commit added**. The key is omitted now rather than present-and-empty.

**Two are behavioural:**

- Matching folded the section name into the same haystack as the page name, so `searchRoutes('organization')` matched *every leaf beneath Organization*. With the header's limit of 8 that fills the dropdown with siblings and pushes the real entity hits off the bottom. Pages named for the query now come first, section-only matches after. Partitioned rather than sorted — `toSorted` is not in this project's TS lib target, and the ordering has exactly two tiers.
- The nav testid embedded the raw route, slashes and all. Slugged, so a spec can select on it.

## Tests

`e2e/global-search-nav-shortcuts.spec.ts` covers the three things a unit test of `searchRoutes` cannot see:

- a shortcut appears for a page entity search cannot return — which is the premise of #330
- selecting it lands on that page
- a page the user has no permission for is **absent**. That one is a disclosure if it ever regresses: the label alone tells an operator the screen exists, and clicking it can only end at `/forbidden`.

Plus two unit cases on the ranking rule and the limit.

## Verified

`lint`, `format:check`, `i18n:check`, `typecheck:e2e` clean, and 1154/1154 unit tests pass. Rebased onto `main` after #390 merged, so the `SAVINGSACCOUNT` destination here is the corrected `/products/savings-accounts/view/:id`.

## Known limitation

Labels are resolved when the query runs, so a language switch does not re-translate results already on screen. In the header they are transient and the next keystroke re-resolves them; on `/search` they persist until the next search. Left as-is rather than widened into a reactive-translation change inside someone else's commit.