### PR TITLE
docs: drop the Karma flags from the unit-test command

### DIFF
--- a/DOCS/RBAC.md
+++ b/DOCS/RBAC.md
@@ -189,7 +189,7 @@ It changes nothing server-side. Fineract still enforces permissions on every req
 
 ```bash
 # Unit — guard semantics, the Access Denied page, navigation filtering
-npm run test -- --watch=false --browsers=ChromeHeadless
+npm run test:unit
 
 # Static — route/navigation parity
 npm run check:route-permissions

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,7 +108,7 @@ npm run check:licenses
 npm run check:licenses:selftest
 bash scripts/check-license.sh
 npm run build
-npm run test -- --watch=false --browsers=ChromeHeadless
+npm run test:unit
 npm run ga:check
 
 # 4. The end-to-end suites, against a real Fineract.


### PR DESCRIPTION
Closes #510.

`RELEASING.md` and `DOCS/RBAC.md` both still give the Karma-era command:

```bash
npm run test -- --watch=false --browsers=ChromeHeadless
```

`--browsers` needs a browser provider, and the builder's check is for the bare `playwright` or `webdriverio` package. This project depends on `@playwright/test`, which does not satisfy it, so the command dies before running a test:

```
Error: The "browsers" option requires either "playwright" or "webdriverio" to be
installed within the project.
    at VitestExecutor.initializeVitest (@angular/build/.../vitest/executor.js:250:19)
```

`--watch=false` still works — `watch` is a real option on the builder — but it is redundant outside a TTY.

Both now say `npm run test:unit`, which is the command `ci.yml` runs. Verified on this branch: `npm run test:unit` gives 236 files / 1415 tests, exit 0, while the old command fails as above.

Docs only; no source or configuration changed.
