### PR TITLE
fix(paginator): reflow controls on mobile

### DIFF
--- a/e2e/mobile-shell.spec.ts
+++ b/e2e/mobile-shell.spec.ts
@@ -161,14 +161,17 @@ test.describe('the shell at a phone viewport', () => {
 
     const paginator = page.locator('app-paginator .paginator');
     await expect(paginator).toBeVisible();
-    const styles = await paginator.evaluate((element) => ({
-      display: getComputedStyle(element).display,
-      columns: getComputedStyle(element).gridTemplateColumns,
-      labelWhiteSpace: getComputedStyle(element.querySelector('.items-per-page')!).whiteSpace,
-    }));
+    const styles = await paginator.evaluate((element) => {
+      const label = element.querySelector<HTMLElement>('.items-per-page')!;
+      return {
+        display: getComputedStyle(element).display,
+        labelWhiteSpace: getComputedStyle(label).whiteSpace,
+        labelFits: label.scrollWidth <= label.clientWidth,
+      };
+    });
     expect(styles.display).toBe('grid');
-    expect(styles.columns.trim().startsWith('max-content')).toBe(true);
     expect(styles.labelWhiteSpace).toBe('nowrap');
+    expect(styles.labelFits).toBe(true);
   });
 
   describe_drawer();

--- a/e2e/mobile-shell.spec.ts
+++ b/e2e/mobile-shell.spec.ts
@@ -139,6 +139,38 @@ test.describe('the shell at a phone viewport', () => {
     expect(columns.trim().split(/\s+/)).toHaveLength(1);
   });
 
+  test('keeps the paginator label intact on a phone viewport', async ({ page }) => {
+    await page.route(/\/api\/v1\/clients/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          totalFilteredRecords: 21,
+          pageItems: [
+            {
+              id: 1,
+              accountNo: '000000001',
+              displayName: 'Aisha Rahman',
+              status: { value: 'Active' },
+            },
+          ],
+        }),
+      }),
+    );
+    await page.goto('/clients');
+
+    const paginator = page.locator('app-paginator .paginator');
+    await expect(paginator).toBeVisible();
+    const styles = await paginator.evaluate((element) => ({
+      display: getComputedStyle(element).display,
+      columns: getComputedStyle(element).gridTemplateColumns,
+      labelWhiteSpace: getComputedStyle(element.querySelector('.items-per-page')!).whiteSpace,
+    }));
+    expect(styles.display).toBe('grid');
+    expect(styles.columns.trim().startsWith('max-content')).toBe(true);
+    expect(styles.labelWhiteSpace).toBe('nowrap');
+  });
+
   describe_drawer();
 
   test('renders tables as cards instead of a sideways scroll', async ({ page }) => {

--- a/src/app/shared/components/paginator/paginator.component.ts
+++ b/src/app/shared/components/paginator/paginator.component.ts
@@ -121,9 +121,12 @@ import { PageEvent } from '../../models/table.model';
       }
       @media (max-width: 768px) {
         .paginator {
-          grid-template-columns: auto minmax(0, 1fr) repeat(4, auto);
           display: grid;
+          grid-template-columns: max-content minmax(0, 1fr) repeat(4, auto);
           gap: 4px;
+        }
+        .items-per-page {
+          white-space: nowrap;
         }
         .page-size-select {
           min-width: 0;

--- a/src/app/shared/components/paginator/paginator.component.ts
+++ b/src/app/shared/components/paginator/paginator.component.ts
@@ -119,6 +119,24 @@ import { PageEvent } from '../../models/table.model';
         --padding-end: 6px;
         margin: 0;
       }
+      @media (max-width: 768px) {
+        .paginator {
+          grid-template-columns: auto minmax(0, 1fr) repeat(4, auto);
+          display: grid;
+          gap: 4px;
+        }
+        .page-size-select {
+          min-width: 0;
+        }
+        .range-label {
+          grid-column: 1 / 3;
+          grid-row: 2;
+          margin: 0;
+        }
+        ion-button {
+          grid-row: 2;
+        }
+      }
     `,
   ],
 })


### PR DESCRIPTION
## What and why

The shared paginator squeezes its label, page-size selector, range, and four navigation buttons into one non-wrapping row on phones. It now uses a two-row grid at the shared mobile breakpoint: page-size controls occupy the first row, while the range and navigation controls occupy the second.

Closes #490

## Validation

- `npm test -- --watch=false --include=src/app/shared/components/paginator/paginator.component.test.ts` — 12 passed
- ESLint on `paginator.component.ts` — passed
- Prettier and `git diff --check` — passed

## Checklist

- [x] No generated API files changed.
- [x] No user-facing strings added.
- [x] Existing paginator unit tests pass.
- [x] Commit is signed.