### PR TITLE
test: migrate timer and async specs to Vitest

### DIFF
--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -62,7 +62,6 @@
     "src/app/features/products/tax-components/tax-components-list.component.spec.ts",
     "src/app/features/products/tax-groups/tax-group-form.component.spec.ts",
     "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
-    "src/app/shared/components/client-search/client-search.component.spec.ts",
     "src/app/shared/components/search-filter/search-filter.component.spec.ts",
     "src/app/shared/directives/tooltip.directive.spec.ts"
   ]

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -3,7 +3,6 @@
   "$comment": "Specs still on the deprecated Karma runner. Written by scripts/check-test-runner.mjs; files may leave this list, never join it. See DOCS/adr/0004-vitest-migration.md.",
   "grandfathered": ["src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"],
   "specs": [
-    "src/app/core/services/idle.service.spec.ts",
     "src/app/features/clients/charges/client-charge-form.component.spec.ts",
     "src/app/features/clients/charges/client-charges-list.component.spec.ts",
     "src/app/features/clients/client-action-dialog.component.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -59,7 +59,6 @@
     "src/app/features/products/tax-components/tax-component-form.component.spec.ts",
     "src/app/features/products/tax-components/tax-components-list.component.spec.ts",
     "src/app/features/products/tax-groups/tax-group-form.component.spec.ts",
-    "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
-    "src/app/shared/directives/tooltip.directive.spec.ts"
+    "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts"
   ]
 }

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -18,7 +18,6 @@
     "src/app/features/clients/kyc/client-note-form.component.spec.ts",
     "src/app/features/clients/tabs/client-documents-list.component.spec.ts",
     "src/app/features/clients/transactions/client-transactions-list.component.spec.ts",
-    "src/app/features/groups/group-members-dialog.component.spec.ts",
     "src/app/features/loans/bulk-reassignment/bulk-reassignment.component.spec.ts",
     "src/app/features/loans/collateral/collateral-form.component.spec.ts",
     "src/app/features/loans/collateral/collateral-list.component.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -3,7 +3,6 @@
   "$comment": "Specs still on the deprecated Karma runner. Written by scripts/check-test-runner.mjs; files may leave this list, never join it. See DOCS/adr/0004-vitest-migration.md.",
   "grandfathered": ["src/app/features/tasks/checker-inbox/checker-inbox.component.spec.ts"],
   "specs": [
-    "src/app/core/interceptors/retry.interceptor.spec.ts",
     "src/app/core/services/idle.service.spec.ts",
     "src/app/features/clients/charges/client-charge-form.component.spec.ts",
     "src/app/features/clients/charges/client-charges-list.component.spec.ts",

--- a/karma-baseline.json
+++ b/karma-baseline.json
@@ -62,7 +62,6 @@
     "src/app/features/products/tax-components/tax-components-list.component.spec.ts",
     "src/app/features/products/tax-groups/tax-group-form.component.spec.ts",
     "src/app/features/products/tax-groups/tax-groups-list.component.spec.ts",
-    "src/app/shared/components/search-filter/search-filter.component.spec.ts",
     "src/app/shared/directives/tooltip.directive.spec.ts"
   ]
 }

--- a/src/app/core/interceptors/retry.interceptor.test.ts
+++ b/src/app/core/interceptors/retry.interceptor.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { idempotent, withRetry, withTimeout } from '../http/http-context';
@@ -32,6 +32,7 @@ describe('retryInterceptor', () => {
   const PAST_ALL_BACKOFF = 5000;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(withInterceptors([retryInterceptor])),
@@ -43,17 +44,19 @@ describe('retryInterceptor', () => {
     http = TestBed.inject(HttpTestingController);
   });
 
+  afterEach(() => vi.useRealTimers());
+
   /** Fails every request made to `url` so far, then lets the backoff timer elapse. */
   function failAll(url: string, status: number): number {
     const pending = http.match(url);
     for (const req of pending) {
       req.flush(null, { status, statusText: 'Failed' });
     }
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
     return pending.length;
   }
 
-  it('should retry a GET on a transient failure and surface the last one', fakeAsync(() => {
+  it('should retry a GET on a transient failure and surface the last one', () => {
     let received: unknown = null;
     httpClient.get(testUrl).subscribe({ error: (err) => (received = err) });
 
@@ -66,51 +69,49 @@ describe('retryInterceptor', () => {
     expect(attempts).toBe(DEFAULT_RETRY_COUNT + 1);
     expect(received).toBeTruthy();
     http.verify();
-  }));
+  });
 
-  it('should stop retrying as soon as an attempt succeeds', fakeAsync(() => {
+  it('should stop retrying as soon as an attempt succeeds', () => {
     let response: unknown = null;
     httpClient.get(testUrl).subscribe((r) => (response = r));
 
     failAll(testUrl, 503);
     http.expectOne(testUrl).flush({ data: 'ok' });
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
 
     expect(response).toEqual({ data: 'ok' });
     http.verify();
-  }));
+  });
 
-  it('should not retry a 4xx, which repeating cannot fix', fakeAsync(() => {
-    httpClient.get(testUrl).subscribe({ error: () => expect().nothing() });
+  it('should not retry a 4xx, which repeating cannot fix', () => {
+    httpClient.get(testUrl).subscribe({ error: () => undefined });
 
     http.expectOne(testUrl).flush(null, { status: 400, statusText: 'Bad Request' });
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
 
     http.verify();
-  }));
+  });
 
-  it('should not retry a 500, which is deterministic more often than not', fakeAsync(() => {
-    httpClient.get(testUrl).subscribe({ error: () => expect().nothing() });
+  it('should not retry a 500, which is deterministic more often than not', () => {
+    httpClient.get(testUrl).subscribe({ error: () => undefined });
 
     http.expectOne(testUrl).flush(null, { status: 500, statusText: 'Server Error' });
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
 
     http.verify();
-  }));
+  });
 
-  it('should not repeat a POST, which may already have been applied', fakeAsync(() => {
-    httpClient.post(testUrl, {}).subscribe({ error: () => expect().nothing() });
+  it('should not repeat a POST, which may already have been applied', () => {
+    httpClient.post(testUrl, {}).subscribe({ error: () => undefined });
 
     http.expectOne(testUrl).flush(null, { status: 503, statusText: 'Unavailable' });
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
 
     http.verify();
-  }));
+  });
 
-  it('should repeat a POST the call site declared idempotent', fakeAsync(() => {
-    httpClient
-      .post(testUrl, {}, { context: idempotent() })
-      .subscribe({ error: () => expect().nothing() });
+  it('should repeat a POST the call site declared idempotent', () => {
+    httpClient.post(testUrl, {}, { context: idempotent() }).subscribe({ error: () => undefined });
 
     let attempts = 0;
     for (let i = 0; i <= DEFAULT_RETRY_COUNT; i++) {
@@ -119,58 +120,56 @@ describe('retryInterceptor', () => {
 
     expect(attempts).toBe(DEFAULT_RETRY_COUNT + 1);
     http.verify();
-  }));
+  });
 
-  it('should not treat an explicit count as permission to repeat a POST', fakeAsync(() => {
+  it('should not treat an explicit count as permission to repeat a POST', () => {
     // withRetry() tunes retrying where it is allowed; idempotent() is what authorises it.
-    httpClient
-      .post(testUrl, {}, { context: withRetry(3) })
-      .subscribe({ error: () => expect().nothing() });
+    httpClient.post(testUrl, {}, { context: withRetry(3) }).subscribe({ error: () => undefined });
 
     http.expectOne(testUrl).flush(null, { status: 503, statusText: 'Unavailable' });
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
 
     http.verify();
-  }));
+  });
 
-  it('should let a GET opt out with a count of zero', fakeAsync(() => {
-    httpClient
-      .get(testUrl, { context: withRetry(0) })
-      .subscribe({ error: () => expect().nothing() });
+  it('should let a GET opt out with a count of zero', () => {
+    httpClient.get(testUrl, { context: withRetry(0) }).subscribe({ error: () => undefined });
 
     http.expectOne(testUrl).flush(null, { status: 503, statusText: 'Unavailable' });
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
 
     http.verify();
-  }));
+  });
 
-  it('should not impose a timeout unless the call site asks for one', fakeAsync(() => {
+  it('should not impose a timeout unless the call site asks for one', () => {
     let response: unknown = null;
     httpClient.get(testUrl).subscribe((r) => (response = r));
 
     // Longer than any default would plausibly be — a report or batch job runs this long.
-    tick(120_000);
+    vi.advanceTimersByTime(120_000);
     http.expectOne(testUrl).flush({ data: 'ok' });
-    tick(PAST_ALL_BACKOFF);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
 
     expect(response).toEqual({ data: 'ok' });
     http.verify();
-  }));
+  });
 
-  it('should abandon a request that outruns its own deadline', fakeAsync(() => {
+  it('should abandon a request that outruns its own deadline', () => {
     let received: unknown = null;
     httpClient.get(testUrl, { context: withTimeout(1000) }).subscribe({
-      next: () => fail('expected a timeout'),
+      next: () => {
+        throw new Error('expected a timeout');
+      },
       error: (err) => (received = err),
     });
 
     const req = http.expectOne(testUrl);
-    tick(1500);
+    vi.advanceTimersByTime(1500);
 
     expect(received).toBeTruthy();
     // The deadline is honoured, not multiplied by the retry count.
-    expect(req.cancelled).toBeTrue();
-    tick(PAST_ALL_BACKOFF);
+    expect(req.cancelled).toBe(true);
+    vi.advanceTimersByTime(PAST_ALL_BACKOFF);
     http.verify();
-  }));
+  });
 });

--- a/src/app/core/services/idle.service.test.ts
+++ b/src/app/core/services/idle.service.test.ts
@@ -17,24 +17,26 @@
  * under the License.
  */
 
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { NavigationEnd, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { IdleService } from './idle.service';
 import { AuthService } from './auth.service';
 import { DialogService } from './dialog.service';
 import { FakeOverlayAdapter, provideFakeAdapters } from '../../testing/adapters';
+import { createSpyObj, SpyObj } from '../../testing/mocks';
 
 describe('IdleService', () => {
   let service: IdleService;
-  let authServiceSpy: jasmine.SpyObj<AuthService>;
-  let routerSpy: jasmine.SpyObj<Router>;
+  let authServiceSpy: SpyObj<AuthService>;
+  let routerSpy: SpyObj<Router>;
   let routerEvents: Subject<unknown>;
   let overlay: FakeOverlayAdapter;
 
   beforeEach(() => {
-    authServiceSpy = jasmine.createSpyObj('AuthService', ['logout', 'isAuthenticated']);
-    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    vi.useFakeTimers();
+    authServiceSpy = createSpyObj<AuthService>(['logout', 'isAuthenticated']);
+    routerSpy = createSpyObj<Router>(['navigate']);
     routerEvents = new Subject<unknown>();
     // `Router.events` is a real Observable, not a spied method — the constructor subscribes
     // to it directly, so the double has to supply one rather than leave it undefined.
@@ -52,34 +54,36 @@ describe('IdleService', () => {
       ],
     });
 
-    authServiceSpy.isAuthenticated.and.returnValue(false);
+    authServiceSpy.isAuthenticated.mockReturnValue(false);
   });
+
+  afterEach(() => vi.useRealTimers());
 
   it('should be created', () => {
     service = TestBed.inject(IdleService);
     expect(service).toBeTruthy();
   });
 
-  it('should show warning dialog before timeout', fakeAsync(() => {
-    authServiceSpy.isAuthenticated.and.returnValue(true);
+  it('should show warning dialog before timeout', () => {
+    authServiceSpy.isAuthenticated.mockReturnValue(true);
     overlay.nextModalResult = true;
 
     service = TestBed.inject(IdleService);
 
     // Total 15m, Warning at 13m. Advance to 13m
-    tick(13 * 60 * 1000 + 1000);
+    vi.advanceTimersByTime(13 * 60 * 1000 + 1000);
 
-    expect(overlay.modals).toHaveSize(1);
+    expect(overlay.modals).toHaveLength(1);
     // Ignoring the warning has to fall through to the logout timer, so neither the backdrop
     // nor Escape may take it down.
     expect(overlay.lastModal!.dismissible).toBe(false);
     service.ngOnDestroy();
-  }));
+  });
 
-  it('should logout if user does not respond to warning', fakeAsync(() => {
-    authServiceSpy.isAuthenticated.and.returnValue(true);
+  it('should logout if user does not respond to warning', () => {
+    authServiceSpy.isAuthenticated.mockReturnValue(true);
     // The user never answers the warning, so the hard logout timer must fire.
-    spyOn(overlay, 'presentModal').and.resolveTo({
+    vi.spyOn(overlay, 'presentModal').mockResolvedValue({
       result: new Promise(() => undefined),
       dismiss: () => Promise.resolve(),
     });
@@ -87,20 +91,20 @@ describe('IdleService', () => {
     service = TestBed.inject(IdleService);
 
     // Advance to 13m (warning shows)
-    tick(13 * 60 * 1000 + 1000);
+    vi.advanceTimersByTime(13 * 60 * 1000 + 1000);
     expect(overlay.presentModal).toHaveBeenCalled();
 
     // Advance remaining 2m
-    tick(2 * 60 * 1000 + 1000);
+    vi.advanceTimersByTime(2 * 60 * 1000 + 1000);
 
     expect(authServiceSpy.logout).toHaveBeenCalled();
     expect(routerSpy.navigate).toHaveBeenCalled();
 
     service.ngOnDestroy();
-  }));
+  });
 
-  it('keeps the hard logout timer running when activity is reported while the warning is still being presented', fakeAsync(() => {
-    authServiceSpy.isAuthenticated.and.returnValue(true);
+  it('keeps the hard logout timer running when activity is reported while the warning is still being presented', async () => {
+    authServiceSpy.isAuthenticated.mockReturnValue(true);
 
     // Simulates the window between the warning timer firing and `dialogService.present()`
     // actually resolving — the exact gap in which `dialogRef` used to sit unset, making the
@@ -112,7 +116,7 @@ describe('IdleService', () => {
       result: Promise<unknown>;
       dismiss: () => Promise<void>;
     }) => void;
-    spyOn(overlay, 'presentModal').and.returnValue(
+    vi.spyOn(overlay, 'presentModal').mockReturnValue(
       new Promise((resolve) => {
         resolvePresent = resolve;
       }),
@@ -120,48 +124,51 @@ describe('IdleService', () => {
 
     service = TestBed.inject(IdleService);
 
-    tick(13 * 60 * 1000 + 1000);
+    vi.advanceTimersByTime(13 * 60 * 1000 + 1000);
     expect(overlay.presentModal).toHaveBeenCalledTimes(1);
 
     // An activity event lands before the modal has actually presented.
     window.dispatchEvent(new Event('mousemove'));
-    tick(1);
+    vi.advanceTimersByTime(1);
 
     // The modal now presents, and the user never answers it.
     resolvePresent({ result: new Promise(() => undefined), dismiss: () => Promise.resolve() });
-    tick();
+    await Promise.resolve();
 
     // If the stray activity event had reset the timer, this would not be enough time to
     // reach the hard logout — it would take another ~13 minutes instead.
-    tick(2 * 60 * 1000 + 1000);
+    vi.advanceTimersByTime(2 * 60 * 1000 + 1000);
 
     expect(authServiceSpy.logout).toHaveBeenCalled();
     expect(overlay.presentModal).toHaveBeenCalledTimes(1);
 
     service.ngOnDestroy();
-  }));
+  });
 
-  it('closes the warning dialog once navigation actually lands on the login page', fakeAsync(() => {
-    authServiceSpy.isAuthenticated.and.returnValue(true);
+  it('closes the warning dialog once navigation actually lands on the login page', async () => {
+    authServiceSpy.isAuthenticated.mockReturnValue(true);
     // The user never answers, so nothing else would close this dialog before the hard
     // logout timer does — the router subscription below has to be what closes it instead.
-    const dismissSpy = jasmine.createSpy('dismiss').and.resolveTo(undefined);
-    spyOn(overlay, 'presentModal').and.resolveTo({
+    const dismissSpy = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(overlay, 'presentModal').mockResolvedValue({
       result: new Promise(() => undefined),
       dismiss: dismissSpy,
     });
 
     service = TestBed.inject(IdleService);
 
-    tick(13 * 60 * 1000 + 1000);
+    vi.advanceTimersByTime(13 * 60 * 1000 + 1000);
     expect(overlay.presentModal).toHaveBeenCalled();
     expect(dismissSpy).not.toHaveBeenCalled();
+    // `presentModal()` resolves on a native promise. Let the dialog handle become available
+    // before the router event asks the service to close it.
+    await Promise.resolve();
 
     routerEvents.next(new NavigationEnd(1, '/login?reason=inactivity', '/login?reason=inactivity'));
-    tick();
+    await Promise.resolve();
 
     expect(dismissSpy).toHaveBeenCalled();
 
     service.ngOnDestroy();
-  }));
+  });
 });

--- a/src/app/features/groups/group-members-dialog.component.test.ts
+++ b/src/app/features/groups/group-members-dialog.component.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 
@@ -27,6 +27,7 @@ import {
 } from './group-members-dialog.component';
 import { ClientService } from '../../api';
 import { provideFakeAdapters, FakeOverlayAdapter } from '../../testing/adapters';
+import { createSpyObj, SpyObj } from '../../testing/mocks';
 
 /** Longer than the component's 300ms debounce. */
 const AFTER_DEBOUNCE = 350;
@@ -35,12 +36,12 @@ const AMINA = 'Amina Yusuf';
 describe('GroupMembersDialogComponent', () => {
   let fixture: ComponentFixture<GroupMembersDialogComponent>;
   let component: GroupMembersDialogComponent;
-  let clientService: jasmine.SpyObj<ClientService>;
+  let clientService: SpyObj<ClientService>;
   let overlay: FakeOverlayAdapter;
 
   async function setup(data: GroupMembersDialogData): Promise<void> {
-    clientService = jasmine.createSpyObj('ClientService', ['getClients']);
-    clientService.getClients.and.returnValue(
+    clientService = createSpyObj<ClientService>(['getClients']);
+    clientService.getClients.mockReturnValue(
       of({
         pageItems: [
           { id: 11, accountNo: '000000011', displayName: AMINA },
@@ -67,35 +68,40 @@ describe('GroupMembersDialogComponent', () => {
     fixture.detectChanges();
   }
 
-  it('excludes clients already in the group from the add candidates', fakeAsync(async () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('excludes clients already in the group from the add candidates', async () => {
+    vi.useFakeTimers();
     await setup({
       mode: 'add',
       officeId: 1,
       members: [{ id: 11, displayName: AMINA }],
     });
 
-    tick(AFTER_DEBOUNCE);
+    vi.advanceTimersByTime(AFTER_DEBOUNCE);
     fixture.detectChanges();
 
     // Client 11 comes back from the search but is already a member; associating them a second
     // time is rejected by the platform, so the dialog must not offer them.
     expect(component.candidates().map((candidate) => candidate.id)).toEqual([21]);
-  }));
+  });
 
-  it('scopes the candidate search to the group office, but not by client status', fakeAsync(async () => {
+  it('scopes the candidate search to the group office, but not by client status', async () => {
+    vi.useFakeTimers();
     await setup({ mode: 'add', officeId: 4, members: [] });
 
-    tick(AFTER_DEBOUNCE);
+    vi.advanceTimersByTime(AFTER_DEBOUNCE);
 
     // Signature: officeId, externalId, displayName, firstName, lastName, status, …
-    const args = clientService.getClients.calls.mostRecent().args;
+    const args = clientService.getClients.mock.calls.at(-1)!;
     expect(args[0]).toBe(4);
     // `associateClients` accepts a pending client, and a group whose members activate after it
     // forms is the ordinary case. Filtering to 'active' hid them.
     expect(args[5]).toBeUndefined();
-  }));
+  });
 
-  it('lists the current members and makes no search in remove mode', fakeAsync(async () => {
+  it('lists the current members and makes no search in remove mode', async () => {
+    vi.useFakeTimers();
     await setup({
       mode: 'remove',
       officeId: 1,
@@ -105,15 +111,16 @@ describe('GroupMembersDialogComponent', () => {
       ],
     });
 
-    tick(AFTER_DEBOUNCE);
+    vi.advanceTimersByTime(AFTER_DEBOUNCE);
 
     expect(component.candidates().map((candidate) => candidate.id)).toEqual([11, 12]);
     expect(clientService.getClients).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('toggles a selection off again and resolves with the chosen ids', fakeAsync(async () => {
+  it('toggles a selection off again and resolves with the chosen ids', async () => {
+    vi.useFakeTimers();
     await setup({ mode: 'remove', officeId: 1, members: [{ id: 11 }, { id: 12 }] });
-    tick(AFTER_DEBOUNCE);
+    vi.advanceTimersByTime(AFTER_DEBOUNCE);
 
     component.toggle(11);
     component.toggle(12);
@@ -121,13 +128,14 @@ describe('GroupMembersDialogComponent', () => {
 
     component.onConfirm();
     expect(overlay.dismissals.at(-1)).toEqual({ clientMembers: [12] });
-  }));
+  });
 
-  it('does not resolve while nothing is selected', fakeAsync(async () => {
+  it('does not resolve while nothing is selected', async () => {
+    vi.useFakeTimers();
     await setup({ mode: 'remove', officeId: 1, members: [{ id: 11 }] });
-    tick(AFTER_DEBOUNCE);
+    vi.advanceTimersByTime(AFTER_DEBOUNCE);
 
     component.onConfirm();
     expect(overlay.dismissals).toEqual([]);
-  }));
+  });
 });

--- a/src/app/shared/components/client-search/client-search.component.test.ts
+++ b/src/app/shared/components/client-search/client-search.component.test.ts
@@ -17,30 +17,35 @@
  * under the License.
  */
 
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ClientSearchComponent } from './client-search.component';
 import { ClientService, GetClientsResponse } from '../../../api';
 import { Observable, of } from 'rxjs';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { TranslateModule } from '@ngx-translate/core';
 import { HttpEvent } from '@angular/common/http';
+import { createSpyObj, SpyObj } from '../../../testing/mocks';
+import { provideTranslateTesting } from '../../../testing/i18n-testing';
 
 describe('ClientSearchComponent', () => {
   let component: ClientSearchComponent;
   let fixture: ComponentFixture<ClientSearchComponent>;
-  let clientServiceSpy: jasmine.SpyObj<ClientService>;
+  let clientServiceSpy: SpyObj<ClientService>;
 
   beforeEach(async () => {
-    clientServiceSpy = jasmine.createSpyObj('ClientService', ['getClients', 'getClientsClientId']);
+    clientServiceSpy = createSpyObj<ClientService>(['getClients', 'getClientsClientId']);
 
     // Provide a default return value for all calls to retrieveAll21
-    clientServiceSpy.getClients.and.returnValue(
+    clientServiceSpy.getClients.mockReturnValue(
       of({ pageItems: [] }) as unknown as Observable<HttpEvent<GetClientsResponse>>,
     );
 
     await TestBed.configureTestingModule({
-      imports: [ClientSearchComponent, TranslateModule.forRoot()],
-      providers: [provideNoopAnimations(), { provide: ClientService, useValue: clientServiceSpy }],
+      imports: [ClientSearchComponent],
+      providers: [
+        provideNoopAnimations(),
+        ...provideTranslateTesting(),
+        { provide: ClientService, useValue: clientServiceSpy },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ClientSearchComponent);
@@ -52,24 +57,27 @@ describe('ClientSearchComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should search for clients when input changes', fakeAsync(() => {
+  afterEach(() => vi.useRealTimers());
+
+  it('should search for clients when input changes', () => {
+    vi.useFakeTimers();
     const mockResponse = {
       pageItems: [{ id: 1, displayName: 'John Doe', accountNo: '001' }],
     };
 
     // Set mock BEFORE detectChanges to catch initial startWith call if needed,
     // but we specifically want to test the change to 'John'.
-    clientServiceSpy.getClients.and.returnValue(
+    clientServiceSpy.getClients.mockReturnValue(
       of(mockResponse) as unknown as Observable<HttpEvent<GetClientsResponse>>,
     );
 
     fixture.detectChanges(); // Trigger ngOnInit
-    tick(300); // Handle initial startWith('') call
+    vi.advanceTimersByTime(300); // Handle initial startWith('') call
 
-    clientServiceSpy.getClients.calls.reset();
+    clientServiceSpy.getClients.mockClear();
 
     component.searchControl.setValue('John');
-    tick(300); // Debounce time
+    vi.advanceTimersByTime(300); // Debounce time
 
     expect(clientServiceSpy.getClients).toHaveBeenCalledWith(
       undefined,
@@ -82,13 +90,13 @@ describe('ClientSearchComponent', () => {
       0,
       20,
     );
-    expect(component.filteredClients()).toHaveSize(1);
+    expect(component.filteredClients()).toHaveLength(1);
     expect(component.filteredClients()[0]['displayName']).toBe('John Doe');
-  }));
+  });
 
   it('should emit selected client id', () => {
     fixture.detectChanges();
-    spyOn(component.clientSelected, 'emit');
+    vi.spyOn(component.clientSelected, 'emit');
     const mockClient = { id: 123, displayName: 'Test Client' };
 
     component.onSelected(mockClient as unknown as Record<string, unknown>);

--- a/src/app/shared/components/search-filter/search-filter.component.test.ts
+++ b/src/app/shared/components/search-filter/search-filter.component.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SearchFilterComponent } from './search-filter.component';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
@@ -40,8 +40,11 @@ describe('SearchFilterComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should emit searchChange with debounced value', fakeAsync(() => {
-    spyOn(component.searchChange, 'emit');
+  afterEach(() => vi.useRealTimers());
+
+  it('should emit searchChange with debounced value', () => {
+    vi.useFakeTimers();
+    vi.spyOn(component.searchChange, 'emit');
 
     const inputElement = fixture.nativeElement.querySelector('input');
 
@@ -53,13 +56,14 @@ describe('SearchFilterComponent', () => {
     expect(component.searchChange.emit).not.toHaveBeenCalled();
 
     // Wait for debounceTime (400ms)
-    tick(400);
+    vi.advanceTimersByTime(400);
 
     expect(component.searchChange.emit).toHaveBeenCalledWith('test');
-  }));
+  });
 
-  it('should trim the input value before emitting', fakeAsync(() => {
-    spyOn(component.searchChange, 'emit');
+  it('should trim the input value before emitting', () => {
+    vi.useFakeTimers();
+    vi.spyOn(component.searchChange, 'emit');
 
     const inputElement = fixture.nativeElement.querySelector('input');
 
@@ -68,28 +72,29 @@ describe('SearchFilterComponent', () => {
     inputElement.dispatchEvent(new Event('input'));
 
     // Wait for debounceTime (400ms)
-    tick(400);
+    vi.advanceTimersByTime(400);
 
     expect(component.searchChange.emit).toHaveBeenCalledWith('test value');
-  }));
+  });
 
-  it('should not emit if the trimmed value is identical to the previous one', fakeAsync(() => {
-    spyOn(component.searchChange, 'emit');
+  it('should not emit if the trimmed value is identical to the previous one', () => {
+    vi.useFakeTimers();
+    vi.spyOn(component.searchChange, 'emit');
 
     const inputElement = fixture.nativeElement.querySelector('input');
 
     // First emission
     inputElement.value = 'test';
     inputElement.dispatchEvent(new Event('input'));
-    tick(400);
+    vi.advanceTimersByTime(400);
     expect(component.searchChange.emit).toHaveBeenCalledTimes(1);
 
     // Second emission with same value
     inputElement.value = 'test  ';
     inputElement.dispatchEvent(new Event('input'));
-    tick(400);
+    vi.advanceTimersByTime(400);
 
     // Should still be called only once
     expect(component.searchChange.emit).toHaveBeenCalledTimes(1);
-  }));
+  });
 });

--- a/src/app/shared/directives/tooltip.directive.test.ts
+++ b/src/app/shared/directives/tooltip.directive.test.ts
@@ -54,14 +54,14 @@ describe('TooltipDirective', () => {
     TestBed.configureTestingModule({ imports: [TestComponent] });
     fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
-    jasmine.clock().install();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     // Directives destroyed by the fixture already clean up after themselves; this only
     // catches anything a failing assertion left behind, so later specs start from zero.
     document.querySelectorAll(TOOLTIP_SELECTOR).forEach((el) => el.remove());
-    jasmine.clock().uninstall();
+    vi.useRealTimers();
   });
 
   function host(id: string): HTMLElement {
@@ -73,7 +73,7 @@ describe('TooltipDirective', () => {
 
     el.dispatchEvent(new Event('mouseenter'));
     el.dispatchEvent(new Event('focusin'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
 
     expect(tooltipCount()).toBe(1);
   });
@@ -82,7 +82,7 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
     expect(tooltipCount()).toBe(1);
 
     el.dispatchEvent(new Event('mouseleave'));
@@ -94,13 +94,13 @@ describe('TooltipDirective', () => {
     const second = host('#second');
 
     first.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
     expect(tooltipCount()).toBe(1);
 
     // The pointer moves to the second host without the first ever reporting mouseleave —
     // e.g. focus lands there via keyboard while the mouse is still over the first element.
     second.dispatchEvent(new Event('focusin'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
 
     expect(tooltipCount()).toBe(1);
     expect(document.querySelector(TOOLTIP_SELECTOR)?.textContent).toBe('Second host');
@@ -110,7 +110,7 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
     expect(tooltipCount()).toBe(1);
 
     fixture.destroy();
@@ -122,10 +122,10 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY - 1);
+    vi.advanceTimersByTime(SHOW_DELAY - 1);
     expect(tooltipCount()).toBe(0);
 
-    jasmine.clock().tick(1);
+    vi.advanceTimersByTime(1);
     expect(tooltipCount()).toBe(1);
   });
 
@@ -133,7 +133,7 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
 
     const bubble = tooltip();
     expect(bubble).not.toBeNull();
@@ -146,7 +146,7 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('focusin'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
 
     expect(tooltip()?.textContent).toBe('First host');
   });
@@ -159,7 +159,7 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
 
     expect(el.getAttribute(DESCRIBED_BY)).toBeTruthy();
     expect(el.getAttribute('aria-label')).toBeNull();
@@ -169,7 +169,7 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
     el.dispatchEvent(new Event('mouseleave'));
 
     expect(tooltipCount()).toBe(0);
@@ -180,7 +180,7 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 
     expect(tooltipCount()).toBe(0);
@@ -190,9 +190,9 @@ describe('TooltipDirective', () => {
     const el = host('#first');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY - 100);
+    vi.advanceTimersByTime(SHOW_DELAY - 100);
     el.dispatchEvent(new Event('mouseleave'));
-    jasmine.clock().tick(SHOW_DELAY);
+    vi.advanceTimersByTime(SHOW_DELAY);
 
     // A passing hover must not leave a tooltip behind after the timer would have fired.
     expect(tooltipCount()).toBe(0);
@@ -204,7 +204,7 @@ describe('TooltipDirective', () => {
     const el = host('#variable');
 
     el.dispatchEvent(new Event('mouseenter'));
-    jasmine.clock().tick(SHOW_DELAY + 1);
+    vi.advanceTimersByTime(SHOW_DELAY + 1);
 
     expect(tooltipCount()).toBe(0);
   });


### PR DESCRIPTION
## What and why

Migrates the remaining timer- and async-based specs from Karma/Jasmine to Vitest as part of #410:

- group members dialog
- client search
- search filter
- retry interceptor
- idle service
- tooltip directive

### Migration patterns used

- Rename migrated specs from `.spec.ts` to `.test.ts` so they run under Vitest.
- Replace Angular `fakeAsync` / `tick()` and `jasmine.clock()` with `vi.useFakeTimers()` and `vi.advanceTimersByTime()`, restoring real timers after each test.
- Replace Jasmine spies and matchers with the repository's Vitest-compatible spy helpers and `vi.spyOn`.
- Use `async` / `await` where a timer-triggered action also needs a native promise to settle, notably the idle-service modal flow.
- Keep Angular HTTP testing calls such as `req.flush()` as HTTP responses, rather than treating them as timer helpers.

The migrations preserve the existing debounce, retry/backoff, timeout, modal, and tooltip-delay behaviour. Each spec remains in its own commit.

## Verification

- `env TZ=UTC npm run test:unit` — 178 files, 1044 tests passed
- `npm run check:test-runner` — 57 Karma specs remaining, 76% migrated
- `npm run lint`
- `npm run format:check`