### PR TITLE
fix(layout): clear the render-time interval when the header is destroyed

### DIFF
--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnDestroy, OnInit } from '@angular/core';
 
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { AuthService } from '../core/services/auth.service';
@@ -401,7 +401,7 @@ type HeaderSearchResult =
     `,
   ],
 })
-export class HeaderComponent implements OnInit {
+export class HeaderComponent implements OnInit, OnDestroy {
   protected readonly authService = inject(AuthService);
   protected readonly translate = inject(TranslateService);
   protected readonly guidanceService = inject(GuidanceService);
@@ -419,6 +419,7 @@ export class HeaderComponent implements OnInit {
 
   readonly businessDate = signal<string>('-');
   readonly renderTime = signal<string>('-');
+  private renderTimeInterval: ReturnType<typeof setInterval> | null = null;
 
   ngOnInit(): void {
     this.loadSystemInfo();
@@ -462,7 +463,17 @@ export class HeaderComponent implements OnInit {
       );
     };
     updateTime();
-    setInterval(updateTime, 60_000);
+    // Held so ngOnDestroy can stop it — the header is destroyed on sign-out and
+    // rebuilt on the next sign-in; an uncleared interval would keep ticking (and
+    // writing to a signal no one reads) once per session.
+    this.renderTimeInterval = setInterval(updateTime, 60_000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.renderTimeInterval !== null) {
+      clearInterval(this.renderTimeInterval);
+      this.renderTimeInterval = null;
+    }
   }
 
   onSearchInput(event: Event) {


### PR DESCRIPTION
## What

Closes #423. `HeaderComponent` now implements `OnDestroy`, holds the interval id in a nullable field, and clears it on destroy.

## Why

The header is destroyed and rebuilt whenever the user leaves the authenticated layout — sign-out is the ordinary case. The uncleared interval kept ticking forever, holding a closure over the destroyed component's `renderTime` signal, one more per re-login, still firing in background tabs.

This was the only `setInterval` in `src/app`; with this change none survive their host.

## Verification

- `npm run lint` clean
- `ng build` succeeds
- Unit suite: **431 passed**, with the same single pre-existing failure (`loan-portfolio-summary`) present on main with and without this change — unrelated to this fix