### PR TITLE
test: migrate object-form spy specs to Vitest

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1565,7 +1565,7 @@
       "count": 1
     }
   },
-  "src/app/shared/components/guidance-tour/guidance-tour.component.spec.ts": {
+  "src/app/shared/components/guidance-tour/guidance-tour.component.test.ts": {
     "no-restricted-imports": {
       "count": 1
     }

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -69,7 +69,6 @@
     "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
     "src/app/shared/components/client-search/client-search.component.spec.ts",
     "src/app/shared/components/search-filter/search-filter.component.spec.ts",
-    "src/app/shared/directives/has-permission.directive.spec.ts",
     "src/app/shared/directives/tooltip.directive.spec.ts"
   ]
 }

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -3,7 +3,6 @@
   "$comment": "Specs still on the deprecated Karma runner. Written by scripts/check-test-runner.mjs; files may leave this list, never join it. See DOCS/adr/0004-vitest-migration.md.",
   "grandfathered": ["src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"],
   "specs": [
-    "src/app/app.config.spec.ts",
     "src/app/core/guards/auth.guard.spec.ts",
     "src/app/core/interceptors/auth.interceptor.spec.ts",
     "src/app/core/interceptors/correlation-id.interceptor.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -3,7 +3,6 @@
   "$comment": "Specs still on the deprecated Karma runner. Written by scripts/check-test-runner.mjs; files may leave this list, never join it. See DOCS/adr/0004-vitest-migration.md.",
   "grandfathered": ["src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"],
   "specs": [
-    "src/app/core/guards/auth.guard.spec.ts",
     "src/app/core/interceptors/auth.interceptor.spec.ts",
     "src/app/core/interceptors/correlation-id.interceptor.spec.ts",
     "src/app/core/interceptors/error.interceptor.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -68,7 +68,6 @@
     "src/app/features/products/tax-groups/tax-group-form.component.spec.ts",
     "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
     "src/app/shared/components/client-search/client-search.component.spec.ts",
-    "src/app/shared/components/guidance-tour/guidance-tour.component.spec.ts",
     "src/app/shared/components/search-filter/search-filter.component.spec.ts",
     "src/app/shared/directives/has-permission.directive.spec.ts",
     "src/app/shared/directives/tooltip.directive.spec.ts"

--- a/src/app/app.config.test.ts
+++ b/src/app/app.config.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createSpyObj } from './testing/mocks';
 import { TestBed } from '@angular/core/testing';
 import { initializeApp, appConfig } from './app.config';
 import { BASE_PATH } from './api/variables';
@@ -29,9 +30,9 @@ describe('AppConfig', () => {
   it('loads the config and applies branding before the app starts', async () => {
     // `initializeApp` resolves its own dependencies with `inject`, so it has to run inside an
     // injection context rather than being handed them as arguments.
-    const configServiceSpy = jasmine.createSpyObj('ConfigService', ['loadConfig']);
-    configServiceSpy.loadConfig.and.returnValue(Promise.resolve());
-    const brandingSpy = jasmine.createSpyObj('BrandingService', ['apply']);
+    const configServiceSpy = createSpyObj<ConfigService>(['loadConfig']);
+    configServiceSpy.loadConfig.mockReturnValue(Promise.resolve());
+    const brandingSpy = createSpyObj<BrandingService>(['apply']);
 
     TestBed.configureTestingModule({
       providers: [
@@ -54,7 +55,7 @@ describe('AppConfig', () => {
 
     expect(basePathProvider).toBeTruthy();
 
-    const configServiceSpy = jasmine.createSpyObj('ConfigService', [], {
+    const configServiceSpy = Object.assign(createSpyObj<ConfigService>([]), {
       apiUrl: `${API_URL}/v1`,
     });
     const result = (basePathProvider!['useFactory'] as (...args: unknown[]) => unknown)(
@@ -68,7 +69,7 @@ describe('AppConfig', () => {
       (p) => p && p['provide'] === BASE_PATH,
     );
 
-    const configServiceSpy = jasmine.createSpyObj('ConfigService', [], {
+    const configServiceSpy = Object.assign(createSpyObj<ConfigService>([]), {
       apiUrl: API_URL,
     });
     const result = (basePathProvider!['useFactory'] as (...args: unknown[]) => unknown)(

--- a/src/app/core/guards/auth.guard.test.ts
+++ b/src/app/core/guards/auth.guard.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createSpyObj, SpyObj } from '../../testing/mocks';
 import { TestBed } from '@angular/core/testing';
 import { Router, UrlTree, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { authGuard } from './auth.guard';
@@ -24,14 +25,14 @@ import { AuthService } from '../services/auth.service';
 import { signal } from '@angular/core';
 
 describe('authGuard', () => {
-  let authServiceSpy: jasmine.SpyObj<AuthService>;
-  let routerSpy: jasmine.SpyObj<Router>;
+  let authServiceSpy: SpyObj<AuthService>;
+  let routerSpy: SpyObj<Router>;
 
   beforeEach(() => {
-    authServiceSpy = jasmine.createSpyObj('AuthService', [], {
+    authServiceSpy = Object.assign(createSpyObj<AuthService>([]), {
       isAuthenticated: signal(false),
     });
-    routerSpy = jasmine.createSpyObj('Router', ['parseUrl']);
+    routerSpy = createSpyObj<Router>(['parseUrl']);
 
     TestBed.configureTestingModule({
       providers: [
@@ -48,7 +49,7 @@ describe('authGuard', () => {
     const result = TestBed.runInInjectionContext(() =>
       authGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
     );
-    expect(result).toBeTrue();
+    expect(result).toBe(true);
   });
 
   it('should redirect to login if user is not authenticated', () => {
@@ -56,7 +57,7 @@ describe('authGuard', () => {
     Object.defineProperty(authServiceSpy, 'isAuthenticated', { get: () => isAuthenticatedSignal });
 
     const loginUrlTree = {} as UrlTree;
-    routerSpy.parseUrl.and.returnValue(loginUrlTree);
+    routerSpy.parseUrl.mockReturnValue(loginUrlTree);
 
     const result = TestBed.runInInjectionContext(() =>
       authGuard({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),

--- a/src/app/shared/components/guidance-tour/guidance-tour.component.test.ts
+++ b/src/app/shared/components/guidance-tour/guidance-tour.component.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createSpyObj, SpyObj } from '../../../testing/mocks';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { GuidanceTourComponent } from './guidance-tour.component';
@@ -27,12 +28,11 @@ import { signal } from '@angular/core';
 describe('GuidanceTourComponent', () => {
   let component: GuidanceTourComponent;
   let fixture: ComponentFixture<GuidanceTourComponent>;
-  let guidanceServiceSpy: jasmine.SpyObj<GuidanceService>;
+  let guidanceServiceSpy: SpyObj<GuidanceService>;
 
   beforeEach(async () => {
-    guidanceServiceSpy = jasmine.createSpyObj(
-      'GuidanceService',
-      ['nextStep', 'previousStep', 'endTour'],
+    guidanceServiceSpy = Object.assign(
+      createSpyObj<GuidanceService>(['nextStep', 'previousStep', 'endTour']),
       {
         isPlaying: signal(true),
         currentStepIndex: signal(0),
@@ -89,9 +89,8 @@ describe('GuidanceTourComponent', () => {
   });
 
   it('renders the Next label translation key on a step that is not the last', async () => {
-    guidanceServiceSpy = jasmine.createSpyObj(
-      'GuidanceService',
-      ['nextStep', 'previousStep', 'endTour'],
+    guidanceServiceSpy = Object.assign(
+      createSpyObj<GuidanceService>(['nextStep', 'previousStep', 'endTour']),
       {
         isPlaying: signal(true),
         currentStepIndex: signal(0),

--- a/src/app/shared/directives/has-permission.directive.test.ts
+++ b/src/app/shared/directives/has-permission.directive.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createSpyObj, SpyObj } from '../../testing/mocks';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -48,7 +49,7 @@ const STRICT_PERMISSION_SELECTOR = '#strict-permission';
 
 describe('HasPermissionDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
-  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let authServiceSpy: SpyObj<AuthService>;
 
   /** Configures the TestBed with RBAC on or off for this deployment. */
   function configure(rbacEnabled: boolean): void {
@@ -62,14 +63,14 @@ describe('HasPermissionDirective', () => {
   }
 
   beforeEach(() => {
-    authServiceSpy = jasmine.createSpyObj('AuthService', ['hasPermission'], {
+    authServiceSpy = Object.assign(createSpyObj<AuthService>(['hasPermission']), {
       currentUser: () => ({ permissions: ['CREATE_CLIENT'] }),
     });
     configure(true);
   });
 
   it('should render elements when permission is granted', () => {
-    authServiceSpy.hasPermission.and.returnValue(true);
+    authServiceSpy.hasPermission.mockReturnValue(true);
     fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
 
@@ -83,7 +84,7 @@ describe('HasPermissionDirective', () => {
   });
 
   it('should hide elements when permission is denied', () => {
-    authServiceSpy.hasPermission.and.returnValue(false);
+    authServiceSpy.hasPermission.mockReturnValue(false);
     fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
 
@@ -99,7 +100,7 @@ describe('HasPermissionDirective', () => {
   it('should render everything when RBAC is disabled, even without permission', () => {
     TestBed.resetTestingModule();
     configure(false);
-    authServiceSpy.hasPermission.and.returnValue(false);
+    authServiceSpy.hasPermission.mockReturnValue(false);
     fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
 


### PR DESCRIPTION
## Summary

- migrate four specs that use object-form `jasmine.createSpyObj()` to Vitest
- preserve property values with `createSpyObj()` and `Object.assign()`
- remove the migrated specs from the Karma baseline
- keep one commit per spec for easier review

Part of #410 and #403.

## Testing

- `TZ=UTC npm run test:unit` — 164 files, 953 tests passed
- `npm run lint`
- `npm run format:check`
