### PR TITLE
fix(accounting): add route titles

### DIFF
--- a/src/app/features/accounting/accounting.routes.ts
+++ b/src/app/features/accounting/accounting.routes.ts
@@ -26,6 +26,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'chart-of-accounts',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_GLACCOUNT' },
+    title: 'nav.chartOfAccounts',
     loadComponent: () =>
       import('./chart-of-accounts.component').then((m) => m.ChartOfAccountsComponent),
   },
@@ -33,6 +34,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'chart-of-accounts/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_GLACCOUNT' },
+    title: 'ACCOUNTING.CREATE_GL_ACCOUNT',
     loadComponent: () =>
       import('./gl-account-form.component').then((m) => m.GLAccountFormComponent),
   },
@@ -40,6 +42,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'chart-of-accounts/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_GLACCOUNT' },
+    title: 'ACCOUNTING.EDIT_GL_ACCOUNT',
     loadComponent: () =>
       import('./gl-account-form.component').then((m) => m.GLAccountFormComponent),
   },
@@ -47,6 +50,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'journal-entries',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_JOURNALENTRY' },
+    title: 'nav.journalEntries',
     loadComponent: () =>
       import('./journal-entries-list.component').then((m) => m.JournalEntriesListComponent),
   },
@@ -54,6 +58,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'journal-entries/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_JOURNALENTRY' },
+    title: 'JOURNAL_ENTRIES.CREATE',
     loadComponent: () =>
       import('./journal-entry-form.component').then((m) => m.JournalEntryFormComponent),
   },
@@ -61,6 +66,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'journal-entries/view/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_JOURNALENTRY' },
+    title: 'JOURNAL_ENTRIES.TRANSACTION',
     loadComponent: () =>
       import('./journal-entry-view.component').then((m) => m.JournalEntryViewComponent),
   },
@@ -68,6 +74,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'frequent-postings',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_JOURNALENTRY' },
+    title: 'FREQUENT_POSTINGS.TITLE',
     loadComponent: () =>
       import('./frequent-postings.component').then((m) => m.FrequentPostingsComponent),
   },
@@ -75,6 +82,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'opening-balances',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'DEFINEOPENINGBALANCE_JOURNALENTRY' },
+    title: 'OPENING_BALANCES.TITLE',
     loadComponent: () =>
       import('./opening-balances.component').then((m) => m.OpeningBalancesComponent),
   },
@@ -82,6 +90,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'closures',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_GLCLOSURE' },
+    title: 'nav.accountingClosures',
     loadComponent: () =>
       import('./accounting-closures-list.component').then((m) => m.AccountingClosuresListComponent),
   },
@@ -89,6 +98,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'closures/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_GLCLOSURE' },
+    title: 'ACCOUNTING_CLOSURES.CREATE',
     loadComponent: () =>
       import('./accounting-closure-form.component').then((m) => m.AccountingClosureFormComponent),
   },
@@ -96,6 +106,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'rules',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_ACCOUNTINGRULE' },
+    title: 'nav.accountingRules',
     loadComponent: () =>
       import('./accounting-rules-list.component').then((m) => m.AccountingRulesListComponent),
   },
@@ -103,6 +114,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'rules/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_ACCOUNTINGRULE' },
+    title: 'ACCOUNTING_RULES.CREATE',
     loadComponent: () =>
       import('./accounting-rule-form.component').then((m) => m.AccountingRuleFormComponent),
   },
@@ -110,6 +122,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'rules/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_ACCOUNTINGRULE' },
+    title: 'ACCOUNTING_RULES.EDIT',
     loadComponent: () =>
       import('./accounting-rule-form.component').then((m) => m.AccountingRuleFormComponent),
   },
@@ -117,6 +130,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'financial-activity-mappings',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_FINANCIALACTIVITYACCOUNT' },
+    title: 'nav.financialActivityMappings',
     loadComponent: () =>
       import('./financial-activity-mappings-list.component').then(
         (m) => m.FinancialActivityMappingsListComponent,
@@ -126,6 +140,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'financial-activity-mappings/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_FINANCIALACTIVITYACCOUNT' },
+    title: 'ACCOUNTING.DEFINE_MAPPING',
     loadComponent: () =>
       import('./financial-activity-mapping-form.component').then(
         (m) => m.FinancialActivityMappingFormComponent,
@@ -135,6 +150,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'financial-activity-mappings/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_FINANCIALACTIVITYACCOUNT' },
+    title: 'ACCOUNTING.EDIT_MAPPING',
     loadComponent: () =>
       import('./financial-activity-mapping-form.component').then(
         (m) => m.FinancialActivityMappingFormComponent,
@@ -144,6 +160,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'charges',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_CHARGE' },
+    title: 'nav.charges',
     loadComponent: () =>
       import('./charges/charges-list.component').then((m) => m.ChargesListComponent),
   },
@@ -151,6 +168,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'charges/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_CHARGE' },
+    title: 'CHARGES.CREATE',
     loadComponent: () =>
       import('./charges/charge-form.component').then((m) => m.ChargeFormComponent),
   },
@@ -158,11 +176,13 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'charges/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_CHARGE' },
+    title: 'CHARGES.EDIT',
     loadComponent: () =>
       import('./charges/charge-form.component').then((m) => m.ChargeFormComponent),
   },
   {
     path: 'provisioning-categories',
+    title: 'nav.provisioningCategories',
     loadComponent: () =>
       import('./provisioning-categories/provisioning-categories-list.component').then(
         (m) => m.ProvisioningCategoriesListComponent,
@@ -172,6 +192,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'provisioning-categories/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_PROVISIONCATEGORY' },
+    title: 'PROVISIONING_CATEGORIES.CREATE',
     loadComponent: () =>
       import('./provisioning-categories/provisioning-categories-form.component').then(
         (m) => m.ProvisioningCategoriesFormComponent,
@@ -181,6 +202,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'provisioning-categories/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_PROVISIONCATEGORY' },
+    title: 'PROVISIONING_CATEGORIES.EDIT',
     loadComponent: () =>
       import('./provisioning-categories/provisioning-categories-form.component').then(
         (m) => m.ProvisioningCategoriesFormComponent,
@@ -188,6 +210,7 @@ export const ACCOUNTING_ROUTES: Routes = [
   },
   {
     path: 'provisioning-criteria',
+    title: 'nav.provisioningCriteria',
     loadComponent: () =>
       import('./provisioning-criteria/provisioning-criteria-list.component').then(
         (m) => m.ProvisioningCriteriaListComponent,
@@ -197,6 +220,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'provisioning-criteria/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_PROVISIONCRITERIA' },
+    title: 'PROVISIONING_CRITERIA.CREATE',
     loadComponent: () =>
       import('./provisioning-criteria/provisioning-criteria-form.component').then(
         (m) => m.ProvisioningCriteriaFormComponent,
@@ -206,6 +230,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'provisioning-criteria/edit/:id',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'UPDATE_PROVISIONCRITERIA' },
+    title: 'PROVISIONING_CRITERIA.EDIT',
     loadComponent: () =>
       import('./provisioning-criteria/provisioning-criteria-form.component').then(
         (m) => m.ProvisioningCriteriaFormComponent,
@@ -213,6 +238,7 @@ export const ACCOUNTING_ROUTES: Routes = [
   },
   {
     path: 'provisioning-entries',
+    title: 'nav.provisioningEntries',
     loadComponent: () =>
       import('./provisioning-entries/provisioning-entries-list.component').then(
         (m) => m.ProvisioningEntriesListComponent,
@@ -222,6 +248,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'provisioning-entries/create',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'CREATE_PROVISIONENTRIES' },
+    title: 'PROVISIONING_ENTRIES.CREATE',
     loadComponent: () =>
       import('./provisioning-entries/provisioning-entries-form.component').then(
         (m) => m.ProvisioningEntriesFormComponent,
@@ -231,6 +258,7 @@ export const ACCOUNTING_ROUTES: Routes = [
     path: 'run-accruals',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'EXECUTEJOB_SCHEDULER' },
+    title: 'RUN_ACCRUALS.TITLE',
     loadComponent: () =>
       import('./run-accruals/run-accruals.component').then((m) => m.RunAccrualsComponent),
   },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1413,6 +1413,7 @@
     "ADD_LEDGER_ACCOUNT": "Add Ledger Account",
     "EDIT_ACCOUNT": "Edit Account",
     "DEFINE_MAPPING": "Define Mapping",
+    "EDIT_MAPPING": "Edit Financial Activity Mapping",
     "GL_CODE": "GL Code",
     "ACCOUNT_TYPE": "Account Type",
     "ACCOUNT_USAGE": "Account Usage",


### PR DESCRIPTION
## Description

Add translation-backed titles to every Accounting child route so breadcrumbs and browser titles identify the active screen instead of stopping at the generic Accounting parent.

The change reuses existing translation keys and adds the one missing English label for editing financial activity mappings.

Closes #420

## Verification

- `npm run lint`
- `npm run build`
- `npm run i18n:check`
- `npm run check:icons`
- `npm run check:a11y-names`
- `TZ=UTC npm run test:unit` — 57 files, 432 tests passed
- Focused Playwright Accounting and breadcrumb checks — 8 passed
- Prettier check on both changed files
- Structural check — all 28 Accounting routes have titles and every key resolves in `en.json`

## Test environment note

The legacy Karma suite was also run on Chrome Headless 151 / Windows: 886 of 898 tests passed. The remaining failures are in unchanged specs and accompanied by the existing Ionic invalid-base-URL harness warnings; a focused Accounting run passed 55 of 56 unchanged component tests. No Karma test imports or exercises the changed route configuration.

## Screenshots

Not included: this is route metadata with no visual redesign. The breadcrumb behavior and Accounting destinations were verified in Chromium through the focused Playwright run.