### PR TITLE
fix(fintech): translate asset owner table titles

### DIFF
--- a/src/app/features/fintech/asset-owner-view/asset-owner-view.component.ts
+++ b/src/app/features/fintech/asset-owner-view/asset-owner-view.component.ts
@@ -139,7 +139,7 @@ export type AssetOwnerTab = (typeof ASSET_OWNER_TAB)[keyof typeof ASSET_OWNER_TA
 
         @if (activeTab() === TAB.details) {
           <app-data-table
-            title="Journal Entries"
+            title="nav.journalEntries"
             [columns]="journalColumns"
             [data]="(journalEntries$ | async) || []"
             [showSearch]="false"

--- a/src/app/features/fintech/asset-owners-list.component.ts
+++ b/src/app/features/fintech/asset-owners-list.component.ts
@@ -43,7 +43,7 @@ import { IonButton, IonIcon } from '@ionic/angular/standalone';
     <app-data-table
       [hasError]="hasError()"
       (retry)="onRetry()"
-      title="External Asset Owners"
+      title="ASSET_OWNERS.TITLE"
       helpTextKey="HELP.ASSET_OWNERS_DESC"
       [columns]="columns"
       [data]="transfers()"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2393,6 +2393,7 @@
     "DESCRIPTION": "Description"
   },
   "ASSET_OWNERS": {
+    "TITLE": "External Asset Owners",
     "LOAN_PRODUCT_ATTRIBUTES": "Loan Product Attributes",
     "ATTRIBUTE_KEY": "Key",
     "ATTRIBUTE_VALUE": "Value"


### PR DESCRIPTION
## What and why

Replace the two remaining hardcoded `app-data-table` titles in `src/app/features/fintech` with translation keys. `Journal Entries` reuses the existing `nav.journalEntries` entry, while `External Asset Owners` gets an `ASSET_OWNERS.TITLE` entry so the English text remains byte-for-byte unchanged.

This covers the `fintech` feature-directory portion of #251. It intentionally does not change hardcoded strings inside component bodies, which #251 lists as out of scope.

Part of #251.

## Verification

- RED/GREEN grep from #251: 2 matching hardcoded data-table attributes on upstream `main`; 0 after this patch under `src/app/features/fintech`
- `ng run fineract-backoffice-ui:unit-test --watch=false --progress=false` — 178 files and 1044/1044 Vitest tests passed
- `ng test fineract-backoffice-ui --watch=false --progress=false` — 329/329 Karma tests passed
- full ESLint check for `src` passed
- repository-wide Prettier check passed
- production build passed; it reported the unchanged upstream header style-budget warning only
- `node scripts/check-translations.mjs` — 1631 referenced keys checked against 2415 English keys, with no missing keys
- icon registry, license headers, and `git diff --check` passed

No real Fineract backend was required because this only routes existing table-title text through the translation catalog and preserves the English UI exactly.

## Screenshots

Not applicable — there is no visual change in English. Other locales now use the translation pipeline instead of a hardcoded English table title.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. (No new component or service code.)
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed. (Both full unit suites plus the translation-key gate pass; there is no dedicated fintech component spec.)
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. (No workflow or API behavior changed.)
- [x] Commits are signed — the commit was created with GitHub and reports a valid verified signature.
