### PR TITLE
fix(login): keep form reachable in short viewports

### DIFF
--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -183,10 +183,13 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
       .login-page {
         display: flex;
         justify-content: center;
-        align-items: center;
+        align-items: safe center;
         /* dvh: on a phone, 100vh is measured against the retracted URL bar, so the card
            ends up centred against a viewport taller than the screen. */
+        box-sizing: border-box;
+        height: 100dvh;
         min-height: 100dvh;
+        overflow-y: auto;
         background: linear-gradient(135deg, #2c3e50 0%, #3498db 100%);
         padding: 1rem;
       }

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -187,6 +187,8 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
         /* dvh: on a phone, 100vh is measured against the retracted URL bar, so the card
            ends up centred against a viewport taller than the screen. */
         box-sizing: border-box;
+        height: 100svh;
+        min-height: 100svh;
         height: 100dvh;
         min-height: 100dvh;
         overflow-y: auto;

--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -183,6 +183,7 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
       .login-page {
         display: flex;
         justify-content: center;
+        align-items: center;
         align-items: safe center;
         /* dvh: on a phone, 100vh is measured against the retracted URL bar, so the card
            ends up centred against a viewport taller than the screen. */


### PR DESCRIPTION
## What and why

The login page is taller than short viewports, but Ionic keeps the document body from scrolling. The page now owns a viewport-height scroll container, includes its padding in that height, and uses safe vertical centering so oversized content aligns to a reachable scroll origin.

Closes #482

## Validation

- `npm test -- --watch=false --include=src/app/features/login/login.component.test.ts` — 6 passed
- ESLint on `login.component.ts` — passed
- Prettier and `git diff --check` — passed

## Checklist

- [x] No generated API files changed.
- [x] No user-facing strings added.
- [x] Existing login unit tests pass.
- [x] Commit is signed.