### PR TITLE
fix(accounting-rules): show load errors instead of an empty list

### DIFF
--- a/e2e/list-pagination.spec.ts
+++ b/e2e/list-pagination.spec.ts
@@ -281,4 +281,35 @@ test.describe('List load failure', () => {
     await expect(page.getByTestId('data-table-error')).toHaveCount(0);
     await expect(page.locator('table.data-table')).toContainText('Weekly Meeting');
   });
+
+  test('accounting rules: reports the failure and reloads when the user retries', async ({
+    page,
+  }) => {
+    await login(page);
+
+    let attempts = 0;
+    await page.route(/\/api\/v1\/accountingrules(\?|$)/, async (route) => {
+      attempts += 1;
+      if (attempts === 1) {
+        await route.fulfill({ status: 500, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 1, name: 'Cash to Bank Transfer' }]),
+      });
+    });
+
+    await page.goto('/accounting/rules');
+
+    // Not "No records found": nobody knows whether there are records.
+    await expect(page.getByTestId('data-table-error')).toBeVisible();
+    await expect(page.locator('table.data-table')).toHaveCount(0);
+
+    await page.getByTestId('data-table-retry').click();
+
+    await expect(page.getByTestId('data-table-error')).toHaveCount(0);
+    await expect(page.locator('table.data-table')).toContainText('Cash to Bank Transfer');
+  });
 });

--- a/src/app/features/accounting/accounting-rules-list.component.test.ts
+++ b/src/app/features/accounting/accounting-rules-list.component.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createSpyObj, SpyObj } from '../../testing/mocks';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { AccountingRulesListComponent } from './accounting-rules-list.component';
+import { AccountingRulesService } from '../../api';
+import { provideIonicTesting } from '../../testing/ionic-testing';
+import { provideTranslateTesting } from '../../testing/i18n-testing';
+
+describe('AccountingRulesListComponent', () => {
+  let component: AccountingRulesListComponent;
+  let fixture: ComponentFixture<AccountingRulesListComponent>;
+  let serviceSpy: SpyObj<AccountingRulesService>;
+
+  const rules = [{ id: 1, name: 'Cash to Bank Transfer' }];
+
+  beforeEach(async () => {
+    serviceSpy = createSpyObj(['getAccountingrules']);
+    serviceSpy.getAccountingrules.mockReturnValue(
+      of(rules) as unknown as ReturnType<AccountingRulesService['getAccountingrules']>,
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [AccountingRulesListComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideIonicTesting(),
+        ...provideTranslateTesting(),
+        { provide: AccountingRulesService, useValue: serviceSpy },
+        { provide: Router, useValue: createSpyObj(['navigate']) },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AccountingRulesListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('loads rules on init', () => {
+    expect(serviceSpy.getAccountingrules).toHaveBeenCalledTimes(1);
+    expect(component.rules()).toEqual(rules);
+    expect(component.hasError()).toBe(false);
+  });
+
+  it('shows a load error instead of an empty table', () => {
+    serviceSpy.getAccountingrules.mockReturnValue(
+      throwError(() => new Error('boom')) as unknown as ReturnType<
+        AccountingRulesService['getAccountingrules']
+      >,
+    );
+
+    component.onRetry();
+    fixture.detectChanges();
+
+    expect(component.hasError()).toBe(true);
+    expect(component.rules()).toEqual([]);
+    expect(fixture.nativeElement.querySelector('[data-testid="data-table-error"]')).not.toBeNull();
+  });
+
+  it('clears the error after a successful retry', () => {
+    serviceSpy.getAccountingrules.mockReturnValue(
+      throwError(() => new Error('boom')) as unknown as ReturnType<
+        AccountingRulesService['getAccountingrules']
+      >,
+    );
+    component.onRetry();
+    expect(component.hasError()).toBe(true);
+
+    serviceSpy.getAccountingrules.mockReturnValue(
+      of(rules) as unknown as ReturnType<AccountingRulesService['getAccountingrules']>,
+    );
+
+    component.onRetry();
+
+    expect(component.hasError()).toBe(false);
+    expect(component.rules()).toEqual(rules);
+  });
+});

--- a/src/app/features/accounting/accounting-rules-list.component.ts
+++ b/src/app/features/accounting/accounting-rules-list.component.ts
@@ -20,6 +20,8 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 
 import { Router } from '@angular/router';
+import { of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
 import { TranslatePipe } from '../../core/adapters';
 import { AccountingRulesService } from '../../api/api/accountingRules.service';
 import { AccountingRuleData } from '../../api/model/models';
@@ -37,6 +39,8 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
   template: `
     <div class="container">
       <app-data-table
+        [hasError]="hasError()"
+        (retry)="onRetry()"
         title="nav.accountingRules"
         [data]="rules()"
         [columns]="columns"
@@ -85,6 +89,8 @@ export class AccountingRulesListComponent implements OnInit {
   private readonly router = inject(Router);
 
   readonly rules = signal<AccountingRuleData[]>([]);
+  /** True when the last load failed, so the table offers a retry instead of an empty list. */
+  readonly hasError = signal(false);
   columns: ColumnDef[] = [
     { key: 'name', label: 'COMMON.NAME', sortable: true },
     { key: 'officeName', label: 'COMMON.OFFICE', sortable: true },
@@ -98,9 +104,20 @@ export class AccountingRulesListComponent implements OnInit {
   }
 
   loadRules() {
-    this.accountingRulesService.getAccountingrules().subscribe((rules) => {
-      this.rules.set(rules);
-    });
+    this.accountingRulesService
+      .getAccountingrules()
+      .pipe(
+        tap(() => this.hasError.set(false)),
+        catchError(() => {
+          this.hasError.set(true);
+          return of([] as AccountingRuleData[]);
+        }),
+      )
+      .subscribe((rules) => this.rules.set(rules ?? []));
+  }
+
+  onRetry(): void {
+    this.loadRules();
   }
 
   onCreate() {


### PR DESCRIPTION
Part of #223. accounting-rules-list now binds hasError/retry so a failed load is not an empty table.