### PR TITLE
fix(login): delay invalid field announcements

### DIFF
--- a/src/app/features/login/login.component.test.ts
+++ b/src/app/features/login/login.component.test.ts
@@ -87,6 +87,20 @@ describe('LoginComponent', () => {
     expect(component['loginForm'].valid).toBe(false);
   });
 
+  it('announces invalid fields only after interaction', () => {
+    const username = fixture.nativeElement.querySelector('#username') as HTMLInputElement;
+    const password = fixture.nativeElement.querySelector('#password') as HTMLInputElement;
+
+    expect(username.hasAttribute('aria-invalid')).toBe(false);
+    expect(password.hasAttribute('aria-invalid')).toBe(false);
+
+    component['loginForm'].controls.username.markAsTouched();
+    fixture.detectChanges();
+
+    expect(username.getAttribute('aria-invalid')).toBe('true');
+    expect(password.hasAttribute('aria-invalid')).toBe(false);
+  });
+
   it('should call login and navigate on success', () => {
     authServiceSpy.login.mockReturnValue(of({} as UserSession));
 

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -129,7 +129,7 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
                 id="tenantId"
                 type="text"
                 formControlName="tenantId"
-                [attr.aria-invalid]="loginForm.get('tenantId')?.invalid"
+                [attr.aria-invalid]="showInvalid('tenantId')"
               />
             </div>
 
@@ -140,7 +140,7 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
                 type="text"
                 formControlName="username"
                 autocomplete="username"
-                [attr.aria-invalid]="loginForm.get('username')?.invalid"
+                [attr.aria-invalid]="showInvalid('username')"
               />
             </div>
 
@@ -151,7 +151,7 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
                 type="password"
                 formControlName="password"
                 autocomplete="current-password"
-                [attr.aria-invalid]="loginForm.get('password')?.invalid"
+                [attr.aria-invalid]="showInvalid('password')"
               />
             </div>
 
@@ -383,6 +383,12 @@ export class LoginComponent {
     username: ['', Validators.required],
     password: ['', Validators.required],
   });
+
+  /** Announce validation only after the user has interacted with the field. */
+  protected showInvalid(name: 'tenantId' | 'username' | 'password'): 'true' | null {
+    const control = this.loginForm.controls[name];
+    return control.invalid && (control.touched || control.dirty) ? 'true' : null;
+  }
 
   /**
    * Switches the application language at runtime.


### PR DESCRIPTION
## What and why

Required login fields expose `aria-invalid="true"` immediately on a pristine form. Screen-reader users therefore hear an error state before they have interacted with the form. The binding now emits `aria-invalid` only when a field is invalid and touched or dirty, and removes the attribute otherwise.

A regression test verifies that Username and Password begin without the attribute and that touching Username exposes its invalid state without changing Password.

Closes #483

## Validation

- `npm test -- --watch=false --include=src/app/features/login/login.component.test.ts` — 7 passed
- ESLint on the changed component and test — passed
- Prettier and `git diff --check` — passed

## Checklist

- [x] No generated API files changed.
- [x] No user-facing strings added.
- [x] Added focused accessibility regression coverage.
- [x] Commit is signed.