### PR TITLE
fix(dialogs): replace native loan and client confirmations

### DIFF
--- a/src/app/features/clients/charges/client-charges-list.component.spec.ts
+++ b/src/app/features/clients/charges/client-charges-list.component.spec.ts
@@ -24,12 +24,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('ClientChargesListComponent', () => {
   let component: ClientChargesListComponent;
   let fixture: ComponentFixture<ClientChargesListComponent>;
   let serviceSpy: jasmine.SpyObj<ClientChargesService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('ClientChargesService', [
@@ -37,6 +39,8 @@ describe('ClientChargesListComponent', () => {
       'deleteClientsClientIdChargesChargeId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getClientsClientIdCharges.and.returnValue(
       of({
         pageItems: [{ id: 1, name: 'Fee', amount: 100 }],
@@ -48,6 +52,7 @@ describe('ClientChargesListComponent', () => {
       providers: [
         { provide: ClientChargesService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ clientId: '1' }) } },
@@ -67,21 +72,22 @@ describe('ClientChargesListComponent', () => {
     expect(component.charges()).toHaveSize(1);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
     serviceSpy.deleteClientsClientIdChargesChargeId.and.returnValue(
       of({}) as unknown as ReturnType<ClientChargesService['deleteClientsClientIdChargesChargeId']>,
     );
 
     component.onDelete({ id: 5, name: 'X' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteClientsClientIdChargesChargeId).toHaveBeenCalledWith(1, 5);
     expect(serviceSpy.getClientsClientIdCharges).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, name: 'X' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteClientsClientIdChargesChargeId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/clients/charges/client-charges-list.component.ts
+++ b/src/app/features/clients/charges/client-charges-list.component.ts
@@ -23,6 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { ClientChargesService, GetClientsChargesPageItems } from '../../../api';
+import { I18N } from '../../../core/adapters';
+import { DialogService } from '../../../core/services/dialog.service';
 import { formatArrayDate } from '../../../core/utils/date-formatter';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
@@ -81,6 +83,8 @@ export class ClientChargesListComponent implements OnInit {
   private readonly clientChargesService = inject(ClientChargesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'CLIENT_CHARGES.NAME', sortable: true },
@@ -118,8 +122,18 @@ export class ClientChargesListComponent implements OnInit {
     this.router.navigate(['/clients', this.clientId, 'charges', 'create']);
   }
 
-  onDelete(row: GetClientsChargesPageItems): void {
-    if (!row.id || !window.confirm('Delete this charge?')) return;
+  async onDelete(row: GetClientsChargesPageItems): Promise<void> {
+    if (!row.id) return;
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('COMMON.DELETE'),
+      message: this.i18n.translate('CLIENT_CHARGES.CONFIRM_DELETE', {
+        name: row.name ?? '',
+        amount: row.amount ?? '',
+        dueDate: this.formatDate(row.dueDate),
+      }),
+      destructive: true,
+    });
+    if (!confirmed) return;
     this.clientChargesService
       .deleteClientsClientIdChargesChargeId(this.clientId, row.id)
       .subscribe({

--- a/src/app/features/clients/collateral/client-collateral-list.component.spec.ts
+++ b/src/app/features/clients/collateral/client-collateral-list.component.spec.ts
@@ -24,12 +24,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('ClientCollateralListComponent', () => {
   let component: ClientCollateralListComponent;
   let fixture: ComponentFixture<ClientCollateralListComponent>;
   let serviceSpy: jasmine.SpyObj<ClientCollateralManagementService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('ClientCollateralManagementService', [
@@ -37,6 +39,8 @@ describe('ClientCollateralListComponent', () => {
       'deleteClientsClientIdCollateralsCollateralId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getClientsClientIdCollaterals.and.returnValue(
       of([{ id: 1, name: 'Gold', quantity: 5 }]) as unknown as ReturnType<
         ClientCollateralManagementService['getClientsClientIdCollaterals']
@@ -48,6 +52,7 @@ describe('ClientCollateralListComponent', () => {
       providers: [
         { provide: ClientCollateralManagementService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ clientId: '1' }) } },
@@ -67,8 +72,7 @@ describe('ClientCollateralListComponent', () => {
     expect(component.collaterals()).toHaveSize(1);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
     serviceSpy.deleteClientsClientIdCollateralsCollateralId.and.returnValue(
       of({}) as unknown as ReturnType<
         ClientCollateralManagementService['deleteClientsClientIdCollateralsCollateralId']
@@ -76,14 +80,16 @@ describe('ClientCollateralListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteClientsClientIdCollateralsCollateralId).toHaveBeenCalledWith(1, 5);
     expect(serviceSpy.getClientsClientIdCollaterals).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteClientsClientIdCollateralsCollateralId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/clients/collateral/client-collateral-list.component.ts
+++ b/src/app/features/clients/collateral/client-collateral-list.component.ts
@@ -23,6 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { ClientCollateralManagementService, ClientCollateralManagementData } from '../../../api';
+import { I18N } from '../../../core/adapters';
+import { DialogService } from '../../../core/services/dialog.service';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 
@@ -80,6 +82,8 @@ export class ClientCollateralListComponent implements OnInit {
   private readonly collateralService = inject(ClientCollateralManagementService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'CLIENT_COLLATERAL.NAME', sortable: true },
@@ -116,8 +120,17 @@ export class ClientCollateralListComponent implements OnInit {
     this.router.navigate(['/clients', this.clientId, 'collaterals', 'edit', row.id]);
   }
 
-  onDelete(row: ClientCollateralManagementData): void {
-    if (!row.id || !window.confirm('Delete this collateral?')) return;
+  async onDelete(row: ClientCollateralManagementData): Promise<void> {
+    if (!row.id) return;
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('COMMON.DELETE'),
+      message: this.i18n.translate('CLIENT_COLLATERAL.CONFIRM_DELETE', {
+        name: row.name ?? '',
+        quantity: row.quantity ?? '',
+      }),
+      destructive: true,
+    });
+    if (!confirmed) return;
     this.collateralService
       .deleteClientsClientIdCollateralsCollateralId(this.clientId, row.id)
       .subscribe({

--- a/src/app/features/clients/transactions/client-transactions-list.component.spec.ts
+++ b/src/app/features/clients/transactions/client-transactions-list.component.spec.ts
@@ -24,17 +24,21 @@ import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('ClientTransactionsListComponent', () => {
   let component: ClientTransactionsListComponent;
   let fixture: ComponentFixture<ClientTransactionsListComponent>;
   let serviceSpy: jasmine.SpyObj<ClientTransactionService>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('ClientTransactionService', [
       'getClientsClientIdTransactions',
       'postClientsClientIdTransactionsTransactionId',
     ]);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getClientsClientIdTransactions.and.returnValue(
       of({
         pageItems: [{ id: 1, amount: 100, reversed: false }],
@@ -45,6 +49,7 @@ describe('ClientTransactionsListComponent', () => {
       imports: [ClientTransactionsListComponent, TranslateModule.forRoot()],
       providers: [
         { provide: ClientTransactionService, useValue: serviceSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ clientId: '1' }) } },
@@ -64,8 +69,7 @@ describe('ClientTransactionsListComponent', () => {
     expect(component.transactions()).toHaveSize(1);
   });
 
-  it('should undo a transaction after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should undo a transaction after confirmation and reload', async () => {
     serviceSpy.postClientsClientIdTransactionsTransactionId.and.returnValue(
       of({}) as unknown as ReturnType<
         ClientTransactionService['postClientsClientIdTransactionsTransactionId']
@@ -73,6 +77,7 @@ describe('ClientTransactionsListComponent', () => {
     );
 
     component.onUndo({ id: 7 });
+    await fixture.whenStable();
 
     expect(serviceSpy.postClientsClientIdTransactionsTransactionId).toHaveBeenCalledWith(
       1,
@@ -82,9 +87,10 @@ describe('ClientTransactionsListComponent', () => {
     expect(serviceSpy.getClientsClientIdTransactions).toHaveBeenCalledTimes(2);
   });
 
-  it('should not undo when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not undo when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onUndo({ id: 7 });
+    await fixture.whenStable();
     expect(serviceSpy.postClientsClientIdTransactionsTransactionId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/clients/transactions/client-transactions-list.component.ts
+++ b/src/app/features/clients/transactions/client-transactions-list.component.ts
@@ -23,6 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { ClientTransactionService, GetClientsPageItems } from '../../../api';
+import { I18N } from '../../../core/adapters';
+import { DialogService } from '../../../core/services/dialog.service';
 import { formatArrayDate } from '../../../core/utils/date-formatter';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
@@ -76,6 +78,8 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 export class ClientTransactionsListComponent implements OnInit {
   private readonly transactionService = inject(ClientTransactionService);
   private readonly route = inject(ActivatedRoute);
+  private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   readonly columns: ColumnDef[] = [
     { key: 'id', label: 'CLIENT_TRANSACTIONS.ID', sortable: true },
@@ -108,8 +112,18 @@ export class ClientTransactionsListComponent implements OnInit {
     return formatArrayDate(value);
   }
 
-  onUndo(row: GetClientsPageItems): void {
-    if (!row.id || !window.confirm('Undo this transaction?')) return;
+  async onUndo(row: GetClientsPageItems): Promise<void> {
+    if (!row.id) return;
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('CLIENT_TRANSACTIONS.UNDO'),
+      message: this.i18n.translate('CLIENT_TRANSACTIONS.CONFIRM_UNDO', {
+        id: row.id,
+        amount: row.amount ?? '',
+        date: this.formatDate(row.date),
+      }),
+      destructive: true,
+    });
+    if (!confirmed) return;
     this.transactionService
       .postClientsClientIdTransactionsTransactionId(this.clientId, row.id, 'undo')
       .subscribe({

--- a/src/app/features/loans/charges/loan-charges-list.component.ts
+++ b/src/app/features/loans/charges/loan-charges-list.component.ts
@@ -23,6 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { LoanChargesService, GetLoansLoanIdChargesChargeIdResponse } from '../../../api';
+import { I18N } from '../../../core/adapters';
+import { DialogService } from '../../../core/services/dialog.service';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 
@@ -82,6 +84,8 @@ export class LoanChargesListComponent implements OnInit {
   private readonly loanChargesService = inject(LoanChargesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'LOAN_CHARGES.TITLE', sortable: true },
@@ -112,8 +116,17 @@ export class LoanChargesListComponent implements OnInit {
     this.router.navigate(['/loans', this.loanId, 'charges', 'add']);
   }
 
-  onDelete(row: GetLoansLoanIdChargesChargeIdResponse): void {
-    if (!row.id || !window.confirm('Delete this charge?')) return;
+  async onDelete(row: GetLoansLoanIdChargesChargeIdResponse): Promise<void> {
+    if (!row.id) return;
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('COMMON.DELETE'),
+      message: this.i18n.translate('LOAN_CHARGES.DELETE_CONFIRM', {
+        name: row.name ?? '',
+        amount: row.amount ?? '',
+      }),
+      destructive: true,
+    });
+    if (!confirmed) return;
     this.loanChargesService.deleteLoansLoanIdChargesLoanChargeId(this.loanId, row.id).subscribe({
       next: () => this.load(),
       error: (err: unknown) => console.error('Failed to delete loan charge', err),

--- a/src/app/features/loans/guarantors/guarantors-list.component.spec.ts
+++ b/src/app/features/loans/guarantors/guarantors-list.component.spec.ts
@@ -24,12 +24,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('GuarantorsListComponent', () => {
   let component: GuarantorsListComponent;
   let fixture: ComponentFixture<GuarantorsListComponent>;
   let serviceSpy: jasmine.SpyObj<GuarantorsService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('GuarantorsService', [
@@ -37,6 +39,8 @@ describe('GuarantorsListComponent', () => {
       'deleteLoansLoanIdGuarantorsGuarantorId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getLoansLoanIdGuarantors.and.returnValue(
       of([{ id: 1, firstname: 'John', lastname: 'Doe', status: true }]) as unknown as ReturnType<
         GuarantorsService['getLoansLoanIdGuarantors']
@@ -48,6 +52,7 @@ describe('GuarantorsListComponent', () => {
       providers: [
         { provide: GuarantorsService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ loanId: '1' }) } },
@@ -67,21 +72,22 @@ describe('GuarantorsListComponent', () => {
     expect(component.guarantors()).toHaveSize(1);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
     serviceSpy.deleteLoansLoanIdGuarantorsGuarantorId.and.returnValue(
       of({}) as unknown as ReturnType<GuarantorsService['deleteLoansLoanIdGuarantorsGuarantorId']>,
     );
 
     component.onDelete({ id: 5, firstname: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteLoansLoanIdGuarantorsGuarantorId).toHaveBeenCalledWith(1, 5);
     expect(serviceSpy.getLoansLoanIdGuarantors).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, firstname: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteLoansLoanIdGuarantorsGuarantorId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/loans/guarantors/guarantors-list.component.ts
+++ b/src/app/features/loans/guarantors/guarantors-list.component.ts
@@ -23,6 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { GuarantorsService, GuarantorData } from '../../../api';
+import { I18N } from '../../../core/adapters';
+import { DialogService } from '../../../core/services/dialog.service';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 
@@ -89,6 +91,8 @@ export class GuarantorsListComponent implements OnInit {
   private readonly guarantorsService = inject(GuarantorsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   readonly columns: ColumnDef[] = [
     { key: 'name', label: 'GUARANTORS.NAME', sortable: false },
@@ -126,8 +130,15 @@ export class GuarantorsListComponent implements OnInit {
     this.router.navigate(['/loans', this.loanId, 'guarantors', 'edit', row.id]);
   }
 
-  onDelete(row: GuarantorData): void {
-    if (!row.id || !window.confirm('Delete this guarantor?')) return;
+  async onDelete(row: GuarantorData): Promise<void> {
+    if (!row.id) return;
+    const name = `${row.firstname ?? ''} ${row.lastname ?? ''}`.trim();
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('COMMON.DELETE'),
+      message: this.i18n.translate('GUARANTORS.CONFIRM_DELETE', { name }),
+      destructive: true,
+    });
+    if (!confirmed) return;
     this.guarantorsService.deleteLoansLoanIdGuarantorsGuarantorId(this.loanId, row.id).subscribe({
       next: () => this.load(),
       error: (err: unknown) => console.error('Failed to delete guarantor', err),

--- a/src/app/features/loans/interest-pauses/interest-pauses-list.component.spec.ts
+++ b/src/app/features/loans/interest-pauses/interest-pauses-list.component.spec.ts
@@ -24,12 +24,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('InterestPausesListComponent', () => {
   let component: InterestPausesListComponent;
   let fixture: ComponentFixture<InterestPausesListComponent>;
   let serviceSpy: jasmine.SpyObj<LoanInterestPauseService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('LoanInterestPauseService', [
@@ -37,6 +39,8 @@ describe('InterestPausesListComponent', () => {
       'deleteLoansLoanIdInterestPausesVariationId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getLoansLoanIdInterestPauses.and.returnValue(
       of([
         { id: 1, startDate: '1 January 2026', endDate: '1 February 2026' },
@@ -48,6 +52,7 @@ describe('InterestPausesListComponent', () => {
       providers: [
         { provide: LoanInterestPauseService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ loanId: '1' }) } },
@@ -73,8 +78,7 @@ describe('InterestPausesListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'interest-pauses', 'create']);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
     serviceSpy.deleteLoansLoanIdInterestPausesVariationId.and.returnValue(
       of({}) as unknown as ReturnType<
         LoanInterestPauseService['deleteLoansLoanIdInterestPausesVariationId']
@@ -82,14 +86,16 @@ describe('InterestPausesListComponent', () => {
     );
 
     component.onDelete({ id: 5 });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteLoansLoanIdInterestPausesVariationId).toHaveBeenCalledWith(1, 5);
     expect(serviceSpy.getLoansLoanIdInterestPauses).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5 });
+    await fixture.whenStable();
     expect(serviceSpy.deleteLoansLoanIdInterestPausesVariationId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/loans/interest-pauses/interest-pauses-list.component.ts
+++ b/src/app/features/loans/interest-pauses/interest-pauses-list.component.ts
@@ -23,6 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { LoanInterestPauseService, InterestPauseResponseDto } from '../../../api';
+import { I18N } from '../../../core/adapters';
+import { DialogService } from '../../../core/services/dialog.service';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 
@@ -72,6 +74,8 @@ export class InterestPausesListComponent implements OnInit {
   private readonly pauseService = inject(LoanInterestPauseService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
+  private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   loanId: number | null = null;
 
@@ -109,8 +113,17 @@ export class InterestPausesListComponent implements OnInit {
     }
   }
 
-  onDelete(row: InterestPauseResponseDto): void {
-    if (!this.loanId || !row.id || !window.confirm('Delete this interest pause?')) return;
+  async onDelete(row: InterestPauseResponseDto): Promise<void> {
+    if (!this.loanId || !row.id) return;
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('COMMON.DELETE'),
+      message: this.i18n.translate('INTEREST_PAUSES.CONFIRM_DELETE', {
+        startDate: row.startDate ?? '',
+        endDate: row.endDate ?? '',
+      }),
+      destructive: true,
+    });
+    if (!confirmed) return;
     this.pauseService.deleteLoansLoanIdInterestPausesVariationId(this.loanId, row.id).subscribe({
       next: () => this.load(),
       error: (err: unknown) => console.error('Failed to delete interest pause', err),

--- a/src/app/features/loans/post-dated-checks/post-dated-checks-list.component.spec.ts
+++ b/src/app/features/loans/post-dated-checks/post-dated-checks-list.component.spec.ts
@@ -24,12 +24,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../../core/services/dialog.service';
 
 describe('PostDatedChecksListComponent', () => {
   let component: PostDatedChecksListComponent;
   let fixture: ComponentFixture<PostDatedChecksListComponent>;
   let serviceSpy: jasmine.SpyObj<RepaymentWithPostDatedChecksService>;
   let routerSpy: jasmine.SpyObj<Router>;
+  let dialogService: jasmine.SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = jasmine.createSpyObj('RepaymentWithPostDatedChecksService', [
@@ -37,6 +39,8 @@ describe('PostDatedChecksListComponent', () => {
       'deleteLoansLoanIdPostdatedchecksPostDatedCheckId',
     ]);
     routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    dialogService = jasmine.createSpyObj('DialogService', ['confirm']);
+    dialogService.confirm.and.resolveTo(true);
     serviceSpy.getLoansLoanIdPostdatedchecks.and.returnValue(
       of([
         { id: 1, name: 'Check A', amount: 1000, accountNo: 12, date: '2026-01-01' },
@@ -50,6 +54,7 @@ describe('PostDatedChecksListComponent', () => {
       providers: [
         { provide: RepaymentWithPostDatedChecksService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: convertToParamMap({ loanId: '1' }) } },
@@ -75,8 +80,7 @@ describe('PostDatedChecksListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'post-dated-checks', 'edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    spyOn(window, 'confirm').and.returnValue(true);
+  it('should delete after confirmation and reload', async () => {
     serviceSpy.deleteLoansLoanIdPostdatedchecksPostDatedCheckId.and.returnValue(
       of({}) as unknown as ReturnType<
         RepaymentWithPostDatedChecksService['deleteLoansLoanIdPostdatedchecksPostDatedCheckId']
@@ -84,14 +88,16 @@ describe('PostDatedChecksListComponent', () => {
     );
 
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteLoansLoanIdPostdatedchecksPostDatedCheckId).toHaveBeenCalledWith(5, 1);
     expect(serviceSpy.getLoansLoanIdPostdatedchecks).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.and.resolveTo(false);
     component.onDelete({ id: 5, name: 'Y' });
+    await fixture.whenStable();
     expect(serviceSpy.deleteLoansLoanIdPostdatedchecksPostDatedCheckId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/loans/post-dated-checks/post-dated-checks-list.component.ts
+++ b/src/app/features/loans/post-dated-checks/post-dated-checks-list.component.ts
@@ -23,6 +23,8 @@ import { TranslateModule } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../../shared';
 import { DataTableComponent } from '../../../shared/components/data-table/data-table.component';
 import { RepaymentWithPostDatedChecksService, GetPostDatedChecks } from '../../../api';
+import { I18N } from '../../../core/adapters';
+import { DialogService } from '../../../core/services/dialog.service';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 
@@ -78,6 +80,8 @@ export class PostDatedChecksListComponent implements OnInit {
   private readonly checkService = inject(RepaymentWithPostDatedChecksService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
+  private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   loanId: number | null = null;
 
@@ -117,8 +121,18 @@ export class PostDatedChecksListComponent implements OnInit {
     }
   }
 
-  onDelete(row: GetPostDatedChecks): void {
-    if (!this.loanId || !row.id || !window.confirm('Delete this post-dated check?')) return;
+  async onDelete(row: GetPostDatedChecks): Promise<void> {
+    if (!this.loanId || !row.id) return;
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('COMMON.DELETE'),
+      message: this.i18n.translate('POST_DATED_CHECKS.CONFIRM_DELETE', {
+        name: row.name ?? '',
+        amount: row.amount ?? '',
+        date: row.date ?? '',
+      }),
+      destructive: true,
+    });
+    if (!confirmed) return;
     this.checkService
       .deleteLoansLoanIdPostdatedchecksPostDatedCheckId(row.id, this.loanId)
       .subscribe({

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1682,7 +1682,7 @@
     "SAVE": "Save",
     "CANCEL": "Cancel",
     "BACK": "Back to Loan",
-    "DELETE_CONFIRM": "Are you sure you want to delete this charge?"
+    "DELETE_CONFIRM": "Delete loan charge “{{name}}” for {{amount}}?"
   },
   "LOAN_ORIGINATORS": {
     "CREATE": "Create Loan Originator",
@@ -1779,13 +1779,15 @@
     "SAVINGS_ID": "Savings Account ID",
     "CLIENT_RELATIONSHIP_TYPE_ID": "Client Relationship Type",
     "AMOUNT": "Guarantee Amount",
-    "DOB": "Date of Birth"
+    "DOB": "Date of Birth",
+    "CONFIRM_DELETE": "Delete guarantor “{{name}}”?"
   },
   "INTEREST_PAUSES": {
     "TITLE": "Interest Pauses",
     "CREATE": "Add Interest Pause",
     "START_DATE": "Start Date",
-    "END_DATE": "End Date"
+    "END_DATE": "End Date",
+    "CONFIRM_DELETE": "Delete the interest pause from {{startDate}} to {{endDate}}?"
   },
   "POST_DATED_CHECKS": {
     "TITLE": "Post-Dated Checks",
@@ -1793,7 +1795,8 @@
     "NAME": "Name",
     "AMOUNT": "Amount",
     "ACCOUNT_NO": "Account No.",
-    "DATE": "Date"
+    "DATE": "Date",
+    "CONFIRM_DELETE": "Delete post-dated check “{{name}}” for {{amount}} dated {{date}}?"
   },
   "CLIENT_CHARGES": {
     "TITLE": "Client Charges",
@@ -1803,7 +1806,8 @@
     "AMOUNT": "Amount",
     "DUE_DATE": "Due Date",
     "PAID": "Paid",
-    "OUTSTANDING": "Outstanding"
+    "OUTSTANDING": "Outstanding",
+    "CONFIRM_DELETE": "Delete client charge “{{name}}” for {{amount}} due {{dueDate}}?"
   },
   "CLIENT_COLLATERAL": {
     "TITLE": "Client Collateral",
@@ -1813,7 +1817,8 @@
     "NAME": "Name",
     "QUANTITY": "Quantity",
     "UNIT_PRICE": "Unit Price",
-    "TOTAL_COLLATERAL": "Total Collateral"
+    "TOTAL_COLLATERAL": "Total Collateral",
+    "CONFIRM_DELETE": "Delete collateral “{{name}}” with quantity {{quantity}}?"
   },
   "CLIENT_TRANSACTIONS": {
     "TITLE": "Client Transactions",
@@ -1821,7 +1826,8 @@
     "DATE": "Date",
     "AMOUNT": "Amount",
     "TYPE": "Type",
-    "UNDO": "Undo"
+    "UNDO": "Undo",
+    "CONFIRM_UNDO": "Undo transaction {{id}} for {{amount}} dated {{date}}? It will remain on the account marked as reversed."
   },
   "MEETINGS": {
     "TITLE": "Meetings",


### PR DESCRIPTION
## What and why

Replace seven `window.confirm` calls on loan and client sub-screens with the app's `DialogService`. The dialogs use translated text, mark the action as destructive, and include values from the selected row so the user can verify the action before confirming.

The six screens with existing specs now cover both confirmation and cancellation.

Closes #231

## Verification

- `npm run lint`
- `npm run i18n:check`
- `npm run format:check`
- `npm run check:icons`
- `npm run check:a11y-names`
- `npm run api:surface`
- `npm run check:licenses`
- `TZ=UTC npm test -- --watch=false` (1155 tests passed)
- `npm run build`

I did not exercise the UI against a live Fineract backend.

## Screenshots

Not included. This change reuses the existing confirmation dialog without changing its appearance.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. No e2e test was added because the change reuses the existing dialog and does not change routing or backend behavior.
- [x] Commits are signed. See [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.
