### PR TITLE
fix: record maker-checker task rejections

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1654,11 +1654,6 @@
       "count": 1
     }
   },
-  "src/app/features/tasks/checker-inbox/checker-inbox.component.ts": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/features/tasks/checker-inbox/view-payload-dialog.component.spec.ts": {
     "no-restricted-imports": {
       "count": 1

--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.test.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { MakerCheckerOr4EyeFunctionalityService } from '../../../api';
+import { provideFakeAdapters } from '../../../testing/adapters';
+import { provideTranslateTesting } from '../../../testing/i18n-testing';
+import { createSpyObj, SpyObj } from '../../../testing/mocks';
+import { CheckerInboxComponent } from './checker-inbox.component';
+
+describe('CheckerInboxComponent', () => {
+  let component: CheckerInboxComponent;
+  let fixture: ComponentFixture<CheckerInboxComponent>;
+  let serviceSpy: SpyObj<MakerCheckerOr4EyeFunctionalityService>;
+  let adapters: ReturnType<typeof provideFakeAdapters>;
+
+  beforeEach(async () => {
+    serviceSpy = createSpyObj([
+      'getMakercheckers',
+      'postMakercheckersAuditId',
+      'deleteMakercheckersAuditId',
+    ]);
+    serviceSpy.getMakercheckers.mockReturnValue(
+      of([]) as unknown as ReturnType<MakerCheckerOr4EyeFunctionalityService['getMakercheckers']>,
+    );
+    serviceSpy.postMakercheckersAuditId.mockReturnValue(
+      of({}) as unknown as ReturnType<
+        MakerCheckerOr4EyeFunctionalityService['postMakercheckersAuditId']
+      >,
+    );
+    adapters = provideFakeAdapters();
+
+    await TestBed.configureTestingModule({
+      imports: [CheckerInboxComponent],
+      providers: [
+        ...provideTranslateTesting(),
+        ...adapters.providers,
+        { provide: MakerCheckerOr4EyeFunctionalityService, useValue: serviceSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CheckerInboxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('rejects through the reject command without deleting the audit entry', async () => {
+    adapters.overlay.nextModalResult = true;
+
+    await component.onReject({ id: 7 });
+
+    expect(serviceSpy.postMakercheckersAuditId).toHaveBeenCalledWith(7, 'reject');
+    expect(serviceSpy.deleteMakercheckersAuditId).not.toHaveBeenCalled();
+    expect(serviceSpy.getMakercheckers).toHaveBeenCalledTimes(2);
+    expect(adapters.overlay.lastToast).toEqual(
+      expect.objectContaining({
+        message: 'CHECKER_INBOX.REJECT_SUCCESS',
+        cssClass: 'success-toast',
+      }),
+    );
+  });
+
+  it('uses the standard destructive confirmation dialog', async () => {
+    adapters.overlay.nextModalResult = false;
+
+    await component.onReject({ id: 7 });
+
+    expect(adapters.overlay.lastModal?.inputs?.['data']).toEqual(
+      expect.objectContaining({
+        title: 'CHECKER_INBOX.REJECT_TITLE',
+        message: 'CHECKER_INBOX.CONFIRM_REJECT',
+        destructive: true,
+      }),
+    );
+  });
+
+  it('does not call either endpoint when rejection is cancelled', async () => {
+    adapters.overlay.nextModalResult = false;
+
+    await component.onReject({ id: 7 });
+
+    expect(serviceSpy.postMakercheckersAuditId).not.toHaveBeenCalled();
+    expect(serviceSpy.deleteMakercheckersAuditId).not.toHaveBeenCalled();
+  });
+
+  it('reports a failed rejection without refreshing the inbox', async () => {
+    adapters.overlay.nextModalResult = true;
+    serviceSpy.postMakercheckersAuditId.mockReturnValue(
+      throwError(() => new Error('request failed')) as ReturnType<
+        MakerCheckerOr4EyeFunctionalityService['postMakercheckersAuditId']
+      >,
+    );
+
+    await component.onReject({ id: 7 });
+
+    expect(serviceSpy.getMakercheckers).toHaveBeenCalledTimes(1);
+    expect(adapters.overlay.lastToast).toEqual(
+      expect.objectContaining({
+        message: 'CHECKER_INBOX.REJECT_ERROR',
+        cssClass: 'error-toast',
+      }),
+    );
+  });
+});

--- a/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
+++ b/src/app/features/tasks/checker-inbox/checker-inbox.component.ts
@@ -19,20 +19,20 @@
 
 import { Component, inject, signal } from '@angular/core';
 
-import { TranslateModule } from '@ngx-translate/core';
 import { Subject, of } from 'rxjs';
 import { catchError, map, startWith, switchMap, tap } from 'rxjs/operators';
 import { DataTableComponent, CellTemplateDirective, ColumnDef } from '../../../shared';
 import { MakerCheckerOr4EyeFunctionalityService, AuditData } from '../../../api';
 import { ViewPayloadDialogComponent } from './view-payload-dialog.component';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
+import { I18N, TranslatePipe } from '../../../core/adapters';
 import { NotificationService } from '../../../core/services/notification.service';
 import { DialogService } from '../../../core/services/dialog.service';
 
 @Component({
   selector: 'app-checker-inbox',
   standalone: true,
-  imports: [TranslateModule, DataTableComponent, CellTemplateDirective, IonIcon, IonButton],
+  imports: [TranslatePipe, DataTableComponent, CellTemplateDirective, IonIcon, IonButton],
   template: `
     <app-data-table
       [hasError]="hasError()"
@@ -54,7 +54,7 @@ import { DialogService } from '../../../core/services/dialog.service';
             fill="clear"
             color="primary"
             (click)="onViewPayload(task)"
-            [attr.aria-label]="'CHECKER_INBOX.VIEW_PAYLOAD' | translate"
+            [attr.aria-label]="'CHECKER_INBOX.VIEW_PAYLOAD' | appTranslate"
           >
             <ion-icon name="eye-outline"></ion-icon>
           </ion-button>
@@ -62,7 +62,7 @@ import { DialogService } from '../../../core/services/dialog.service';
             fill="clear"
             class="approve-btn"
             (click)="onApprove(task)"
-            [attr.aria-label]="'ACTIONS.APPROVE' | translate"
+            [attr.aria-label]="'ACTIONS.APPROVE' | appTranslate"
           >
             <ion-icon name="checkmark-circle-outline"></ion-icon>
           </ion-button>
@@ -70,7 +70,7 @@ import { DialogService } from '../../../core/services/dialog.service';
             fill="clear"
             color="danger"
             (click)="onReject(task)"
-            [attr.aria-label]="'ACTIONS.REJECT' | translate"
+            [attr.aria-label]="'ACTIONS.REJECT' | appTranslate"
           >
             <ion-icon name="close-circle-outline"></ion-icon>
           </ion-button>
@@ -97,6 +97,7 @@ export class CheckerInboxComponent {
   private readonly makerCheckerService = inject(MakerCheckerOr4EyeFunctionalityService);
   private readonly notifications = inject(NotificationService);
   private readonly dialogService = inject(DialogService);
+  private readonly i18n = inject(I18N);
 
   columns: ColumnDef[] = [
     { key: 'id', label: 'COMMON.ID', sortable: true },
@@ -161,18 +162,23 @@ export class CheckerInboxComponent {
     });
   }
 
-  onReject(task: Record<string, unknown>) {
-    if (confirm('Are you sure you want to reject this task?')) {
-      this.makerCheckerService.deleteMakercheckersAuditId(task['id'] as number).subscribe({
-        next: () => {
-          this.notifications.success('Task rejected successfully');
-          this.refreshSubject.next();
-        },
-        error: () => {
-          this.notifications.error('Failed to reject task');
-        },
-      });
-    }
+  async onReject(task: Record<string, unknown>): Promise<void> {
+    const confirmed = await this.dialogService.confirm({
+      title: this.i18n.translate('CHECKER_INBOX.REJECT_TITLE'),
+      message: this.i18n.translate('CHECKER_INBOX.CONFIRM_REJECT'),
+      destructive: true,
+    });
+    if (!confirmed) return;
+
+    this.makerCheckerService.postMakercheckersAuditId(task['id'] as number, 'reject').subscribe({
+      next: () => {
+        this.notifications.success(this.i18n.translate('CHECKER_INBOX.REJECT_SUCCESS'));
+        this.refreshSubject.next();
+      },
+      error: () => {
+        this.notifications.error(this.i18n.translate('CHECKER_INBOX.REJECT_ERROR'));
+      },
+    });
   }
 
   formatDate(dateArray: unknown): string {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2074,7 +2074,11 @@
     "NO_STEPS": "No steps configured for this job."
   },
   "CHECKER_INBOX": {
-    "VIEW_PAYLOAD": "View payload"
+    "VIEW_PAYLOAD": "View payload",
+    "REJECT_TITLE": "Reject task",
+    "CONFIRM_REJECT": "Are you sure you want to reject this task?",
+    "REJECT_SUCCESS": "Task rejected successfully",
+    "REJECT_ERROR": "Failed to reject task"
   },
   "BUSINESS_DATES": {
     "TITLE": "Business Date Management",


### PR DESCRIPTION
## What and why

Rejecting a maker-checker task used the DELETE endpoint, removing the audit entry instead of recording the rejection. This change sends the supported `reject` command through the maker-checker POST endpoint so the decision remains in the audit trail.

It also replaces the browser-native confirmation and hardcoded reject messages with the standard translated destructive dialog, and adds regression coverage that explicitly proves the DELETE endpoint is never called.

Closes #280

## Verification

- `npm run test:unit` — 47 files, 364 tests passed
- `npm test -- --watch=false` — 868 tests passed
- `npm run lint:prune`
- `npm run build`
- `npm run i18n:check`
- `npm run check:icons`
- `npm run check:test-runner`
- Changed files pass Prettier and `git diff --check`
- UI behavior exercised with adapter-backed component tests; no real Fineract backend was required

## Screenshots

Not applicable — this changes confirmation behavior and API semantics without changing layout.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. Not added: the API contract and confirm/cancel behavior are covered by component tests; no new route or backend workflow was introduced.
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.