### PR TITLE
fix(login): stop announcing pristine inputs as aria-invalid

### DIFF
--- a/src/app/features/login/login.component.ts
+++ b/src/app/features/login/login.component.ts
@@ -129,7 +129,7 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
                 id="tenantId"
                 type="text"
                 formControlName="tenantId"
-                [attr.aria-invalid]="loginForm.get('tenantId')?.invalid"
+                [attr.aria-invalid]="(loginForm.get('tenantId')?.invalid && (loginForm.get('tenantId')?.touched || loginForm.get('tenantId')?.dirty)) ? 'true' : null"
               />
             </div>
 
@@ -140,7 +140,7 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
                 type="text"
                 formControlName="username"
                 autocomplete="username"
-                [attr.aria-invalid]="loginForm.get('username')?.invalid"
+                [attr.aria-invalid]="(loginForm.get('username')?.invalid && (loginForm.get('username')?.touched || loginForm.get('username')?.dirty)) ? 'true' : null"
               />
             </div>
 
@@ -151,7 +151,7 @@ import { HelpIconComponent } from '../../shared/components/help-icon/help-icon.c
                 type="password"
                 formControlName="password"
                 autocomplete="current-password"
-                [attr.aria-invalid]="loginForm.get('password')?.invalid"
+                [attr.aria-invalid]="(loginForm.get('password')?.invalid && (loginForm.get('password')?.touched || loginForm.get('password')?.dirty)) ? 'true' : null"
               />
             </div>
 


### PR DESCRIPTION
## Summary

On a fresh `/login` load the username and password inputs carried `aria-invalid="true"` before any interaction, so screen readers announced both fields as invalid on a pristine form (#483). `tenantId` escaped only because it ships with a default value.

## Fix

Each binding now gates on touched/dirty per the issue's suggestion, and emits `null` (attribute absent) rather than `false` for pristine fields:

```
[attr.aria-invalid]="(control.invalid && (control.touched || control.dirty)) ? 'true' : null"
```

After a submit attempt (touched/dirty), genuinely invalid fields still announce `aria-invalid="true"` — the error state is preserved where it is real.

Closes #483
