### PR TITLE
fix(working-capital): register unlink-outline and record the new API surface

### DIFF
--- a/src/app/core/adapters/api/api-surface.json
+++ b/src/app/core/adapters/api/api-surface.json
@@ -666,6 +666,10 @@
   "WorkingCapitalLoanAccountLockService": [
     "postInternalWorkingCapitalLoansLoanIdPlaceLockLockOwner"
   ],
+  "WorkingCapitalLoanBreachActionsService": [
+    "getWorkingCapitalLoansLoanIdBreachActions",
+    "postWorkingCapitalLoansLoanIdBreachActions"
+  ],
   "WorkingCapitalLoanBreachScheduleService": ["getWorkingCapitalLoansLoanIdBreachSchedule"],
   "WorkingCapitalLoanCOBCatchUpService": [
     "getWorkingCapitalLoansIsCatchUpRunning",
@@ -673,10 +677,22 @@
     "postWorkingCapitalLoansCatchUp"
   ],
   "WorkingCapitalLoanChargesService": ["getWorkingCapitalLoansLoanIdCharges"],
-  "WorkingCapitalLoanDelinquencyActionsService": ["getWorkingCapitalLoansLoanIdDelinquencyActions"],
+  "WorkingCapitalLoanDelinquencyActionsService": [
+    "getWorkingCapitalLoansLoanIdDelinquencyActions",
+    "postWorkingCapitalLoansLoanIdDelinquencyActions"
+  ],
   "WorkingCapitalLoanInternalCOBApiService": [
     "deleteInternalWorkingCapitalLoansInternalLastCobRun",
     "postInternalWorkingCapitalLoansInternalLastCobRun"
+  ],
+  "WorkingCapitalLoanNearBreachActionsService": [
+    "getWorkingCapitalLoansLoanIdNearBreachActions",
+    "postWorkingCapitalLoansLoanIdNearBreachActions"
+  ],
+  "WorkingCapitalLoanOriginatorsService": [
+    "deleteWorkingCapitalLoansLoanIdOriginatorsOriginatorId",
+    "getWorkingCapitalLoansLoanIdOriginators",
+    "postWorkingCapitalLoansLoanIdOriginatorsOriginatorId"
   ],
   "WorkingCapitalLoanProductsService": [
     "deleteWorkingCapitalLoanProductsProductId",

--- a/src/app/core/icons.ts
+++ b/src/app/core/icons.ts
@@ -130,6 +130,7 @@ import {
   trashOutline,
   trendingDownOutline,
   trendingUpOutline,
+  unlinkOutline,
   walletOutline,
   warningOutline,
 } from 'ionicons/icons';
@@ -256,6 +257,7 @@ export const APP_ICONS: Record<string, string> = {
   'trash-outline': trashOutline,
   'trending-down-outline': trendingDownOutline,
   'trending-up-outline': trendingUpOutline,
+  'unlink-outline': unlinkOutline,
   'wallet-outline': walletOutline,
   'warning-outline': warningOutline,
 };


### PR DESCRIPTION
Follow-up to #408, fixing the two CI gates that the Working Capital servicing work tripped. Both are real defects rather than check noise, which is what those gates exist to demonstrate.

## 1. `unlink-outline` was never registered

`wc-loan-view` renders `<ion-icon name="unlink-outline">` on the originator detach control, but the icon was not in `APP_ICONS`.

This is not cosmetic. Ionic resolves an unregistered name by lazily **fetching an SVG over the network**, and the production CSP blocks that — see #360 for the same class of failure. The detach control therefore rendered as blank space, with nothing in the console to say why. A user looking for "detach originator" would find an unlabelled gap.

Registered in both lists in `src/app/core/icons.ts`, in the alphabetical position the file already keeps them in.

## 2. Eight operations missing from `api-surface.json`

The new breach, near-breach, delinquency-action and originator screens call eight generated operations that the manifest did not record:

```
WorkingCapitalLoanBreachActionsService.getWorkingCapitalLoansLoanIdBreachActions
WorkingCapitalLoanBreachActionsService.postWorkingCapitalLoansLoanIdBreachActions
WorkingCapitalLoanDelinquencyActionsService.postWorkingCapitalLoansLoanIdDelinquencyActions
WorkingCapitalLoanNearBreachActionsService.getWorkingCapitalLoansLoanIdNearBreachActions
WorkingCapitalLoanNearBreachActionsService.postWorkingCapitalLoansLoanIdNearBreachActions
WorkingCapitalLoanOriginatorsService.deleteWorkingCapitalLoansLoanIdOriginatorsOriginatorId
WorkingCapitalLoanOriginatorsService.getWorkingCapitalLoansLoanIdOriginators
WorkingCapitalLoanOriginatorsService.postWorkingCapitalLoansLoanIdOriginatorsOriginatorId
```

That manifest is what converts an upstream endpoint removal into a single diagnostic naming the operation and its callers, instead of compile errors scattered across every feature that used it (ADR 0003). An unrecorded call is a caller the check cannot warn about — so the gap would have gone unnoticed precisely until the moment it mattered.

Regenerated with `node scripts/check-api-surface.mjs --write`. I diffed the result rather than trusting it: **8 operations added, 0 removed**, 142 → 145 services, 564 → 572 operations. The three newly reached services are Breach, NearBreach and Originators; `WorkingCapitalLoanDelinquencyActionsService` was already recorded for its GET and gains only the POST.

## Verification

- [x] `npm run check:icons` — all names registered (115 in the registry)
- [x] `npm run api:surface` — 145 services, 572 operations, OK
- [x] `npm run lint`, `npm run format:check` clean
- [x] `npm run i18n:check`, `check:route-permissions`, `check:a11y-names`, `check:test-runner` clean
- [x] `./scripts/check-license.sh` clean
- [x] **Apache RAT** run locally with the same jar CI pins (checksum verified against `ci.yml`): Approved 734, **Unapproved 0**, Unknown 0
- [x] `npm run ga:check` — 8/9 gates, 0 blocking failures
- [x] `npm run test:unit` — 270 pass across 30 files
- [x] Commit GPG-signed

One papercut worth knowing for anyone regenerating that manifest: `--write` emits JSON that Prettier then reformats, so `npm run format` has to follow `--write` or `format:check` fails. Not fixed here to keep this diff to the two gates.
