### PR TITLE
feat(loans): edit interest pause periods

### DIFF
--- a/e2e/loan-servicing-gaps.spec.ts
+++ b/e2e/loan-servicing-gaps.spec.ts
@@ -18,7 +18,7 @@
  */
 
 /**
- * The loan gaps closed in #266, against mocks.
+ * The loan gaps closed in #266 and the interest-pause edit flow from #283, against mocks.
  *
  * Mocked rather than backend for two reasons. The four data tabs need a loan carrying term
  * variations, overdue charges, originators and a delinquency block, and a fresh platform
@@ -44,6 +44,7 @@ const MENU_TRIGGER = '#loanMenu-trigger';
 const UNDO_APPROVAL_ITEM = 'loan-undo-approval-action';
 const WRONG_CLIENT = 'approved against the wrong client';
 const OFFICER_NAME = 'Field Officer';
+const INTEREST_PAUSE_ID = 77;
 
 interface LoanOverrides {
   status?: Record<string, unknown>;
@@ -88,10 +89,11 @@ function loan(overrides: LoanOverrides) {
 /** Records what the page sent, so the assertions are about requests rather than appearances. */
 interface Probe {
   commands: { command: string | null; body: unknown }[];
+  interestPauseUpdates: { variationId: number; body: Record<string, unknown> }[];
 }
 
 async function loginWithLoan(page: Page, overrides: LoanOverrides): Promise<Probe> {
-  const probe: Probe = { commands: [] };
+  const probe: Probe = { commands: [], interestPauseUpdates: [] };
 
   await page.route('**/config.json*', async (route) => {
     await route.fulfill({
@@ -130,6 +132,40 @@ async function loginWithLoan(page: Page, overrides: LoanOverrides): Promise<Prob
     await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
   });
 
+  await page.route(
+    new RegExp(`/api/v1/loans/${LOAN_ID}/interest-pauses(?:/\\d+)?(?:\\?|$)`),
+    async (route) => {
+      const request = route.request();
+      if (request.method() === 'PUT') {
+        const variationId = Number(new URL(request.url()).pathname.split('/').pop());
+        probe.interestPauseUpdates.push({
+          variationId,
+          body: request.postDataJSON() as Record<string, unknown>,
+        });
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ loanId: LOAN_ID, resourceId: variationId }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        // Fineract deployments can serialize LocalDate this way; the form accepts this as well
+        // as the ISO strings declared by the generated OpenAPI model.
+        body: JSON.stringify([
+          {
+            id: INTEREST_PAUSE_ID,
+            startDate: [2026, 4, 1],
+            endDate: [2026, 4, 8],
+          },
+        ]),
+      });
+    },
+  );
+
   await page.route(/\/api\/v1\/loans\/456(\?|$)/, async (route) => {
     const request = route.request();
     if (request.method() === 'POST') {
@@ -164,6 +200,31 @@ async function loginWithLoan(page: Page, overrides: LoanOverrides): Promise<Prob
 const tab = (page: Page, testId: string) => page.getByTestId(testId);
 
 test.describe('Loan servicing gaps', () => {
+  test('edits an interest pause through PUT while preserving its existing dates', async ({
+    page,
+  }) => {
+    const probe = await loginWithLoan(page, {});
+
+    await page.goto(`/loans/${LOAN_ID}/interest-pauses`);
+    await page.getByRole('button', { name: 'Edit' }).click();
+
+    await expect(page).toHaveURL(`/loans/${LOAN_ID}/interest-pauses/edit/${INTEREST_PAUSE_ID}`);
+    await expect(page.getByText('Edit Interest Pause', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect.poll(() => probe.interestPauseUpdates.length).toBe(1);
+    expect(probe.interestPauseUpdates[0]).toEqual({
+      variationId: INTEREST_PAUSE_ID,
+      body: {
+        startDate: '01 April 2026',
+        endDate: '08 April 2026',
+        dateFormat: 'dd MMMM yyyy',
+        locale: 'en',
+      },
+    });
+    await expect(page).toHaveURL(`/loans/${LOAN_ID}/interest-pauses`);
+  });
+
   test('undo approval sends an empty body, without the locale the platform refuses', async ({
     page,
   }) => {

--- a/src/app/core/adapters/api/api-surface.json
+++ b/src/app/core/adapters/api/api-surface.json
@@ -393,7 +393,8 @@
   "LoanInterestPauseService": [
     "deleteLoansLoanIdInterestPausesVariationId",
     "getLoansLoanIdInterestPauses",
-    "postLoansLoanIdInterestPauses"
+    "postLoansLoanIdInterestPauses",
+    "putLoansLoanIdInterestPausesVariationId"
   ],
   "LoanOriginatorsService": [
     "deleteLoanOriginatorsOriginatorId",

--- a/src/app/features/loans/interest-pauses/interest-pause-form.component.test.ts
+++ b/src/app/features/loans/interest-pauses/interest-pause-form.component.test.ts
@@ -22,7 +22,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { InterestPauseFormComponent } from './interest-pause-form.component';
 import { LoanInterestPauseService } from '../../../api';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
@@ -32,8 +32,19 @@ describe('InterestPauseFormComponent', () => {
   let serviceSpy: SpyObj<LoanInterestPauseService>;
   let routerSpy: SpyObj<Router>;
 
-  beforeEach(async () => {
-    serviceSpy = createSpyObj(['postLoansLoanIdInterestPauses']);
+  async function setup(
+    params?: { loanId: string; variationId?: string },
+    pauses: { id: number; startDate: string | number[]; endDate: string | number[] }[] = [],
+  ) {
+    const routeParams = params ?? { loanId: '1' };
+    serviceSpy = createSpyObj([
+      'getLoansLoanIdInterestPauses',
+      'postLoansLoanIdInterestPauses',
+      'putLoansLoanIdInterestPausesVariationId',
+    ]);
+    serviceSpy.getLoansLoanIdInterestPauses.mockReturnValue(
+      of(pauses) as unknown as ReturnType<LoanInterestPauseService['getLoansLoanIdInterestPauses']>,
+    );
     routerSpy = createSpyObj(['navigate']);
 
     await TestBed.configureTestingModule({
@@ -43,7 +54,7 @@ describe('InterestPauseFormComponent', () => {
         { provide: Router, useValue: routerSpy },
         {
           provide: ActivatedRoute,
-          useValue: { snapshot: { paramMap: convertToParamMap({ loanId: '1' }) } },
+          useValue: { snapshot: { paramMap: convertToParamMap(routeParams) } },
         },
         provideNoopAnimations(),
       ],
@@ -52,19 +63,22 @@ describe('InterestPauseFormComponent', () => {
     fixture = TestBed.createComponent(InterestPauseFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }
 
-  it('should read the loan id from the route', () => {
+  it('should read the loan id from the route', async () => {
+    await setup();
+
     expect(component).toBeTruthy();
     expect(component.loanId).toBe(1);
   });
 
-  it('should post the formatted dates and navigate to the list', () => {
+  it('should post the formatted dates and navigate to the list', async () => {
+    await setup();
     serviceSpy.postLoansLoanIdInterestPauses.mockReturnValue(
       of({}) as unknown as ReturnType<LoanInterestPauseService['postLoansLoanIdInterestPauses']>,
     );
-    component.startDate = '2026-01-01';
-    component.endDate = '2026-02-01';
+    component.startDate.set('2026-01-01');
+    component.endDate.set('2026-02-01');
 
     component.onSubmit();
 
@@ -78,5 +92,60 @@ describe('InterestPauseFormComponent', () => {
       }),
     );
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'interest-pauses']);
+  });
+
+  it('should load and pre-fill the selected pause in edit mode', async () => {
+    await setup({ loanId: '1', variationId: '7' }, [
+      { id: 6, startDate: '2026-03-10', endDate: '2026-03-20' },
+      { id: 7, startDate: [2026, 4, 1], endDate: [2026, 4, 8] },
+    ]);
+
+    expect(component.isEditMode()).toBe(true);
+    expect(component.variationId).toBe(7);
+    expect(component.startDate()).toBe('2026-04-01');
+    expect(component.endDate()).toBe('2026-04-08');
+  });
+
+  it('should put the formatted dates and navigate to the list in edit mode', async () => {
+    await setup({ loanId: '1', variationId: '7' }, [
+      { id: 7, startDate: '2026-04-01', endDate: '2026-04-08' },
+    ]);
+    serviceSpy.putLoansLoanIdInterestPausesVariationId.mockReturnValue(
+      of({}) as unknown as ReturnType<
+        LoanInterestPauseService['putLoansLoanIdInterestPausesVariationId']
+      >,
+    );
+    component.startDate.set('2026-04-02');
+    component.endDate.set('2026-04-09');
+
+    component.onSubmit();
+
+    expect(serviceSpy.putLoansLoanIdInterestPausesVariationId).toHaveBeenCalledWith(
+      1,
+      7,
+      expect.objectContaining({
+        startDate: '02 April 2026',
+        endDate: '09 April 2026',
+        dateFormat: 'dd MMMM yyyy',
+        locale: 'en',
+      }),
+    );
+    expect(serviceSpy.postLoansLoanIdInterestPauses).not.toHaveBeenCalled();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'interest-pauses']);
+  });
+
+  it('should re-enable the edit form when the update is rejected', async () => {
+    await setup({ loanId: '1', variationId: '7' }, [
+      { id: 7, startDate: '2026-04-01', endDate: '2026-04-08' },
+    ]);
+    serviceSpy.putLoansLoanIdInterestPausesVariationId.mockReturnValue(
+      throwError(() => new Error('overlap')) as ReturnType<
+        LoanInterestPauseService['putLoansLoanIdInterestPausesVariationId']
+      >,
+    );
+    component.onSubmit();
+
+    expect(component.isSaving()).toBe(false);
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/loans/interest-pauses/interest-pause-form.component.ts
+++ b/src/app/features/loans/interest-pauses/interest-pause-form.component.ts
@@ -21,7 +21,11 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { LoanInterestPauseService, InterestPauseRequestDto } from '../../../api';
+import {
+  LoanInterestPauseService,
+  InterestPauseRequestDto,
+  InterestPauseResponseDto,
+} from '../../../api';
 import {
   IonButton,
   IonCard,
@@ -36,14 +40,16 @@ import {
   IonSpinner,
 } from '@ionic/angular/standalone';
 import {
+  formatArrayDate,
   formatDateToFineract,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
+  toIsoDate,
 } from '../../../core/utils/date-formatter';
 
 /**
- * Create form for an interest pause period on a loan. Submits a start/end date pair
- * formatted with the Fineract date format and locale. The loan id is taken from the route.
+ * Create or edit an interest pause period on a loan. Submits a start/end date pair formatted
+ * with the Fineract date format and locale. The loan and variation ids come from the route.
  */
 @Component({
   selector: 'app-interest-pause-form',
@@ -67,7 +73,9 @@ import {
     <div class="form-container">
       <ion-card>
         <ion-card-header>
-          <ion-card-title>{{ 'INTEREST_PAUSES.CREATE' | translate }}</ion-card-title>
+          <ion-card-title>
+            {{ (isEditMode() ? 'INTEREST_PAUSES.EDIT' : 'INTEREST_PAUSES.CREATE') | translate }}
+          </ion-card-title>
         </ion-card-header>
 
         <ion-card-content>
@@ -84,7 +92,8 @@ import {
                     data-testid="startDate-picker"
                     presentation="date"
                     name="startDate"
-                    [(ngModel)]="startDate"
+                    [ngModel]="startDate()"
+                    (ngModelChange)="startDate.set($event)"
                     required
                   ></ion-datetime>
                 </ng-template>
@@ -101,7 +110,8 @@ import {
                     data-testid="endDate-picker"
                     presentation="date"
                     name="endDate"
-                    [(ngModel)]="endDate"
+                    [ngModel]="endDate()"
+                    (ngModelChange)="endDate.set($event)"
                     required
                   ></ion-datetime>
                 </ng-template>
@@ -151,16 +161,50 @@ export class InterestPauseFormComponent implements OnInit {
   private readonly router = inject(Router);
 
   loanId: number | null = null;
+  variationId: number | null = null;
+  readonly isEditMode = signal(false);
   readonly isSaving = signal(false);
 
-  startDate: string | null = null;
-  endDate: string | null = null;
+  readonly startDate = signal<string | null>(null);
+  readonly endDate = signal<string | null>(null);
 
   ngOnInit(): void {
-    const id = this.route.snapshot.paramMap.get('loanId');
-    if (id) {
-      this.loanId = +id;
+    const loanId = this.route.snapshot.paramMap.get('loanId');
+    const variationId = this.route.snapshot.paramMap.get('variationId');
+    if (loanId) {
+      this.loanId = +loanId;
     }
+    if (variationId) {
+      this.variationId = +variationId;
+      this.isEditMode.set(true);
+      this.loadPause();
+    }
+  }
+
+  private loadPause(): void {
+    if (!this.loanId || !this.variationId) return;
+
+    this.pauseService.getLoansLoanIdInterestPauses(this.loanId).subscribe({
+      next: (pauses: InterestPauseResponseDto[]) => {
+        const pause = pauses.find(({ id }) => id === this.variationId);
+        if (pause) {
+          this.startDate.set(this.toFormDate(pause.startDate));
+          this.endDate.set(this.toFormDate(pause.endDate));
+        }
+      },
+      // The global error interceptor displays Fineract's response to the user.
+      error: () => undefined,
+    });
+  }
+
+  /**
+   * Fineract's OpenAPI model declares these values as ISO strings, while older deployments
+   * serialize `LocalDate` as `[year, month, day]`. Accept both so editing also works against
+   * installations whose response shape predates the generated model.
+   */
+  private toFormDate(value: unknown): string | null {
+    const date = Array.isArray(value) ? formatArrayDate(value) : toIsoDate(String(value ?? ''));
+    return date && date !== '-' ? date : null;
   }
 
   onSubmit(): void {
@@ -168,13 +212,22 @@ export class InterestPauseFormComponent implements OnInit {
     this.isSaving.set(true);
 
     const request: InterestPauseRequestDto = {
-      startDate: formatDateToFineract(this.startDate),
-      endDate: formatDateToFineract(this.endDate),
+      startDate: formatDateToFineract(this.startDate()),
+      endDate: formatDateToFineract(this.endDate()),
       dateFormat: FINERACT_DATE_FORMAT,
       locale: FINERACT_LOCALE,
     };
 
-    this.pauseService.postLoansLoanIdInterestPauses(this.loanId, request).subscribe({
+    const save$ =
+      this.isEditMode() && this.variationId
+        ? this.pauseService.putLoansLoanIdInterestPausesVariationId(
+            this.loanId,
+            this.variationId,
+            request,
+          )
+        : this.pauseService.postLoansLoanIdInterestPauses(this.loanId, request);
+
+    save$.subscribe({
       next: () => this.router.navigate(['/loans', this.loanId, 'interest-pauses']),
       error: () => this.isSaving.set(false),
     });

--- a/src/app/features/loans/interest-pauses/interest-pauses-list.component.test.ts
+++ b/src/app/features/loans/interest-pauses/interest-pauses-list.component.test.ts
@@ -79,6 +79,12 @@ describe('InterestPausesListComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'interest-pauses', 'create']);
   });
 
+  it('should navigate to edit for the selected pause', () => {
+    component.onEdit({ id: 5 });
+
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'interest-pauses', 'edit', 5]);
+  });
+
   it('should delete after confirmation and reload', async () => {
     serviceSpy.deleteLoansLoanIdInterestPausesVariationId.mockReturnValue(
       of({}) as unknown as ReturnType<

--- a/src/app/features/loans/interest-pauses/interest-pauses-list.component.ts
+++ b/src/app/features/loans/interest-pauses/interest-pauses-list.component.ts
@@ -30,7 +30,7 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 
 /**
  * Lists interest pause periods (start/end date) for a specific loan and allows
- * creating a new pause or deleting an existing one. The loan id is taken from the route.
+ * creating, editing, or deleting them. The loan id is taken from the route.
  */
 @Component({
   selector: 'app-interest-pauses-list',
@@ -57,6 +57,15 @@ import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
       (create)="onCreate()"
     >
       <ng-template appCellTemplate="actions" let-row>
+        <ion-button
+          fill="clear"
+          color="primary"
+          [attr.aria-label]="'COMMON.EDIT' | translate"
+          [appTooltip]="'COMMON.EDIT' | translate"
+          (click)="onEdit(row)"
+        >
+          <ion-icon name="create-outline"></ion-icon>
+        </ion-button>
         <ion-button
           fill="clear"
           color="danger"
@@ -113,6 +122,12 @@ export class InterestPausesListComponent implements OnInit {
     }
   }
 
+  onEdit(row: InterestPauseResponseDto): void {
+    if (this.loanId && row.id) {
+      this.router.navigate(['/loans', this.loanId, 'interest-pauses', 'edit', row.id]);
+    }
+  }
+
   async onDelete(row: InterestPauseResponseDto): Promise<void> {
     if (!this.loanId || !row.id) return;
     const confirmed = await this.dialogService.confirm({
@@ -126,7 +141,8 @@ export class InterestPausesListComponent implements OnInit {
     if (!confirmed) return;
     this.pauseService.deleteLoansLoanIdInterestPausesVariationId(this.loanId, row.id).subscribe({
       next: () => this.load(),
-      error: (err: unknown) => console.error('Failed to delete interest pause', err),
+      // The global error interceptor displays Fineract's response to the user.
+      error: () => undefined,
     });
   }
 }

--- a/src/app/features/loans/loans.routes.ts
+++ b/src/app/features/loans/loans.routes.ts
@@ -162,6 +162,15 @@ export const LOANS_ROUTES: Routes = [
       ),
   },
   {
+    path: ':loanId/interest-pauses/edit/:variationId',
+    canActivate: [authGuard, permissionGuard],
+    data: { permissions: 'UPDATE_INTEREST_PAUSE' },
+    loadComponent: () =>
+      import('./interest-pauses/interest-pause-form.component').then(
+        (m) => m.InterestPauseFormComponent,
+      ),
+  },
+  {
     path: ':loanId/post-dated-checks',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_LOAN' },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1897,6 +1897,7 @@
   "INTEREST_PAUSES": {
     "TITLE": "Interest Pauses",
     "CREATE": "Add Interest Pause",
+    "EDIT": "Edit Interest Pause",
     "START_DATE": "Start Date",
     "END_DATE": "End Date",
     "CONFIRM_DELETE": "Delete the interest pause from {{startDate}} to {{endDate}}?"


### PR DESCRIPTION
## What and why

Interest pauses could be created and deleted, but a mistyped date could not be corrected without removing the pause and creating a second record. This adds an edit action and guarded route, reuses the existing form in edit mode, pre-fills the selected variation, and saves it through the generated PUT operation.

The edit loader accepts both ISO dates declared by the generated OpenAPI model and the `[year, month, day]` shape returned by older Fineract deployments. Delete failures are now left to the global error interceptor instead of being hidden in the console.

Closes #283.

## Verification

- Focused Vitest: 10/10 passed (list navigation, create POST, edit pre-fill, edit PUT, rejected update)
- Mocked Playwright: `loan-servicing-gaps.spec.ts` 14/14 passed with one worker, including list -> edit -> save and an exact PUT URL/body assertion
- `npm run lint`
- `npm run i18n:check`
- `npm run check:icons`
- `npm run typecheck:e2e`
- Production build passed (with the existing header component budget warning)
- Prettier check passed for all seven changed files

The complete unit suite currently reports 1,343 passed and 37 failures in the unrelated loan-product and fixed-deposit-product accounting specs. I reproduced the same 37 failures after stashing every change in this PR and running against clean `upstream/main`.

A real-backend e2e was not run locally because Docker is unavailable on this machine. The PUT method, path, parameter order, and request shape were cross-checked against `LoanInterestPauseApiResource`, `InterestPauseRequestDto`, and Fineract's `Verify interest pause update` acceptance scenario.

## Screenshots

Not attached. The UI change is the standard `create-outline` row action and the existing form with an edit title; the complete workflow is exercised by the mocked Playwright test above.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] No new browser globals or imperative third-party APIs were introduced; the adapter-boundary item is not applicable.
- [x] User-facing strings use translation keys.
- [x] I added focused unit coverage for both create and edit modes.
- [x] I added mocked e2e coverage for the complete edit workflow; real-backend execution is documented above.
- [x] Commits are signed.