### PR TITLE
fix(a11y): replace native confirm with DialogService in calendars and meetings

### DIFF
--- a/src/app/features/calendars/calendars-list.component.test.ts
+++ b/src/app/features/calendars/calendars-list.component.test.ts
@@ -25,12 +25,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { provideTranslateTesting } from '../../testing/i18n-testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../core/services/dialog.service';
 
 describe('CalendarsListComponent', () => {
   let component: CalendarsListComponent;
   let fixture: ComponentFixture<CalendarsListComponent>;
   let serviceSpy: SpyObj<CalendarService>;
   let routerSpy: SpyObj<Router>;
+  let dialogService: SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = createSpyObj([
@@ -38,6 +40,8 @@ describe('CalendarsListComponent', () => {
       'deleteEntityTypeEntityIdCalendarsCalendarId',
     ]);
     routerSpy = createSpyObj(['navigate']);
+    dialogService = createSpyObj(['confirm']);
+    dialogService.confirm.mockResolvedValue(true);
     serviceSpy.getEntityTypeEntityIdCalendars.mockReturnValue(
       of([{ id: 1, title: 'Weekly Meeting', startDate: '2026-01-15' }]) as unknown as ReturnType<
         CalendarService['getEntityTypeEntityIdCalendars']
@@ -50,6 +54,7 @@ describe('CalendarsListComponent', () => {
         ...provideTranslateTesting(),
         { provide: CalendarService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -76,8 +81,8 @@ describe('CalendarsListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/calendars', 'centers', 2, 'edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.mockResolvedValue(true);
     serviceSpy.deleteEntityTypeEntityIdCalendarsCalendarId.mockReturnValue(
       of({}) as unknown as ReturnType<
         CalendarService['deleteEntityTypeEntityIdCalendarsCalendarId']
@@ -85,6 +90,7 @@ describe('CalendarsListComponent', () => {
     );
 
     component.onDelete({ id: 5 });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteEntityTypeEntityIdCalendarsCalendarId).toHaveBeenCalledWith(
       'centers',
@@ -94,9 +100,10 @@ describe('CalendarsListComponent', () => {
     expect(serviceSpy.getEntityTypeEntityIdCalendars).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.mockResolvedValue(false);
     component.onDelete({ id: 5 });
+    await fixture.whenStable();
     expect(serviceSpy.deleteEntityTypeEntityIdCalendarsCalendarId).not.toHaveBeenCalled();
   });
 

--- a/src/app/features/calendars/calendars-list.component.ts
+++ b/src/app/features/calendars/calendars-list.component.ts
@@ -19,7 +19,7 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { ColumnDef, CellTemplateDirective } from '../../shared';
@@ -28,6 +28,7 @@ import { CalendarService, CalendarData } from '../../api';
 import { formatArrayDate } from '../../core/utils/date-formatter';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../shared/directives/tooltip.directive';
+import { DialogService } from '../../core/services/dialog.service';
 
 /**
  * Lists the calendars (meeting schedules) attached to a single group or center.
@@ -89,6 +90,8 @@ export class CalendarsListComponent implements OnInit {
   private readonly calendarService = inject(CalendarService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'title', label: 'CALENDARS.TITLE_FIELD', sortable: true },
@@ -140,12 +143,21 @@ export class CalendarsListComponent implements OnInit {
   }
 
   onDelete(row: CalendarData): void {
-    if (!row.id || !window.confirm('Delete this calendar?')) return;
-    this.calendarService
-      .deleteEntityTypeEntityIdCalendarsCalendarId(this.entityType, this.entityId, row.id)
-      .subscribe({
-        next: () => this.load(),
-        error: (err: unknown) => console.error('Failed to delete calendar', err),
+    if (!row.id) return;
+
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('CALENDARS.DELETE'),
+        message: this.translate.instant('CALENDARS.CONFIRM_DELETE', { name: row.title }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.calendarService
+          .deleteEntityTypeEntityIdCalendarsCalendarId(this.entityType, this.entityId, row.id!)
+          .subscribe({
+            next: () => this.load(),
+          });
       });
   }
 }

--- a/src/app/features/meetings/meetings-list.component.test.ts
+++ b/src/app/features/meetings/meetings-list.component.test.ts
@@ -25,12 +25,14 @@ import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { provideTranslateTesting } from '../../testing/i18n-testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { DialogService } from '../../core/services/dialog.service';
 
 describe('MeetingsListComponent', () => {
   let component: MeetingsListComponent;
   let fixture: ComponentFixture<MeetingsListComponent>;
   let serviceSpy: SpyObj<MeetingsService>;
   let routerSpy: SpyObj<Router>;
+  let dialogService: SpyObj<DialogService>;
 
   beforeEach(async () => {
     serviceSpy = createSpyObj([
@@ -38,6 +40,8 @@ describe('MeetingsListComponent', () => {
       'deleteEntityTypeEntityIdMeetingsMeetingId',
     ]);
     routerSpy = createSpyObj(['navigate']);
+    dialogService = createSpyObj(['confirm']);
+    dialogService.confirm.mockResolvedValue(true);
     serviceSpy.getEntityTypeEntityIdMeetings.mockReturnValue(
       of([{ id: 1, meetingDate: '2026-01-15' }]) as unknown as ReturnType<
         MeetingsService['getEntityTypeEntityIdMeetings']
@@ -50,6 +54,7 @@ describe('MeetingsListComponent', () => {
         ...provideTranslateTesting(),
         { provide: MeetingsService, useValue: serviceSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: DialogService, useValue: dialogService },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -76,13 +81,14 @@ describe('MeetingsListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/meetings', 'groups', 1, 'edit', 3]);
   });
 
-  it('should delete after confirmation and reload', () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  it('should delete after confirmation and reload', async () => {
+    dialogService.confirm.mockResolvedValue(true);
     serviceSpy.deleteEntityTypeEntityIdMeetingsMeetingId.mockReturnValue(
       of({}) as unknown as ReturnType<MeetingsService['deleteEntityTypeEntityIdMeetingsMeetingId']>,
     );
 
     component.onDelete({ id: 5 });
+    await fixture.whenStable();
 
     expect(serviceSpy.deleteEntityTypeEntityIdMeetingsMeetingId).toHaveBeenCalledWith(
       'groups',
@@ -92,9 +98,10 @@ describe('MeetingsListComponent', () => {
     expect(serviceSpy.getEntityTypeEntityIdMeetings).toHaveBeenCalledTimes(2);
   });
 
-  it('should not delete when cancelled', () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
+  it('should not delete when cancelled', async () => {
+    dialogService.confirm.mockResolvedValue(false);
     component.onDelete({ id: 5 });
+    await fixture.whenStable();
     expect(serviceSpy.deleteEntityTypeEntityIdMeetingsMeetingId).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/meetings/meetings-list.component.ts
+++ b/src/app/features/meetings/meetings-list.component.ts
@@ -19,13 +19,14 @@
 
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ColumnDef, CellTemplateDirective } from '../../shared';
 import { DataTableComponent } from '../../shared/components/data-table/data-table.component';
 import { MeetingsService, MeetingData } from '../../api';
 import { formatArrayDate } from '../../core/utils/date-formatter';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { TooltipDirective } from '../../shared/directives/tooltip.directive';
+import { DialogService } from '../../core/services/dialog.service';
 
 /**
  * Lists the meetings recorded against a single group or center. The entity type
@@ -88,6 +89,8 @@ export class MeetingsListComponent implements OnInit {
   private readonly meetingsService = inject(MeetingsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+  private readonly translate = inject(TranslateService);
 
   readonly columns: ColumnDef[] = [
     { key: 'meetingDate', label: 'MEETINGS.MEETING_DATE', sortable: false },
@@ -133,12 +136,23 @@ export class MeetingsListComponent implements OnInit {
   }
 
   onDelete(row: MeetingData): void {
-    if (!row.id || !window.confirm('Delete this meeting?')) return;
-    this.meetingsService
-      .deleteEntityTypeEntityIdMeetingsMeetingId(this.entityType, this.entityId, row.id)
-      .subscribe({
-        next: () => this.load(),
-        error: (err: unknown) => console.error('Failed to delete meeting', err),
+    if (!row.id) return;
+
+    void this.dialogService
+      .confirm({
+        title: this.translate.instant('MEETINGS.DELETE'),
+        message: this.translate.instant('MEETINGS.CONFIRM_DELETE', {
+          name: this.formatDate(row.meetingDate),
+        }),
+        destructive: true,
+      })
+      .then((confirmed) => {
+        if (!confirmed) return;
+        this.meetingsService
+          .deleteEntityTypeEntityIdMeetingsMeetingId(this.entityType, this.entityId, row.id!)
+          .subscribe({
+            next: () => this.load(),
+          });
       });
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1947,7 +1947,9 @@
     "EDIT": "Edit Meeting",
     "MEETING_DATE": "Meeting Date",
     "PRESENT_COUNT": "Attendance Recorded",
-    "CALENDAR_ID": "Calendar"
+    "CALENDAR_ID": "Calendar",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete meeting on \"{{name}}\"?"
   },
   "CALENDARS": {
     "TITLE": "Calendars",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1955,7 +1955,9 @@
     "CREATE": "Create Calendar",
     "EDIT": "Edit Calendar",
     "START_DATE": "Start Date",
-    "TYPE": "Type"
+    "TYPE": "Type",
+    "DELETE": "Delete",
+    "CONFIRM_DELETE": "Delete calendar \"{{name}}\"?"
   },
   "GROUP_LEVELS": {
     "LEVEL_NAME": "Level Name",


### PR DESCRIPTION
## What and why

Replaces the native `window.confirm()` dialog with the app's styled `DialogService.confirm()` in the calendars and meetings delete flows, matching the pattern already used elsewhere in the app (e.g. `codes-list.component.ts`). This gives these two remaining screens a translated, themed, destructive-marked confirmation instead of the browser's untranslatable, unstyled dialog.

Closes #232

## Verification

- Ran `npm run lint`, `npm run i18n:check`, and `npm test` — all passing
- Updated unit tests in `calendars-list.component.spec.ts` and `meetings-list.component.spec.ts` to mock `DialogService.confirm()` instead of `window.confirm`
- Manually verified the styled confirm modal renders correctly with real translated text (title, message with interpolated name/date, destructive styling) using a temporary preview test with the real `DialogService` and `TranslateModule`
- Exercised with mocks only; did not test against a real Fineract backend

## Screenshots
Before:
<img width="1202" height="358" alt="Before" src="https://github.com/user-attachments/assets/448bb106-5004-40ce-bac2-e3fdcfaf75f8" />

After:
<img width="1372" height="870" alt="After" src="https://github.com/user-attachments/assets/e4480b06-a695-4541-9e26-88c1dc43b1b8" />




## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. — Not added: this is a UI-only confirmation dialog swap with existing unit test coverage; no new user flow to cover with e2e.
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.