### PR TITLE
test: migrate four manual specs to Vitest

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1057,7 +1057,7 @@
       "count": 1
     }
   },
-  "src/app/features/reporting/report-execution.service.spec.ts": {
+  "src/app/features/reporting/report-execution.service.test.ts": {
     "unicorn/no-array-sort": {
       "count": 1
     }

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -79,7 +79,6 @@
     "src/app/features/products/tax-components/tax-components-list.component.spec.ts",
     "src/app/features/products/tax-groups/tax-group-form.component.spec.ts",
     "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
-    "src/app/features/reporting/report-execution.service.spec.ts",
     "src/app/layout/header.component.spec.ts",
     "src/app/layout/main-layout.component.spec.ts",
     "src/app/shared/components/client-search/client-search.component.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -1,9 +1,7 @@
 {
   "license": "Apache-2.0",
   "$comment": "Specs still on the deprecated Karma runner. Written by scripts/check-test-runner.mjs; files may leave this list, never join it. See DOCS/adr/0004-vitest-migration.md.",
-  "grandfathered": [
-    "src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"
-  ],
+  "grandfathered": ["src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"],
   "specs": [
     "projects/fineract-mfe/src/app/app.spec.ts",
     "src/app/app.component.spec.ts",
@@ -79,7 +77,6 @@
     "src/app/features/products/tax-components/tax-components-list.component.spec.ts",
     "src/app/features/products/tax-groups/tax-group-form.component.spec.ts",
     "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
-    "src/app/layout/main-layout.component.spec.ts",
     "src/app/shared/components/client-search/client-search.component.spec.ts",
     "src/app/shared/components/guidance-tour/guidance-tour.component.spec.ts",
     "src/app/shared/components/search-filter/search-filter.component.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -1,7 +1,9 @@
 {
   "license": "Apache-2.0",
   "$comment": "Specs still on the deprecated Karma runner. Written by scripts/check-test-runner.mjs; files may leave this list, never join it. See DOCS/adr/0004-vitest-migration.md.",
-  "grandfathered": ["src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"],
+  "grandfathered": [
+    "src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"
+  ],
   "specs": [
     "projects/fineract-mfe/src/app/app.spec.ts",
     "src/app/app.component.spec.ts",
@@ -46,7 +48,6 @@
     "src/app/features/loans/post-dated-checks/post-dated-check-form.component.spec.ts",
     "src/app/features/loans/post-dated-checks/post-dated-checks-list.component.spec.ts",
     "src/app/features/loans/tabs/loan-delinquency-tab.component.spec.ts",
-    "src/app/features/login/login.component.spec.ts",
     "src/app/features/products/account-action-form.component.spec.ts",
     "src/app/features/products/accounting/advanced-accounting-mappings.component.spec.ts",
     "src/app/features/products/accounting/product-accounting-section.component.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -79,7 +79,6 @@
     "src/app/features/products/tax-components/tax-components-list.component.spec.ts",
     "src/app/features/products/tax-groups/tax-group-form.component.spec.ts",
     "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
-    "src/app/layout/header.component.spec.ts",
     "src/app/layout/main-layout.component.spec.ts",
     "src/app/shared/components/client-search/client-search.component.spec.ts",
     "src/app/shared/components/guidance-tour/guidance-tour.component.spec.ts",

--- a/src/app/features/login/login.component.test.ts
+++ b/src/app/features/login/login.component.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createSpyObj, SpyObj } from '../../testing/mocks';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
@@ -24,42 +25,41 @@ import { of, throwError } from 'rxjs';
 import { LoginComponent } from './login.component';
 import { AuthService, UserSession } from '../../core/services/auth.service';
 import { ConfigService } from '../../core/services/config.service';
-import { TranslateModule } from '@ngx-translate/core';
 import { WritableSignal, signal } from '@angular/core';
+import { provideTranslateTesting } from '../../testing/i18n-testing';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
-  let authServiceSpy: jasmine.SpyObj<AuthService>;
-  let configServiceSpy: jasmine.SpyObj<ConfigService>;
-  let routerSpy: jasmine.SpyObj<Router>;
+  let authServiceSpy: SpyObj<AuthService>;
+  let configServiceSpy: SpyObj<ConfigService>;
+  let routerSpy: SpyObj<Router>;
   const mockApiUrl = 'https://localhost:8443/fineract-provider/api/v1';
 
   /** Configures the TestBed with the query parameters the login route was reached with. */
   async function setup(queryParams: Record<string, string> = {}) {
-    authServiceSpy = jasmine.createSpyObj('AuthService', [
-      'login',
-      'currentTenantId',
-      'twoFactorPending',
-      'logout',
-    ]);
-    authServiceSpy.currentTenantId.and.returnValue('default');
+    authServiceSpy = createSpyObj(['login', 'currentTenantId', 'twoFactorPending', 'logout']);
+    authServiceSpy.currentTenantId.mockReturnValue('default');
     // No second factor: what every deployment without `fineract.security.2fa.enabled` sees.
-    authServiceSpy.twoFactorPending.and.returnValue(false);
+    authServiceSpy.twoFactorPending.mockReturnValue(false);
 
-    configServiceSpy = jasmine.createSpyObj('ConfigService', ['setApiUrl', 'isAllowedApiUrl'], {
-      apiUrl: mockApiUrl,
-      // The component reads the allow-list to build the endpoint picker.
-      config: signal({ allowedApiOrigins: [] }),
-    });
-    configServiceSpy.setApiUrl.and.returnValue(true);
-    configServiceSpy.isAllowedApiUrl.and.returnValue(true);
+    configServiceSpy = Object.assign(
+      createSpyObj<ConfigService>(['setApiUrl', 'isAllowedApiUrl']),
+      {
+        apiUrl: mockApiUrl,
+        // The component reads the allow-list to build the endpoint picker.
+        config: signal({ allowedApiOrigins: [] }),
+      },
+    );
+    configServiceSpy.setApiUrl.mockReturnValue(true);
+    configServiceSpy.isAllowedApiUrl.mockReturnValue(true);
 
-    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    routerSpy = createSpyObj(['navigate']);
 
     await TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, TranslateModule.forRoot(), LoginComponent],
+      imports: [ReactiveFormsModule, LoginComponent],
       providers: [
+        ...provideTranslateTesting(),
         { provide: AuthService, useValue: authServiceSpy },
         { provide: ConfigService, useValue: configServiceSpy },
         { provide: Router, useValue: routerSpy },
@@ -84,11 +84,11 @@ describe('LoginComponent', () => {
   });
 
   it('should be invalid when empty', () => {
-    expect(component['loginForm'].valid).toBeFalse();
+    expect(component['loginForm'].valid).toBe(false);
   });
 
   it('should call login and navigate on success', () => {
-    authServiceSpy.login.and.returnValue(of({} as UserSession));
+    authServiceSpy.login.mockReturnValue(of({} as UserSession));
 
     component['loginForm'].setValue({
       serverUrl: mockApiUrl,
@@ -106,7 +106,7 @@ describe('LoginComponent', () => {
   });
 
   it('should set error on login failure', () => {
-    authServiceSpy.login.and.returnValue(
+    authServiceSpy.login.mockReturnValue(
       throwError(() => ({ error: { defaultUserMessage: 'Failed' } })),
     );
 
@@ -124,9 +124,9 @@ describe('LoginComponent', () => {
     expect((component as unknown as { error: WritableSignal<string | null> }).error()).toBe(
       'Failed',
     );
-    expect(
-      (component as unknown as { isLoading: WritableSignal<boolean> }).isLoading(),
-    ).toBeFalse();
+    expect((component as unknown as { isLoading: WritableSignal<boolean> }).isLoading()).toBe(
+      false,
+    );
   });
 
   describe('session expiry notice', () => {

--- a/src/app/features/reporting/report-execution.service.test.ts
+++ b/src/app/features/reporting/report-execution.service.test.ts
@@ -52,7 +52,7 @@ describe('ReportExecutionService', () => {
     let discovered = false;
     service.getReportParameters('Portfolio at Risk').subscribe((parameters) => {
       discovered = true;
-      expect(parameters).toHaveSize(2);
+      expect(parameters).toHaveLength(2);
       expect(parameters[0].queryParameter).toBe('R_officeId');
       expect(parameters[0].options).toEqual([
         { id: 1, name: HEAD_OFFICE },
@@ -100,12 +100,12 @@ describe('ReportExecutionService', () => {
     );
     expect(lookup.request.params.get('parameterType')).toBe('true');
     lookup.flush({ data: [{ row: [1, HEAD_OFFICE] }] });
-    expect(discovered).toBeTrue();
+    expect(discovered).toBe(true);
   });
 
   it('keeps cascading selects empty until their parent has a value', () => {
     service.getReportParameters('Active Loans - Summary').subscribe((parameters) => {
-      expect(parameters).toHaveSize(2);
+      expect(parameters).toHaveLength(2);
       expect(parameters[0].options).toEqual([{ id: 1, name: HEAD_OFFICE }]);
       expect(parameters[1].queryParameter).toBe('R_loanOfficerId');
       expect(parameters[1].parentParameterName).toBe('OfficeIdSelectOne');
@@ -153,12 +153,12 @@ describe('ReportExecutionService', () => {
 
   it('isolates a failed lookup instead of dropping the parameter form', () => {
     service.getReportParameters('Tenant Report').subscribe((parameters) => {
-      expect(parameters).toHaveSize(2);
+      expect(parameters).toHaveLength(2);
       expect(parameters[0].options).toEqual([]);
       // Recorded, so the field can distinguish "no offices" from "offices unknown".
-      expect(parameters[0].optionsFailed).toBeTrue();
+      expect(parameters[0].optionsFailed).toBe(true);
       expect(parameters[1].options).toEqual([{ id: 'USD', name: 'US Dollar' }]);
-      expect(parameters[1].optionsFailed).toBeFalse();
+      expect(parameters[1].optionsFailed).toBe(false);
     });
 
     http
@@ -318,10 +318,12 @@ describe('ReportExecutionService', () => {
   it('skips malformed template rows without dropping valid parameters', () => {
     service.getReportParameters('Tenant Report').subscribe({
       next: (parameters) => {
-        expect(parameters).toHaveSize(1);
+        expect(parameters).toHaveLength(1);
         expect(parameters[0].queryParameter).toBe('R_startDate');
       },
-      error: fail,
+      error: (error) => {
+        throw error;
+      },
     });
 
     http

--- a/src/app/layout/header.component.test.ts
+++ b/src/app/layout/header.component.test.ts
@@ -17,37 +17,38 @@
  * under the License.
  */
 
+import { createSpyObj, SpyObj } from '../testing/mocks';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { HeaderComponent } from './header.component';
 import { AuthService } from '../core/services/auth.service';
 import { NavigationConfigService } from '../core/services/navigation-config.service';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
 import { ViewportService } from '../core/services/viewport.service';
-import { EMPTY } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { WritableSignal, signal } from '@angular/core';
+import { provideTranslateTesting } from '../testing/i18n-testing';
+import { BusinessDateManagementService } from '../api';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
-  let authServiceSpy: jasmine.SpyObj<AuthService>;
-  let navigationConfigSpy: jasmine.SpyObj<NavigationConfigService>;
-  let translateService: TranslateService;
-  let routerSpy: jasmine.SpyObj<Router>;
+  let authServiceSpy: SpyObj<AuthService>;
+  let navigationConfigSpy: SpyObj<NavigationConfigService>;
+  let routerSpy: SpyObj<Router>;
   let isMobile: WritableSignal<boolean>;
 
   beforeEach(async () => {
-    authServiceSpy = jasmine.createSpyObj('AuthService', ['logout'], {
+    authServiceSpy = Object.assign(createSpyObj<AuthService>(['logout']), {
       username: signal('mifos'),
       officeName: signal('Head Office'),
     });
-    navigationConfigSpy = jasmine.createSpyObj('NavigationConfigService', ['searchRoutes']);
-    navigationConfigSpy.searchRoutes.and.returnValue([]);
+    navigationConfigSpy = createSpyObj(['searchRoutes']);
+    navigationConfigSpy.searchRoutes.mockReturnValue([]);
     // `routerState` and `events` are properties, not methods, so createSpyObj needs them in the
     // property bag. The header reads the route tree for the phone header's page title, the same
     // way BreadcrumbComponent does; without them it throws in ngOnInit.
-    routerSpy = jasmine.createSpyObj('Router', ['navigate', 'navigateByUrl'], {
+    routerSpy = Object.assign(createSpyObj<Router>(['navigate', 'navigateByUrl']), {
       routerState: { snapshot: { root: { url: [], routeConfig: null, firstChild: null } } },
       events: EMPTY,
     });
@@ -60,10 +61,12 @@ describe('HeaderComponent', () => {
     isMobile = signal(false);
 
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), HeaderComponent],
+      imports: [HeaderComponent],
       providers: [
+        ...provideTranslateTesting(),
         { provide: AuthService, useValue: authServiceSpy },
         { provide: NavigationConfigService, useValue: navigationConfigSpy },
+        { provide: BusinessDateManagementService, useValue: { getBusinessdate: () => of([]) } },
         { provide: Router, useValue: routerSpy },
         { provide: ViewportService, useValue: { isMobile } },
       ],
@@ -71,7 +74,6 @@ describe('HeaderComponent', () => {
 
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
-    translateService = TestBed.inject(TranslateService);
     fixture.detectChanges();
   });
 
@@ -104,9 +106,11 @@ describe('HeaderComponent', () => {
   });
 
   it('should switch language', () => {
-    spyOn(translateService, 'use');
+    const translate = (component as unknown as { translate: { use(language: string): unknown } })
+      .translate;
+    const useSpy = vi.spyOn(translate, 'use');
     component.switchLanguage('hi');
-    expect(translateService.use).toHaveBeenCalledWith('hi');
+    expect(useSpy).toHaveBeenCalledWith('hi');
   });
 
   it('navigates to a page result via navigateByUrl', () => {
@@ -136,7 +140,7 @@ describe('HeaderComponent', () => {
     fixture.detectChanges();
 
     const item = fixture.debugElement.query(By.css('ion-item'));
-    const event = jasmine.createSpyObj('MouseEvent', ['preventDefault']);
+    const event = createSpyObj(['preventDefault']);
     item.triggerEventHandler('mousedown', event);
 
     expect(event.preventDefault).toHaveBeenCalled();

--- a/src/app/layout/main-layout.component.test.ts
+++ b/src/app/layout/main-layout.component.test.ts
@@ -17,13 +17,16 @@
  * under the License.
  */
 
+import { createSpyObj, SpyObj } from '../testing/mocks';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MainLayoutComponent } from './main-layout.component';
 import { AuthService, UserSession } from '../core/services/auth.service';
 import { GuidanceService } from '../core/services/guidance.service';
-import { TranslateModule } from '@ngx-translate/core';
 import { Router, RouterModule } from '@angular/router';
 import { signal } from '@angular/core';
+import { provideTranslateTesting } from '../testing/i18n-testing';
+import { BusinessDateManagementService } from '../api';
+import { of } from 'rxjs';
 
 function keydown(overrides: Partial<KeyboardEvent> & { target: EventTarget }): KeyboardEvent {
   return {
@@ -31,7 +34,7 @@ function keydown(overrides: Partial<KeyboardEvent> & { target: EventTarget }): K
     altKey: false,
     ctrlKey: false,
     shiftKey: false,
-    preventDefault: jasmine.createSpy('preventDefault'),
+    preventDefault: vi.fn(),
     ...overrides,
   } as unknown as KeyboardEvent;
 }
@@ -39,7 +42,7 @@ function keydown(overrides: Partial<KeyboardEvent> & { target: EventTarget }): K
 describe('MainLayoutComponent', () => {
   let component: MainLayoutComponent;
   let fixture: ComponentFixture<MainLayoutComponent>;
-  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let authServiceSpy: SpyObj<AuthService>;
 
   beforeEach(async () => {
     const mockSession: UserSession = {
@@ -52,16 +55,20 @@ describe('MainLayoutComponent', () => {
       permissions: ['ALL_FUNCTIONS'],
     };
 
-    authServiceSpy = jasmine.createSpyObj('AuthService', ['hasPermission'], {
+    authServiceSpy = Object.assign(createSpyObj<AuthService>(['hasPermission']), {
       username: signal('mifos'),
       officeName: signal('Head Office'),
       currentUser: signal<UserSession | null>(mockSession),
     });
-    authServiceSpy.hasPermission.and.returnValue(true);
+    authServiceSpy.hasPermission.mockReturnValue(true);
 
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot(), RouterModule.forRoot([]), MainLayoutComponent],
-      providers: [{ provide: AuthService, useValue: authServiceSpy }],
+      imports: [RouterModule.forRoot([]), MainLayoutComponent],
+      providers: [
+        ...provideTranslateTesting(),
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: BusinessDateManagementService, useValue: { getBusinessdate: () => of([]) } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MainLayoutComponent);
@@ -81,7 +88,7 @@ describe('MainLayoutComponent', () => {
 
   describe('global keyboard shortcuts', () => {
     it('navigates to the bound route on a shortcut keydown', () => {
-      const navigateSpy = spyOn(TestBed.inject(Router), 'navigate');
+      const navigateSpy = vi.spyOn(TestBed.inject(Router), 'navigate');
 
       component.onKeydown(keydown({ key: 'c', altKey: true, target: document.body }));
 
@@ -89,8 +96,8 @@ describe('MainLayoutComponent', () => {
     });
 
     it('starts the guidance tour for the current route on the help shortcut', () => {
-      spyOnProperty(TestBed.inject(Router), 'url').and.returnValue('/dashboard');
-      const startTourSpy = spyOn(TestBed.inject(GuidanceService), 'startTour');
+      vi.spyOn(TestBed.inject(Router), 'url', 'get').mockReturnValue('/dashboard');
+      const startTourSpy = vi.spyOn(TestBed.inject(GuidanceService), 'startTour');
 
       component.onKeydown(keydown({ key: 'h', altKey: true, target: document.body }));
 
@@ -98,7 +105,7 @@ describe('MainLayoutComponent', () => {
     });
 
     it('ignores keydown events while typing into a form control', () => {
-      const navigateSpy = spyOn(TestBed.inject(Router), 'navigate');
+      const navigateSpy = vi.spyOn(TestBed.inject(Router), 'navigate');
       const input = document.createElement('input');
 
       component.onKeydown(keydown({ key: 'c', altKey: true, target: input }));
@@ -107,7 +114,7 @@ describe('MainLayoutComponent', () => {
     });
 
     it('ignores unbound key combinations', () => {
-      const navigateSpy = spyOn(TestBed.inject(Router), 'navigate');
+      const navigateSpy = vi.spyOn(TestBed.inject(Router), 'navigate');
 
       component.onKeydown(keydown({ key: 'z', altKey: true, target: document.body }));
 


### PR DESCRIPTION
Part of #403 and #410. Closes #411.

Trackers:

- Overall migration: https://github.com/apache/fineract-backoffice-ui/issues/403#issuecomment-5419731357
- #411 area checklist: https://github.com/apache/fineract-backoffice-ui/issues/411#issuecomment-5390596060
- #410 manual checklist: https://github.com/apache/fineract-backoffice-ui/issues/410#issuecomment-5418797763

## Summary

- migrate the four manual specs left from #411: login, report execution, header, and main layout
- replace object-form Jasmine spies with explicit Vitest spies and signal-backed properties
- replace the Jasmine `fail` callback and `spyOnProperty` usage with their Vitest equivalents
- reduce the Karma baseline from 83 to 79 specs

These tests do not use `fakeAsync`, `done()`, or virtual timers, so their timing model is unchanged. Each spec is kept in its own commit as requested by #410.

## Testing

- focused: 4 files, 28 tests passed
- Vitest: 157 files, 927 tests passed
- Karma: 446 tests passed
- combined total unchanged at 1,373 tests
- `npm run lint`
- `npm run format:check`
- `npm run check:test-runner`