### PR TITLE
refactor(products): use formatArrayDate helper

### DIFF
--- a/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
@@ -50,6 +50,7 @@ import {
   PutFixedDepositAccountsAccountIdRequest,
 } from '../../../api';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -412,9 +413,7 @@ export class FixedDepositAccountFormComponent implements OnInit {
       next: (data: GetFixedDepositAccountsAccountIdResponse) => {
         const dateArray = data.timeline?.submittedOnDate as unknown as number[];
         if (dateArray) {
-          this.submittedOnDate.set(
-            toIsoDate(new Date(dateArray[0], dateArray[1] - 1, dateArray[2])),
-          );
+          this.submittedOnDate.set(formatArrayDate(dateArray));
         }
         this.account.set({
           clientId: data.clientId,

--- a/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
@@ -51,6 +51,7 @@ import {
   PostRecurringDepositAccountsRequest,
 } from '../../../api';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
@@ -466,9 +467,7 @@ export class RecurringDepositAccountFormComponent implements OnInit {
       next: (data: GetRecurringDepositAccountsAccountIdResponse) => {
         const dateArray = data.timeline?.submittedOnDate as unknown as number[];
         if (dateArray) {
-          this.submittedOnDate.set(
-            toIsoDate(new Date(dateArray[0], dateArray[1] - 1, dateArray[2])),
-          );
+          this.submittedOnDate.set(formatArrayDate(dateArray));
         }
         this.account.set({
           clientId: data.clientId,

--- a/src/app/features/products/savings-account-transaction-form.component.ts
+++ b/src/app/features/products/savings-account-transaction-form.component.ts
@@ -41,7 +41,7 @@ import {
   IonSpinner,
   IonTextarea,
 } from '@ionic/angular/standalone';
-import { toIsoDate } from '../../core/utils/date-formatter';
+import { formatArrayDate, toIsoDate } from '../../core/utils/date-formatter';
 import { TooltipDirective } from '../../shared/directives/tooltip.directive';
 import {
   SavingsAccountTransactionsService,
@@ -233,9 +233,7 @@ export class SavingsAccountTransactionFormComponent implements OnInit {
           const data = typeof template === 'string' ? JSON.parse(template) : template;
           this.paymentTypeOptions.set(data.paymentTypeOptions || []);
           if (data.date) {
-            this.transactionDate.set(
-              toIsoDate(new Date(data.date[0], data.date[1] - 1, data.date[2])),
-            );
+            this.transactionDate.set(formatArrayDate(data.date));
           }
         },
         error: () => {


### PR DESCRIPTION
## What and why

Replace the three remaining manual Fineract array-date conversions in the `products` feature with the existing `formatArrayDate` helper. This removes repeated 1-based month arithmetic while preserving the existing missing-date guards and ISO values expected by the date controls.

This covers the remaining `products` portion of #257. The default value sites that intentionally use `toIsoDate(new Date())` are unchanged.

Part of #257.

## Verification

- `npm test -- --watch=false --progress=false` — 414/414 Karma tests passed
- `npm run test:unit -- --watch=false --progress=false` — 164 files and 959/959 Vitest tests passed
- `npm test -- --watch=false --include='src/app/features/products/fixed-deposits/fixed-deposit-form.component.spec.ts'` — 16/16 focused tests passed
- `npm run test:unit -- --include='src/app/features/products/savings-account-transaction-form.component.test.ts' --watch=false` — 5/5 focused tests passed
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run check:icons`
- `npm run i18n:check`
- `./scripts/check-license.sh`
- `git diff --check`

No real Fineract backend was required because this is a behavior-preserving refactor covered by component/unit tests and the repository-wide build and static checks.

## Screenshots

Not applicable; there is no UI or visible date change.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. (No new component or service code.)
- [x] User-facing strings use translation keys. (No user-facing strings changed.)
- [x] I added or updated tests appropriate to this change. (Existing component coverage plus both full unit suites verify behavior.)
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. (No UI workflow changed.)
- [x] Commits are signed — the commit was created with GitHub's verified signature.
