### PR TITLE
test: migrate errors spec from Karma to Vitest

### DIFF
--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -52,7 +52,6 @@
     "src/app/features/clients/tabs/client-documents-list.component.spec.ts",
     "src/app/features/clients/transactions/client-transactions-list.component.spec.ts",
     "src/app/features/dashboard/system-status.component.spec.ts",
-    "src/app/features/errors/access-denied.component.spec.ts",
     "src/app/features/groups/group-action-dialog.component.spec.ts",
     "src/app/features/groups/group-form.component.spec.ts",
     "src/app/features/groups/group-members-dialog.component.spec.ts",

--- a/src/app/features/errors/access-denied.component.test.ts
+++ b/src/app/features/errors/access-denied.component.test.ts
@@ -57,7 +57,7 @@ describe('AccessDeniedComponent', () => {
 
   it('states what happened in a single top-level heading', () => {
     const headings = host.querySelectorAll('h1');
-    expect(headings).toHaveSize(1);
+    expect(headings).toHaveLength(1);
     expect(headings[0].textContent?.trim()).toBeTruthy();
   });
 


### PR DESCRIPTION
## What and why

Migrates the `features/errors` access-denied component test from Karma/Jasmine to Vitest as part of the ongoing test-runner migration.

The existing test behavior is preserved, with the Jasmine-specific `toHaveSize` matcher replaced by Vitest-compatible `toHaveLength`.

Part of #411

## Verification

- `npm run test:unit -- --watch=false`
  - 48 test files passed
  - 374 tests passed
- `npm test -- --watch=false --browsers=ChromeHeadless`
  - 858 tests passed
- Verified total test count is preserved:
  - Before: 364 Vitest + 868 Karma = 1232 tests
  - After: 374 Vitest + 858 Karma = 1232 tests
- `npm run lint`
- `npm run format:check`
- `node scripts/check-test-runner.mjs`
- `npm run build`
- `npm run check:icons`
- `npm run i18n:check`
- No UI workflow was changed; verification was limited to automated tests and build/static checks.

## Screenshots

Not applicable — test-runner migration only; no UI behavior changed.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] No new component or service code was added, so the adapter-boundary requirement is not applicable.
- [x] No user-facing strings were added or changed.
- [x] I updated the existing tests by migrating them from Karma/Jasmine to Vitest.
- [x] No UI workflow was changed, so additional e2e coverage is not applicable.
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.