### PR TITLE
test: migrate interop spec from Karma to Vitest

### DIFF
--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -58,7 +58,6 @@
     "src/app/features/groups/group-members-dialog.component.spec.ts",
     "src/app/features/groups/group-view.component.spec.ts",
     "src/app/features/groups/tabs/group-accounts-tab.component.spec.ts",
-    "src/app/features/interop/interop-health.component.spec.ts",
     "src/app/features/loans/bulk-reassignment/bulk-reassignment.component.spec.ts",
     "src/app/features/loans/collateral/collateral-form.component.spec.ts",
     "src/app/features/loans/collateral/collateral-list.component.spec.ts",

--- a/src/app/features/interop/interop-health.component.test.ts
+++ b/src/app/features/interop/interop-health.component.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createSpyObj, SpyObj } from '../../testing/mocks';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { Subject } from 'rxjs';
@@ -31,13 +32,13 @@ const SPINNER_SELECTOR = 'ion-spinner';
 describe('InteropHealthComponent', () => {
   let fixture: ComponentFixture<InteropHealthComponent>;
   let component: InteropHealthComponent;
-  let interopService: jasmine.SpyObj<InterOperationService>;
+  let interopService: SpyObj<InterOperationService>;
   let healthResponse: Subject<unknown>;
 
   beforeEach(async () => {
     healthResponse = new Subject<unknown>();
-    interopService = jasmine.createSpyObj('InterOperationService', ['getInteroperationHealth']);
-    interopService.getInteroperationHealth.and.returnValue(healthResponse as never);
+    interopService = createSpyObj(['getInteroperationHealth']);
+    interopService.getInteroperationHealth.mockReturnValue(healthResponse as never);
 
     await TestBed.configureTestingModule({
       imports: [InteropHealthComponent],
@@ -64,9 +65,9 @@ describe('InteropHealthComponent', () => {
   it('requests health and exposes the pending state', () => {
     const button = checkHealth();
 
-    expect(interopService.getInteroperationHealth).toHaveBeenCalledOnceWith();
-    expect(component.isLoading()).toBeTrue();
-    expect(button.disabled).toBeTrue();
+    expect(interopService.getInteroperationHealth).toHaveBeenCalledExactlyOnceWith();
+    expect(component.isLoading()).toBe(true);
+    expect(button.disabled).toBe(true);
     expect(fixture.nativeElement.querySelector(SPINNER_SELECTOR)).not.toBeNull();
   });
 
@@ -78,8 +79,8 @@ describe('InteropHealthComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('pre')?.textContent).toContain('"status": "UP"');
-    expect(component.isLoading()).toBeFalse();
-    expect(button.disabled).toBeFalse();
+    expect(component.isLoading()).toBe(false);
+    expect(button.disabled).toBe(false);
     expect(fixture.nativeElement.querySelector(SPINNER_SELECTOR)).toBeNull();
   });
 
@@ -90,8 +91,8 @@ describe('InteropHealthComponent', () => {
     fixture.detectChanges();
 
     expect(component.health()).toBeNull();
-    expect(component.isLoading()).toBeFalse();
-    expect(button.disabled).toBeFalse();
+    expect(component.isLoading()).toBe(false);
+    expect(button.disabled).toBe(false);
     expect(fixture.nativeElement.querySelector(SPINNER_SELECTOR)).toBeNull();
   });
 });


### PR DESCRIPTION
## What and why

Migrates the interop health component spec from the deprecated Karma/Jasmine runner to Vitest using the repository codemod. The migration is intentionally scoped to features/interop and preserves the existing three test cases and their behavior.

Part of #411

## Verification

- npm run test:unit — 31 files and 273 tests passed (previously 30 files and 270 tests)
- npm test -- --watch=false — 918 tests passed (previously 921)
- Total test count remained unchanged at 1,191
- npm run lint
- npm run format:check
- node scripts/check-test-runner.mjs — 191 Karma specs remaining
- npm run build
- npm run check:icons
- npm run i18n:check

## Screenshots

Not applicable — test-runner migration only; no UI behavior changed.

## Checklist

- [x] I did not hand-edit generated files under src/app/api/.
- [x] No component or service code changed; the adapter-boundary requirement is not applicable.
- [x] No user-facing strings changed.
- [x] The existing three interop health tests were migrated without semantic changes.
- [x] No UI workflow changed; e2e coverage is not applicable.
- [x] The commit is signed.

