### PR TITLE
fix(organization): title the loan portfolio summary route

### DIFF
--- a/src/app/features/organization/organization.routes.ts
+++ b/src/app/features/organization/organization.routes.ts
@@ -170,6 +170,7 @@ export const ORGANIZATION_ROUTES: Routes = [
     path: 'loan-portfolio-summary',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_LOAN' },
+    title: 'ORGANIZATION.LOAN_PORTFOLIO_SUMMARY',
     loadComponent: () =>
       import('./loan-portfolio-summary/loan-portfolio-summary.component').then(
         (m) => m.LoanPortfolioSummaryComponent,


### PR DESCRIPTION
One line. Refs #421.

The Loan Portfolio Summary screen went in with #419 without a route `title`, so it inherited `Organization` for the browser tab and — because the breadcrumb added in the same PR is derived from that same route metadata — rendered with no breadcrumb at all.

Before / after, captured against a live Fineract instance:

| | |
|---|---|
| Every other Organization screen, still untitled (#421) | ![Offices, no breadcrumb](https://raw.githubusercontent.com/Aman-Mittal/fineract-backoffice-ui/assets/issue-screenshots/gap-offices.png) |
| This screen, with the title | ![Loan portfolio summary, breadcrumb present](https://raw.githubusercontent.com/Aman-Mittal/fineract-backoffice-ui/assets/issue-screenshots/ok-portfolio-summary.png) |

The tab title goes from `Organization · Fineract` to `Loan Portfolio Summary · Fineract`.

**Why only this route.** The other twenty in `organization.routes.ts` are #421, deliberately left as a good-first-issue so the section can be picked up as its own piece of work — and this commit gives whoever takes it a worked example in the file they will be editing. This one is fixed here rather than there because the screen was added in the same change that added the breadcrumb; shipping the trail without making the new screen appear in it was an omission, not a decision.

`lint`, `format:check`, `i18n:check` and `check:route-permissions` pass. The translation key `ORGANIZATION.LOAN_PORTFOLIO_SUMMARY` already exists — it is what the sidebar entry uses.
