### PR TITLE
fix(dashboard): stack widgets on mobile

### DIFF
--- a/e2e/mobile-shell.spec.ts
+++ b/e2e/mobile-shell.spec.ts
@@ -129,6 +129,14 @@ test.describe('the shell at a phone viewport', () => {
     expect(Math.abs(shell - viewport)).toBeLessThanOrEqual(1);
   });
 
+  test('stacks dashboard columns on a phone viewport', async ({ page }) => {
+    const layout = page.locator('.dashboard-layout');
+    await expect(layout).toBeVisible();
+
+    const columns = await layout.evaluate((element) => getComputedStyle(element).gridTemplateColumns);
+    expect(columns.trim().split(/\s+/)).toHaveLength(1);
+  });
+
   describe_drawer();
 
   test('renders tables as cards instead of a sideways scroll', async ({ page }) => {

--- a/e2e/mobile-shell.spec.ts
+++ b/e2e/mobile-shell.spec.ts
@@ -133,7 +133,9 @@ test.describe('the shell at a phone viewport', () => {
     const layout = page.locator('.dashboard-layout');
     await expect(layout).toBeVisible();
 
-    const columns = await layout.evaluate((element) => getComputedStyle(element).gridTemplateColumns);
+    const columns = await layout.evaluate(
+      (element) => getComputedStyle(element).gridTemplateColumns,
+    );
     expect(columns.trim().split(/\s+/)).toHaveLength(1);
   });
 

--- a/src/app/features/dashboard/system-status.component.ts
+++ b/src/app/features/dashboard/system-status.component.ts
@@ -499,6 +499,11 @@ import {
         background: rgba(46, 204, 113, 0.16);
         color: var(--success-color);
       }
+      @media (max-width: 768px) {
+        .dashboard-layout {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
     `,
   ],
 })


### PR DESCRIPTION
## What and why

The dashboard's main and side widget columns remain side by side at phone widths, leaving each too narrow for its headings and status text. The dashboard layout now collapses to one full-width column at the shared 768px mobile breakpoint.

Closes #491

## Validation

- `npm test -- --watch=false --include=src/app/features/dashboard/system-status.component.test.ts` — 7 passed
- ESLint on `system-status.component.ts` — passed
- Prettier and `git diff --check` — passed

## Checklist

- [x] No generated API files changed.
- [x] No user-facing strings added.
- [x] Existing dashboard unit tests pass.
- [x] Commit is signed.