### PR TITLE
ci: verify commits against GitHub's own verdict, and explain failures on the PR

### DIFF
--- a/.github/scripts/check-commit-signatures.js
+++ b/.github/scripts/check-commit-signatures.js
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Fails a pull request whose commits GitHub does not report as **Verified**, and explains on
+ * the pull request itself what to do about it.
+ *
+ * ## Why this replaced a local git check
+ *
+ * The previous gate ran `scripts/verify-signed-commits.sh` on the runner and passed anything
+ * whose `%G?` was not `N`. That asks "is a signature attached?". GitHub asks something
+ * stricter: "was this made by a key registered to a GitHub account, whose verified email
+ * matches the committer?" A commit passes the first and fails the second routinely — a
+ * signature made with a key GitHub has never seen, or a `user.email` that is not an address
+ * on any account, both produce a signed-looking commit that shows as Unverified.
+ *
+ * A runner holds no contributor public keys, so it cannot answer the second question itself.
+ * It does not need to: GitHub already computed the answer and hands it over per commit as
+ * `commit.verification`. This asks for that and believes it.
+ *
+ * ## Why `pull_request_target`, and what makes it safe here
+ *
+ * Under `pull_request`, the workflow *and* the scripts it calls come from the merge ref —
+ * the pull request's own copy. A contributor can therefore edit the gate that is meant to
+ * gate them, which is not a hypothetical: it is how a signed-commit check came to accept any
+ * `gpgsig` header.
+ *
+ * `pull_request_target` runs the base repository's copy of the workflow and carries a token
+ * that can comment, which a fork's `pull_request` run deliberately does not. The hazard of
+ * that trigger — "pwn request" — is checking out or executing the pull request's code while
+ * holding that token. This does neither: the calling workflow's checkout is ref-less and
+ * sparse (`.github/scripts` from the base branch), and the only input read here is the API
+ * response, never the diff, never the commit tree.
+ *
+ * Commit *messages* are attacker-controlled and do reach the comment body, so subjects are
+ * truncated and their `@` and `#` references defused before they are posted.
+ *
+ * Two consequences of the trigger, both worth knowing:
+ *
+ *   - Changes to this file take effect only once merged. A pull request editing it cannot
+ *     test it — which is the entire point.
+ *   - This is early, explanatory feedback, not the last line of defence. Branch protection's
+ *     "Require signed commits" is enforced by GitHub itself and cannot be edited by any
+ *     workflow; this check exists so a contributor learns *why* before they hit that wall.
+ */
+
+const MARKER = '<!-- signed-commits -->';
+
+/** GitHub caps `listCommits` at 250; past that the check reports what it could see. */
+const MAX_COMMITS = 250;
+
+const CONTRIBUTING =
+  'https://github.com/apache/fineract-backoffice-ui/blob/main/CONTRIBUTING.md#commit-signing';
+
+/**
+ * What each `verification.reason` actually means for the contributor, and what fixes it.
+ *
+ * These are not interchangeable, which is why a blanket "please sign your commits" has such a
+ * poor hit rate. `no_user` in particular is *not* a signing problem — the signature is fine
+ * and the identity is wrong — so telling someone to set up signing sends them to re-do the
+ * one part they already got right.
+ */
+const REASONS = {
+  unsigned: {
+    summary: 'These commits carry no signature at all.',
+    fix: `Set up commit signing, then re-sign the commits already on this branch. [CONTRIBUTING.md](${CONTRIBUTING}) has the setup.`,
+  },
+  no_user: {
+    summary:
+      'These commits **are signed**, but the committer email is not an address GitHub can match to any account — so it never gets as far as checking the key. Note that the commits are not attributed to your GitHub profile either, which is the same cause.',
+    fix: 'This is an identity problem, not a signing one — your signing setup is fine. Check `git config user.email` and set it to an address that is **verified on your GitHub account** (Settings → Emails), then re-sign.',
+  },
+  unverified_email: {
+    summary:
+      'The committer email is on your GitHub account, but that address has not been verified.',
+    fix: 'Verify the address under Settings → Emails, then re-sign. No change to your signing key is needed.',
+  },
+  unknown_key: {
+    summary: 'The signing key is not registered on your GitHub account.',
+    fix: 'Add the public half of your signing key under Settings → SSH and GPG keys, as a **signing** key, then re-sign.',
+  },
+  unknown_signature_type: {
+    summary: 'GitHub does not recognise this signature type.',
+    fix: 'Sign with GPG or SSH — see [CONTRIBUTING.md](' + CONTRIBUTING + ').',
+  },
+  expired_key: {
+    summary: 'The signing key has expired.',
+    fix: 'Extend or replace the key, upload the new public key to GitHub, then re-sign.',
+  },
+  not_signing_key: {
+    summary: 'The key is on your account, but not marked as a signing key.',
+    fix: 'Add it under Settings → SSH and GPG keys as a signing key, then re-sign.',
+  },
+  bad_signature: {
+    summary: 'The signature does not match the commit contents.',
+    fix: 'Re-sign the commits.',
+  },
+  malformed_signature: {
+    summary: 'The signature could not be parsed.',
+    fix: 'Re-sign the commits.',
+  },
+};
+
+const FALLBACK = {
+  summary: 'GitHub could not verify the signature on these commits.',
+  fix: `See [CONTRIBUTING.md](${CONTRIBUTING}) for the expected signing setup.`,
+};
+
+/**
+ * Commit subjects are written by the contributor and land in a comment this repository posts.
+ * Keeping the characters but breaking the reference with a zero-width space means a subject
+ * cannot turn into a notification for an unrelated person or a cross-link to someone's issue.
+ */
+function defuseReferences(text) {
+  return text.replace(/@(?=[A-Za-z0-9])/g, '@​').replace(/#(?=\d)/g, '#​');
+}
+
+function subjectOf(commit) {
+  const subject = (commit.commit?.message ?? '').split('\n', 1)[0];
+  const clipped = subject.length > 72 ? `${subject.slice(0, 71)}…` : subject;
+  return defuseReferences(clipped);
+}
+
+/** Groups the unverified commits by reason, so each remedy is stated once. */
+function groupByReason(unverified) {
+  const groups = new Map();
+  for (const commit of unverified) {
+    const reason = commit.commit?.verification?.reason ?? 'unknown';
+    if (!groups.has(reason)) groups.set(reason, []);
+    groups.get(reason).push(commit);
+  }
+  return groups;
+}
+
+function buildBody({ unverified, total, truncated }) {
+  const groups = groupByReason(unverified);
+  const plural = unverified.length === 1 ? 'commit is' : 'commits are';
+
+  const sections = [...groups.entries()].map(([reason, commits]) => {
+    const { summary, fix } = REASONS[reason] ?? FALLBACK;
+    const list = commits.map((c) => `- \`${c.sha.slice(0, 8)}\` ${subjectOf(c)}`).join('\n');
+    return `### \`${reason}\`\n\n${summary}\n\n${list}\n\n**How to fix:** ${fix}`;
+  });
+
+  const resign = [
+    '```bash',
+    '# only for the identity reasons above (no_user / unverified_email):',
+    'git config user.email "you@example.com"',
+    '',
+    '# re-sign every commit on this branch:',
+    "git rebase --exec 'git commit --amend --no-edit --reset-author -S' origin/main",
+    'git push --force-with-lease',
+    '```',
+  ].join('\n');
+
+  return (
+    [
+      MARKER,
+      '',
+      '## Commits on this pull request are not verified',
+      '',
+      `${unverified.length} of ${total} ${plural} not showing as **Verified** on GitHub, so this pull request cannot be merged into \`main\` yet.`,
+      truncated
+        ? `\n> This pull request has more than ${MAX_COMMITS} commits; only the first ${MAX_COMMITS} were checked.\n`
+        : null,
+      '',
+      ...sections.flatMap((section) => [section, '']),
+      '### Re-signing',
+      '',
+      resign,
+      '',
+      'Force-pushing is expected here — re-signing rewrites the commits, so their hashes change.',
+      '',
+      '---',
+      '',
+      'This comment is posted automatically and updates itself when you push; it disappears once every commit verifies. ' +
+        'If you believe this is wrong, say so on the pull request — a maintainer can check.',
+    ]
+      // Only the optional truncation notice is droppable; `''` entries are the blank lines that
+      // separate Markdown blocks, and filtering them out runs headings into paragraphs.
+      .filter((line) => line !== null)
+      .join('\n')
+  );
+}
+
+/**
+ * Posts, updates, or removes the single comment this check owns.
+ *
+ * Matching on the marker keeps it to one comment however many times the contributor pushes;
+ * removing it on success means a fixed pull request does not keep a stale failure at the
+ * bottom, which is the state people screenshot and get confused by later.
+ */
+async function syncComment({ github, context, issueNumber, body }) {
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  const existing = comments.find(
+    (comment) => comment.user?.type === 'Bot' && comment.body?.includes(MARKER),
+  );
+
+  if (!body) {
+    if (existing) {
+      await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+      return 'deleted';
+    }
+    return 'noop';
+  }
+
+  if (existing) {
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+    return 'updated';
+  }
+  await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+  return 'created';
+}
+
+module.exports = async ({ github, context, core }) => {
+  const log = core?.info ?? console.log;
+  const { owner, repo } = context.repo;
+  const pull = context.payload.pull_request;
+
+  if (!pull) {
+    core?.setFailed?.('No pull request in the event payload.');
+    return;
+  }
+
+  const commits = await github.paginate(github.rest.pulls.listCommits, {
+    owner,
+    repo,
+    pull_number: pull.number,
+    per_page: 100,
+  });
+
+  const checked = commits.slice(0, MAX_COMMITS);
+  const truncated = commits.length > MAX_COMMITS;
+  const unverified = checked.filter((c) => c.commit?.verification?.verified !== true);
+
+  for (const commit of checked) {
+    const { verified, reason } = commit.commit?.verification ?? {};
+    log(`${verified ? '✅' : '❌'} ${commit.sha.slice(0, 8)} ${reason ?? 'unknown'}`);
+  }
+
+  if (unverified.length === 0) {
+    const action = await syncComment({ github, context, issueNumber: pull.number, body: null });
+    log(`All ${checked.length} commit(s) verified. Comment: ${action}.`);
+    return;
+  }
+
+  for (const commit of unverified) {
+    core?.error?.(
+      `Commit ${commit.sha.slice(0, 8)} is not verified by GitHub ` +
+        `(${commit.commit?.verification?.reason ?? 'unknown'}).`,
+      { title: 'Unverified commit' },
+    );
+  }
+
+  const body = buildBody({ unverified, total: checked.length, truncated });
+  const action = await syncComment({ github, context, issueNumber: pull.number, body });
+  log(`Comment ${action}.`);
+
+  core?.setFailed?.(
+    `${unverified.length} of ${checked.length} commit(s) are not verified by GitHub. ` +
+      'See the comment on the pull request.',
+  );
+};
+
+// Exported for the unit tests; not used by the workflow.
+module.exports.buildBody = buildBody;
+module.exports.groupByReason = groupByReason;
+module.exports.defuseReferences = defuseReferences;
+module.exports.MARKER = MARKER;
+module.exports.REASONS = REASONS;

--- a/.github/scripts/welcome-contributor.js
+++ b/.github/scripts/welcome-contributor.js
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Greets a first-time contributor on the pull request they just opened, with the things a
+ * maintainer would otherwise type out by hand: where the community talks, the code of
+ * conduct everyone here is held to, and what actually has to be true before their change can
+ * be merged.
+ *
+ * ## Who gets this
+ *
+ * `author_association === 'FIRST_TIME_CONTRIBUTOR' | 'FIRST_TIMER'` — GitHub's own judgement,
+ * already in the event payload, so this costs no API call and cannot go stale. It means
+ * "has not previously committed to this repository", so somebody whose earlier pull request
+ * is still open counts as a first-timer again. That is a deliberate trade: greeting someone
+ * twice is a small cost, and the alternative — a search query per opened pull request — adds
+ * a rate-limited call and an index-lag failure mode to buy very little.
+ *
+ * Bots are skipped. Maintainers, members and past contributors are skipped.
+ *
+ * ## Why the comment is deliberately not a wall of rules
+ *
+ * The merge requirements are already in CONTRIBUTING.md and restated in the pull request
+ * template, and they still get missed — so repeating all of them here would be repeating a
+ * thing that demonstrably does not work. What this lists is the short set that most often
+ * blocks a first pull request, each linked to the page that explains it. The signing check
+ * comments separately and specifically when it fails, which is the moment that advice is
+ * actually read.
+ *
+ * ## Safety
+ *
+ * Runs on `pull_request_target` so it holds a token that can comment on fork pull requests.
+ * It never checks out or executes the pull request's code; the only field taken from the
+ * event is the author's login, which is defused before it reaches the body so a crafted
+ * username cannot turn the greeting into a mention of somebody else.
+ */
+
+const MARKER = '<!-- welcome-contributor -->';
+
+const CODE_OF_CONDUCT = 'https://www.apache.org/foundation/policies/conduct';
+const MAILING_LIST = 'https://lists.apache.org/list.html?dev@fineract.apache.org';
+const MATRIX_HOME = 'https://matrix.to/#/%23apache-fineract-home:matrix.org';
+const MATRIX_DEV = 'https://matrix.to/#/%23apache-fineract-dev:matrix.org';
+const DOCS = 'https://fineract.apache.org/docs/current/';
+const REPO = 'https://github.com/apache/fineract-backoffice-ui/blob/main';
+
+const WELCOMED_ASSOCIATIONS = new Set(['FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER']);
+
+/**
+ * A login is `[A-Za-z0-9-]` so it cannot itself contain an `@` or `#`, but the greeting is
+ * assembled from event data and this keeps that guarantee local rather than assumed.
+ */
+function defuseReferences(text) {
+  return String(text)
+    .replace(/@(?=[A-Za-z0-9])/g, '@​')
+    .replace(/#(?=\d)/g, '#​');
+}
+
+function buildBody(login) {
+  const who = login ? ` @${login}` : '';
+  return [
+    MARKER,
+    '',
+    `## Welcome, and thank you${who} 👋`,
+    '',
+    'This looks like your first pull request to the Fineract back-office UI. A maintainer will',
+    'review it — in the meantime, here is what is worth knowing.',
+    '',
+    '### The community',
+    '',
+    `- **Code of conduct** — everyone taking part here, including in review, is held to the [ASF Code of Conduct](${CODE_OF_CONDUCT}). Please give it a read.`,
+    `- **Mailing list** — [dev@fineract.apache.org](${MAILING_LIST}) is where design questions and anything bigger than a single change get discussed. Subscribe by emailing \`dev-subscribe@fineract.apache.org\`. In an Apache project the mailing list is the project's record: **if a decision was not made on the list, it did not happen**, so it is worth being on it.`,
+    `- **Matrix** — [#apache-fineract-home](${MATRIX_HOME}) for general chat, [#apache-fineract-dev](${MATRIX_DEV}) for development. Good for a quick question; use the list for anything that should be findable later.`,
+    `- **Docs** — [fineract.apache.org/docs/current](${DOCS}).`,
+    '',
+    '### What has to be true before this can merge',
+    '',
+    `- **Your commits must be signed _and_ show as Verified on GitHub.** This is the one that catches people out most often, and "signed" is not sufficient on its own — GitHub also has to be able to tie the signature to your account, which means \`git config user.email\` must be an address verified on your GitHub profile. [Setup instructions](${REPO}/CONTRIBUTING.md#commit-signing). If this is wrong, a check will comment here telling you exactly which part.`,
+    `- **CI has to be green.** Every check and how to reproduce it locally is in [DOCS/CI_CHECKS.md](${REPO}/DOCS/CI_CHECKS.md). Before pushing, \`npm run lint\`, \`npm run format:check\`, \`npm run test:unit\` and \`npm run build\` cover most of it.`,
+    `- **New tests go in Vitest** (\`*.test.ts\`), not Karma — the Karma suite is shrinking and CI fails if it grows. See [CONTRIBUTING.md](${REPO}/CONTRIBUTING.md#unit-tests).`,
+    `- **New files need the Apache licence header** — \`./scripts/check-license.sh\` checks this.`,
+    `- **User-facing strings need translation keys**, not literals — \`npm run i18n:check\`.`,
+    `- **Third-party surfaces go through \`src/app/core/adapters/\`** rather than being called directly. [ADR 0003](${REPO}/DOCS/adr/0003-adapter-boundary.md) explains why.`,
+    '',
+    'The checklist in the pull request description covers the rest.',
+    '',
+    '### If a review takes a while',
+    '',
+    'This is a volunteer project, so a quiet week happens. Nudging the pull request or asking on',
+    'the mailing list is welcome and not considered rude.',
+    '',
+    '---',
+    '',
+    '<sub>Posted automatically the first time you open a pull request here.</sub>',
+  ].join('\n');
+}
+
+/** Idempotent: a re-run, or a reopened pull request, must not stack up greetings. */
+async function alreadyWelcomed({ github, context, issueNumber }) {
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  return comments.some((comment) => comment.user?.type === 'Bot' && comment.body?.includes(MARKER));
+}
+
+module.exports = async ({ github, context, core }) => {
+  const log = core?.info ?? console.log;
+  const pull = context.payload.pull_request;
+
+  if (!pull) {
+    log('No pull request in the event payload; nothing to do.');
+    return;
+  }
+
+  const association = pull.author_association;
+  if (!WELCOMED_ASSOCIATIONS.has(association)) {
+    log(`Author association is ${association}; not a first-time contributor. Skipping.`);
+    return;
+  }
+
+  if (pull.user?.type === 'Bot') {
+    log('Pull request opened by a bot. Skipping.');
+    return;
+  }
+
+  if (await alreadyWelcomed({ github, context, issueNumber: pull.number })) {
+    log('Already welcomed on this pull request. Skipping.');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pull.number,
+    body: buildBody(defuseReferences(pull.user?.login ?? '')),
+  });
+  log(`Welcomed ${pull.user?.login ?? 'contributor'} on #${pull.number}.`);
+};
+
+// Exported for the unit tests; not used by the workflow.
+module.exports.buildBody = buildBody;
+module.exports.defuseReferences = defuseReferences;
+module.exports.MARKER = MARKER;
+module.exports.WELCOMED_ASSOCIATIONS = WELCOMED_ASSOCIATIONS;

--- a/.github/workflows/signed-commit.yml
+++ b/.github/workflows/signed-commit.yml
@@ -18,40 +18,60 @@
 
 name: Fineract Signed Commits Check
 
+# Asks GitHub whether it verified each commit on the pull request, and says so on the pull
+# request when it did not. The reasoning — why the old local `%G?` check could not answer
+# this, and why the trigger below is what it is — lives in
+# .github/scripts/check-commit-signatures.js.
+#
+# Two things follow from `pull_request_target` and are easy to trip over:
+#
+#   - The copy of this workflow that runs is the one on the **base branch**. A pull request
+#     editing this file cannot change the check applied to it. That is deliberate: under
+#     `pull_request`, a contributor could weaken their own gate, and did.
+#   - Nothing here may check out or execute the pull request's code. Writable token plus
+#     untrusted code is the "pwn request" vulnerability. The checkout below is ref-less and
+#     sparse, so it yields this repository's base branch and nothing from the fork.
+#
+# This is early feedback, not the enforcement boundary. Branch protection's "Require signed
+# commits" is enforced by GitHub itself and cannot be edited by any workflow; this check
+# exists so a contributor is told *which* of several distinct problems they have, and how to
+# fix it, before they run into that.
+
 on:
-  pull_request:
+  # zizmor: ignore[dangerous-triggers] — required to comment on fork pull requests, and safe
+  # here: no checkout of the pull request's code, and the only input is the GitHub API's own
+  # verification verdict.
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   verify-signatures:
     name: Verify Commit Signatures
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read # ref-less checkout of this repository's base branch
+      pull-requests: write # the explanatory comment
     steps:
-      - name: Checkout repository
+      # No `ref:`. On `pull_request_target` this resolves to the base branch of *this*
+      # repository, never the pull request's head — which is what makes the writable token
+      # above safe to hold. Only the script directory is fetched.
+      - name: Check out this repository's scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          fetch-depth: 0
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
 
-      - name: Fetch base branch
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: git fetch origin "$BASE_REF"
-
-      - name: Verify signatures
-        env:
-          BASE_REF: ${{ github.base_ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          ./scripts/verify-signed-commits.sh \
-            --base-ref "origin/$BASE_REF" \
-            --head-ref "$HEAD_SHA" \
-            --strict
+      - name: Verify signatures and report
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const check = require('./.github/scripts/check-commit-signatures.js');
+            await check({ github, context, core });

--- a/.github/workflows/welcome-contributor.yml
+++ b/.github/workflows/welcome-contributor.yml
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Welcome New Contributors
+
+# Greets a first-time contributor on the pull request they just opened: the code of conduct,
+# the mailing list and Matrix rooms, and the handful of requirements that most often block a
+# first change. The wording and the reasoning behind what is and is not included live in
+# .github/scripts/welcome-contributor.js.
+#
+# `pull_request_target` because a fork's `pull_request` run gets a read-only token and so
+# cannot comment — which would exclude exactly the people this is for. Nothing here checks
+# out or executes the pull request's code; the greeting is assembled from the base branch's
+# copy of the script and one field of the event payload.
+
+on:
+  # zizmor: ignore[dangerous-triggers] — required to comment on fork pull requests, and safe
+  # here: no checkout of the pull request's code and nothing from the fork is executed.
+  pull_request_target:
+    types: [opened, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  welcome:
+    name: Post the welcome comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Cheap pre-filter so the job does not even start for the common case. The script checks
+    # this again, since it is the half that must stay correct if this condition is edited.
+    if: >-
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+      github.event.pull_request.author_association == 'FIRST_TIMER'
+    permissions:
+      contents: read # ref-less checkout of this repository's base branch
+      pull-requests: write # the greeting itself
+    steps:
+      # No `ref:`. On `pull_request_target` this is the base branch of *this* repository, not
+      # the pull request's head — which is what makes the writable token above safe to hold.
+      - name: Check out this repository's scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Welcome the contributor
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const welcome = require('./.github/scripts/welcome-contributor.js');
+            await welcome({ github, context, core });

--- a/scripts/pr-comment-actions.test.mjs
+++ b/scripts/pr-comment-actions.test.mjs
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The two `pull_request_target` comment actions.
+ *
+ *   node --test "scripts/*.test.mjs"
+ *
+ * Both hold a token that can write to this repository while reacting to a fork's pull
+ * request, so the properties worth pinning are the ones that keep that safe and quiet:
+ * exactly one comment per pull request however many times it is pushed, the comment removed
+ * again once the problem is fixed, and no attacker-controlled text turned into a live
+ * `@mention`. Neither can be exercised on the pull request that introduces it — a
+ * `pull_request_target` workflow only runs from the base branch — so these tests are the
+ * only pre-merge check that the logic is right.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import checkSignatures from '../.github/scripts/check-commit-signatures.js';
+import welcome from '../.github/scripts/welcome-contributor.js';
+
+const { buildBody, groupByReason, defuseReferences, MARKER } = checkSignatures;
+
+/** A commit as `pulls.listCommits` returns it. */
+function commit(sha, { verified = false, reason = 'no_user', message = 'chore: a change' } = {}) {
+  return { sha, commit: { message, verification: { verified, reason } } };
+}
+
+/**
+ * Records what the script asked the API to do, so a test can assert on the calls rather than
+ * on a rendered string.
+ */
+function fakeGithub({ comments = [], commits = [] } = {}) {
+  const calls = { created: [], updated: [], deleted: [] };
+  const github = {
+    paginate: async (fn) => fn(),
+    rest: {
+      issues: {
+        listComments: async () => comments,
+        createComment: async (args) => calls.created.push(args),
+        updateComment: async (args) => calls.updated.push(args),
+        deleteComment: async (args) => calls.deleted.push(args),
+      },
+      pulls: { listCommits: async () => commits },
+    },
+  };
+  return { github, calls };
+}
+
+function fakeCore() {
+  const state = { failed: null, errors: [] };
+  return {
+    state,
+    core: {
+      info: () => {},
+      error: (message) => state.errors.push(message),
+      setFailed: (message) => {
+        state.failed = message;
+      },
+    },
+  };
+}
+
+const context = { repo: { owner: 'apache', repo: 'fineract-backoffice-ui' } };
+const pullEvent = (pull) => ({ ...context, payload: { pull_request: pull } });
+
+/* ---------------------------------------------------------------- signatures */
+
+test('a fully verified pull request fails nothing and posts no comment', async () => {
+  const { github, calls } = fakeGithub({
+    commits: [commit('aaaaaaaa', { verified: true, reason: 'valid' })],
+  });
+  const { core, state } = fakeCore();
+
+  await checkSignatures({ github, context: pullEvent({ number: 7 }), core });
+
+  assert.equal(state.failed, null);
+  assert.equal(calls.created.length, 0);
+});
+
+test('an unverified commit fails the check and comments once', async () => {
+  const { github, calls } = fakeGithub({ commits: [commit('deadbeef')] });
+  const { core, state } = fakeCore();
+
+  await checkSignatures({ github, context: pullEvent({ number: 7 }), core });
+
+  assert.match(state.failed, /1 of 1 commit/);
+  assert.equal(calls.created.length, 1);
+  assert.ok(calls.created[0].body.includes(MARKER));
+  assert.ok(calls.created[0].body.includes('deadbee'));
+});
+
+test('a re-run updates the existing comment instead of adding a second', async () => {
+  const existing = { id: 99, user: { type: 'Bot' }, body: `${MARKER}\nstale` };
+  const { github, calls } = fakeGithub({ comments: [existing], commits: [commit('deadbeef')] });
+  const { core } = fakeCore();
+
+  await checkSignatures({ github, context: pullEvent({ number: 7 }), core });
+
+  assert.equal(calls.created.length, 0);
+  assert.equal(calls.updated.length, 1);
+  assert.equal(calls.updated[0].comment_id, 99);
+});
+
+test('fixing the signatures removes the comment the failure left behind', async () => {
+  const existing = { id: 99, user: { type: 'Bot' }, body: `${MARKER}\nold failure` };
+  const { github, calls } = fakeGithub({
+    comments: [existing],
+    commits: [commit('aaaaaaaa', { verified: true, reason: 'valid' })],
+  });
+  const { core, state } = fakeCore();
+
+  await checkSignatures({ github, context: pullEvent({ number: 7 }), core });
+
+  assert.equal(state.failed, null);
+  assert.equal(calls.deleted.length, 1);
+  assert.equal(calls.deleted[0].comment_id, 99);
+});
+
+test('a human comment quoting the marker is never overwritten', async () => {
+  const human = { id: 5, user: { type: 'User' }, body: `I saw ${MARKER} in the logs` };
+  const { github, calls } = fakeGithub({ comments: [human], commits: [commit('deadbeef')] });
+  const { core } = fakeCore();
+
+  await checkSignatures({ github, context: pullEvent({ number: 7 }), core });
+
+  assert.equal(calls.updated.length, 0);
+  assert.equal(calls.created.length, 1);
+});
+
+test('each reason is explained once, with its own remedy', () => {
+  const groups = groupByReason([
+    commit('a1', { reason: 'no_user' }),
+    commit('a2', { reason: 'no_user' }),
+    commit('b1', { reason: 'unsigned' }),
+  ]);
+  assert.deepEqual([...groups.keys()], ['no_user', 'unsigned']);
+  assert.equal(groups.get('no_user').length, 2);
+});
+
+test('no_user is explained as an identity problem, not a signing one', () => {
+  const body = buildBody({ unverified: [commit('a1', { reason: 'no_user' })], total: 1 });
+  assert.match(body, /user\.email/);
+  assert.match(body, /not a signing one/);
+});
+
+test('an unrecognised reason still produces a usable comment', () => {
+  const body = buildBody({ unverified: [commit('a1', { reason: 'something_new' })], total: 1 });
+  assert.match(body, /something_new/);
+  assert.match(body, /CONTRIBUTING/);
+});
+
+test('a commit subject cannot mention anyone from the comment', () => {
+  const body = buildBody({
+    unverified: [commit('a1', { reason: 'unsigned', message: 'fix @maintainer per #1234' })],
+    total: 1,
+  });
+  assert.ok(!/@maintainer/.test(body), 'mention should be defused');
+  assert.ok(!/#1234/.test(body), 'issue reference should be defused');
+});
+
+test('an overlong commit subject is truncated', () => {
+  const body = buildBody({
+    unverified: [commit('a1', { reason: 'unsigned', message: 'x'.repeat(200) })],
+    total: 1,
+  });
+  assert.ok(body.includes('…'));
+  assert.ok(!body.includes('x'.repeat(100)));
+});
+
+test('defuseReferences keeps the text readable', () => {
+  assert.equal(defuseReferences('@user').normalize('NFKD').replace(/​/g, ''), '@user');
+});
+
+/**
+ * Regression: the body was assembled with `.filter(Boolean)`, which silently dropped every
+ * intentional `''` separator along with the optional truncation notice. The Markdown still
+ * "worked" as a string and every assertion above still passed — it just rendered with the
+ * headings welded to the paragraph above them. Only reading the posted output showed it.
+ */
+test('every heading is preceded by a blank line', () => {
+  const body = buildBody({
+    unverified: [commit('a1', { reason: 'no_user' }), commit('b1', { reason: 'unsigned' })],
+    total: 2,
+  });
+  const lines = body.split('\n');
+  let inFence = false;
+  lines.forEach((line, i) => {
+    if (line.startsWith('```')) {
+      inFence = !inFence;
+      return;
+    }
+    // `#` inside a fence is a shell comment, not a heading.
+    if (inFence || i === 0 || !line.startsWith('#')) return;
+    assert.equal(lines[i - 1], '', `heading "${line}" must have a blank line before it`);
+  });
+});
+
+/* ------------------------------------------------------------------ welcome */
+
+test('a first-time contributor is greeted', async () => {
+  const { github, calls } = fakeGithub();
+  const { core } = fakeCore();
+
+  await welcome({
+    github,
+    context: pullEvent({
+      number: 3,
+      author_association: 'FIRST_TIME_CONTRIBUTOR',
+      user: { login: 'newcomer', type: 'User' },
+    }),
+    core,
+  });
+
+  assert.equal(calls.created.length, 1);
+  const body = calls.created[0].body;
+  assert.ok(body.includes(welcome.MARKER));
+  assert.match(body, /Code of Conduct/);
+  assert.match(body, /dev@fineract\.apache\.org/);
+  assert.match(body, /matrix\.to/);
+  assert.match(body, /Verified/);
+});
+
+test('the greeting renders as Markdown, with every heading separated', () => {
+  const lines = welcome.buildBody('newcomer').split('\n');
+  let inFence = false;
+  lines.forEach((line, i) => {
+    if (line.startsWith('```')) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence || i === 0 || !line.startsWith('#')) return;
+    assert.equal(lines[i - 1], '', `heading "${line}" must have a blank line before it`);
+  });
+});
+
+test('every link in the greeting is an absolute URL', () => {
+  const body = welcome.buildBody('newcomer');
+  for (const [, url] of body.matchAll(/\]\(([^)]+)\)/g)) {
+    assert.match(url, /^https:\/\//, `"${url}" must be absolute — the comment has no repo context`);
+  }
+});
+
+test('a returning contributor is not greeted again', async () => {
+  const { github, calls } = fakeGithub();
+  const { core } = fakeCore();
+
+  await welcome({
+    github,
+    context: pullEvent({
+      number: 3,
+      author_association: 'CONTRIBUTOR',
+      user: { login: 'regular', type: 'User' },
+    }),
+    core,
+  });
+
+  assert.equal(calls.created.length, 0);
+});
+
+test('a bot is not greeted', async () => {
+  const { github, calls } = fakeGithub();
+  const { core } = fakeCore();
+
+  await welcome({
+    github,
+    context: pullEvent({
+      number: 3,
+      author_association: 'FIRST_TIME_CONTRIBUTOR',
+      user: { login: 'dependabot[bot]', type: 'Bot' },
+    }),
+    core,
+  });
+
+  assert.equal(calls.created.length, 0);
+});
+
+test('reopening a pull request does not stack up greetings', async () => {
+  const existing = { id: 12, user: { type: 'Bot' }, body: `${welcome.MARKER}\nhello` };
+  const { github, calls } = fakeGithub({ comments: [existing] });
+  const { core } = fakeCore();
+
+  await welcome({
+    github,
+    context: pullEvent({
+      number: 3,
+      author_association: 'FIRST_TIME_CONTRIBUTOR',
+      user: { login: 'newcomer', type: 'User' },
+    }),
+    core,
+  });
+
+  assert.equal(calls.created.length, 0);
+});

--- a/scripts/verify-signed-commits.sh
+++ b/scripts/verify-signed-commits.sh
@@ -18,6 +18,20 @@
 # under the License.
 
 # Usage: ./scripts/verify-signed-commits.sh [--base-ref <ref>] [--head-ref <ref>] [--strict] [--help]
+#
+# A local pre-push aid, NOT the CI gate. It answers "is a signature attached?", which is a
+# weaker question than the one that decides whether a pull request can merge: GitHub asks
+# whether the signature was made by a key registered to an account whose verified email
+# matches the committer. A commit can pass here and still show as Unverified — a key GitHub
+# has never seen, or a `user.email` that is not an address on any account, both look signed
+# to git and are refused by GitHub.
+#
+# It cannot be strengthened to close that gap: a checkout holds no contributor public keys,
+# so the runner has nothing to verify against. The gate therefore asks GitHub instead, in
+# .github/workflows/signed-commit.yml — which also comments on the pull request explaining
+# which of several distinct problems applies.
+#
+# Use this to catch the obvious case (forgot to sign at all) before pushing.
 set -e
 
 BASE_REF="origin/main"


### PR DESCRIPTION
Closes #428.

Two workflows: the signed-commit gate now asks GitHub whether it verified each commit and explains on the PR when it did not, and first-time contributors get a greeting with the code of conduct, the community channels and the requirements that most often block a first change.

## The check was asking the wrong question

`verify-signed-commits.sh` passed anything whose `%G?` was not `N` — "is a signature attached?". GitHub asks whether the signature was made by a key registered to an account whose verified email matches the committer. Commits pass the first and fail the second routinely:

| PR | check | commits | verified | reason |
|---|---|---|---|---|
| #392 | ✅ success | 3 | 0 | `no_user` |
| #331 | ✅ success | 2 | 0 | `no_user` |

A runner cannot answer the stricter question — it holds no contributor public keys, which is exactly why the old script documented `E`/`U`/`B` as deliberate passes. It does not need to: GitHub already computed the answer and returns it per commit as `commit.verification`.

## The gate could be edited by the branch it gates

Under `pull_request`, the workflow *and* its scripts come from the merge ref — the PR's own copy. A contributor can therefore weaken the check meant to gate them, which is not hypothetical: it is how the accept-any-`gpgsig` fallback in #392 came about.

`pull_request_target` runs the base repository's copy and carries a token that can comment, which a fork's `pull_request` run deliberately does not (read-only token, so the current workflow could not comment even if it wanted to).

**What keeps that safe:** neither workflow checks out or executes the PR's code. Both take a ref-less, sparse checkout of `.github/scripts` from the base branch and read only the API response — never the diff, never the commit tree. Commit *subjects* do reach the comment body, so they are truncated and their `@`/`#` references defused. This follows the reasoning already written down in `pr-comments.yml`.

zizmor passes at this repository's own settings (`--min-severity informational --min-confidence low`); the two `dangerous-triggers` findings are ignored inline with justification, matching the existing convention.

## Failures explain themselves

Grouped by `verification.reason`, because the remedies are not interchangeable — which is why a blanket "please sign your commits" has such a poor hit rate. `no_user`, the reason on both affected PRs, is **not a signing problem**: the signature is fine and `user.email` is not an address on any GitHub account. Telling those contributors to set up signing sends them to redo the one part they got right.

Rendered from the live API against #392:

> ### `no_user`
>
> These commits **are signed**, but the committer email is not an address GitHub can match to any account — so it never gets as far as checking the key. Note that the commits are not attributed to your GitHub profile either, which is the same cause.
>
> - `9d7f1793` feat(clients): add empty-state actions on account tabs
> - `74f75234` Merge upstream main and resolve client-view spec conflict
> - `af3ef580` ci: recognise SSH commit signatures on the Actions runner
>
> **How to fix:** This is an identity problem, not a signing one — your signing setup is fine. Check `git config user.email` and set it to an address that is **verified on your GitHub account** (Settings → Emails), then re-sign.

One comment per PR, updated on push, **deleted** once every commit verifies so a fixed PR keeps no stale failure.

`scripts/verify-signed-commits.sh` stays as a local pre-push aid, with a header stating plainly that it is no longer the gate and explaining why it cannot be one.

## Welcome workflow

First-time contributors (`FIRST_TIME_CONTRIBUTOR` / `FIRST_TIMER`, straight from the payload — no API call, no rate limit) get the [ASF Code of Conduct](https://www.apache.org/foundation/policies/conduct), the [dev mailing list](https://lists.apache.org/list.html?dev@fineract.apache.org) with the `dev-subscribe@` address, the [Matrix rooms](https://matrix.to/#/%23apache-fineract-home:matrix.org), and the six requirements that most often block a first PR. Bots skipped; idempotent on reopen.

It is deliberately short. CONTRIBUTING.md and the PR template already state everything, and they still get missed — restating all of it would repeat something that demonstrably does not land.

## Testing

Neither workflow can be exercised by the PR that adds it — `pull_request_target` only ever runs the base branch's copy — so **the unit tests are the entire pre-merge safety net**. `scripts/pr-comment-actions.test.mjs` (16 new tests, `npm run test:scripts`) covers comment idempotency, deletion on success, never overwriting a human comment who happens to quote the marker, per-reason grouping, and defusing `@`/`#` in attacker-controlled subjects.

Both scripts were also run against the live GitHub API for #392 (fails, `no_user`) and #393 (passes, no comment). That is what caught a rendering bug the unit tests missed: `.filter(Boolean)` was stripping the intentional blank lines out of the body, so headings welded to the paragraph above them. The string still "worked" and every assertion still passed — only reading the posted output showed it. There is now a test pinning it.

All 13 static checks, `test:scripts` (28 passing) and `check-license.sh` pass.

## Still worth doing separately

Enable branch protection **Require signed commits** on `main`. GitHub enforces that itself and no workflow can weaken it. This check is the explanation, not the wall — and #428 has the rest of the reasoning.
