### PR TITLE
fix(dates): read a date-only string as a calendar date, not as UTC midnight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,18 @@ jobs:
             ${{ runner.os }}-angular-test-
       - name: Run unit tests on Vitest
         run: npm run test:unit
+      # The runner's clock is UTC and playwright.config.ts pins Asia/Kolkata, so every timezone
+      # this project tests at is at or east of Greenwich — and a local/UTC date mix-up is
+      # invisible at a non-negative offset. That is how #496 shipped: a bare `YYYY-MM-DD` read as
+      # UTC midnight and printed back with local getters submitted the day before, for users the
+      # suite never simulated.
+      #
+      # A second pass costs about a minute and covers the whole application rather than the one
+      # helper, which no assertion running only at UTC can do.
+      - name: Run unit tests west of Greenwich
+        run: npm run test:unit
+        env:
+          TZ: America/New_York
       - name: Run microfrontend tests on Vitest
         run: npm run test:mfe
 

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -39,11 +39,6 @@
       "count": 4
     }
   },
-  "src/app/core/utils/date-formatter.ts": {
-    "unicorn/prefer-number-properties": {
-      "count": 2
-    }
-  },
   "src/app/features/accounting/accounting-closure-form.component.ts": {
     "no-restricted-imports": {
       "count": 1

--- a/src/app/core/utils/date-formatter.test.ts
+++ b/src/app/core/utils/date-formatter.test.ts
@@ -100,9 +100,45 @@ describe('date-formatter', () => {
       }
     });
 
+    /**
+     * These are the cases that motivated the date-only branch. They only *fail* at a negative
+     * UTC offset, so CI runs the whole unit suite a second time under `TZ=America/New_York` —
+     * see the "Run unit tests west of Greenwich" step in `ci.yml`. Under UTC they still pin the
+     * behaviour; they just cannot detect its absence.
+     */
+    describe('a date-only string', () => {
+      it('is read as the calendar date it spells, not as UTC midnight', () => {
+        expect(formatDateToFineract('2026-01-15')).toBe('15 January 2026');
+        expect(formatDateToFineract('2026-04-01')).toBe('01 April 2026');
+      });
+
+      it('does not roll back across a month or a year boundary', () => {
+        // The 1st is the case that exposes the shift most sharply: a day early crosses into the
+        // previous month, and on 1 January into the previous year.
+        expect(formatDateToFineract('2026-01-01')).toBe('01 January 2026');
+        expect(formatDateToFineract('2026-03-01')).toBe('01 March 2026');
+      });
+
+      it('agrees with the array form of the same date', () => {
+        for (const iso of ['2026-01-01', '2026-06-15', '2026-12-31']) {
+          const [year, month, day] = iso.split('-').map(Number);
+          expect(formatDateToFineract(iso)).toBe(formatDateToFineract([year, month, day]));
+        }
+      });
+    });
+
+    it('leaves a string carrying a time to the platform parser', () => {
+      // What ion-datetime emits. `new Date()` already reads a local timestamp as local, and an
+      // explicit `Z` as UTC — neither needs the date-only branch, and both would be wrong if it
+      // claimed them.
+      expect(formatDateToFineract('2026-07-26T14:30:00')).toBe('26 July 2026');
+    });
+
     it('returns empty string for invalid input', () => {
       expect(formatDateToFineract(null)).toBe('');
       expect(formatDateToFineract([2026])).toBe('');
+      expect(formatDateToFineract('not-a-date')).toBe('');
+      expect(formatDateToFineract('2026-13-45')).toBe('');
     });
   });
 });

--- a/src/app/core/utils/date-formatter.ts
+++ b/src/app/core/utils/date-formatter.ts
@@ -32,6 +32,22 @@ const MONTHS = [
   'December',
 ];
 
+/** The date-only form ECMAScript specifies as UTC: exactly `YYYY-MM-DD`, nothing more. */
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Builds a local `Date` from calendar parts, rejecting a value that is merely well-shaped.
+ *
+ * `new Date(2026, 12, 45)` does not fail — it rolls forward to 14 February 2027. Handing a
+ * malformed string back as a real date is worse than refusing it, since the caller sends the
+ * result to the platform as the user's chosen date, so the parts are read back and compared.
+ */
+function localDate(year: number, month: number, day: number): Date {
+  const d = new Date(year, month - 1, day);
+  const rolled = d.getFullYear() !== year || d.getMonth() !== month - 1 || d.getDate() !== day;
+  return rolled ? new Date(Number.NaN) : d;
+}
+
 /**
  * Formats a Date object (or date-like string/array) into the Fineract-preferred
  * 'dd Month yyyy' format (e.g., '15 January 2026', '02 August 2026').
@@ -41,6 +57,15 @@ const MONTHS = [
  * format it is told to use, so an unpadded '2 August 2026' does not merely fail validation — it
  * fails to parse at all and the request comes back 500. That made every dated submission in the
  * application fail on the 1st through the 9th of any month, and succeed for the rest of it.
+ *
+ * A **date-only** string is read through its parts rather than handed to `new Date()`. ECMAScript
+ * reads `'2026-01-15'` as UTC midnight while the getters below read local time, so west of
+ * Greenwich the two disagree and the output lands a day early — `'2026-01-15'` formats as
+ * `14 January 2026` in `America/New_York`. Every screen that pre-fills a date from an API
+ * response and is saved without re-picking that field went out with the wrong day.
+ *
+ * A string carrying a time (`'2026-01-15T00:00:00'`, what `ion-datetime` emits) or an explicit
+ * zone (`'...Z'`) is left to `new Date()`, which already reads both correctly.
  *
  * @param date - The date to format.
  * @returns The formatted date string, or empty string if invalid.
@@ -56,12 +81,13 @@ export function formatDateToFineract(date: Date | string | number[] | null | und
       return '';
     }
   } else if (typeof date === 'string') {
-    d = new Date(date);
+    const parts = DATE_ONLY.exec(date);
+    d = parts ? localDate(+parts[1], +parts[2], +parts[3]) : new Date(date);
   } else {
     d = date;
   }
 
-  if (isNaN(d.getTime())) return '';
+  if (Number.isNaN(d.getTime())) return '';
 
   const day = String(d.getDate()).padStart(2, '0');
   const month = MONTHS[d.getMonth()];
@@ -104,7 +130,7 @@ export function toIsoDate(date: Date | string | null | undefined): string {
     return date.split('T', 1)[0];
   }
 
-  if (isNaN(date.getTime())) return '';
+  if (Number.isNaN(date.getTime())) return '';
 
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');

--- a/src/app/features/centers/center-action-dialog.component.ts
+++ b/src/app/features/centers/center-action-dialog.component.ts
@@ -32,6 +32,7 @@ import {
 
 import { CentersService } from '../../api';
 import { OVERLAY, TranslatePipe } from '../../core/adapters';
+import { toIsoDate } from '../../core/utils/date-formatter';
 
 export interface CenterActionDialogData {
   command: 'activate' | 'close';
@@ -156,7 +157,7 @@ export class CenterActionDialogComponent implements OnInit {
   readonly data = input.required<CenterActionDialogData>();
 
   readonly closureReasons = signal<{ id?: number; name?: string }[]>([]);
-  date = new Date().toISOString();
+  date = toIsoDate(new Date());
   closureReasonId?: number;
 
   ngOnInit(): void {

--- a/src/app/features/centers/center-meeting-dialog.component.ts
+++ b/src/app/features/centers/center-meeting-dialog.component.ts
@@ -35,6 +35,7 @@ import {
 import { BASE_PATH } from '../../api';
 import { OVERLAY, TranslatePipe } from '../../core/adapters';
 import { CenterMeeting } from './center-detail.model';
+import { toIsoDate } from '../../core/utils/date-formatter';
 
 export interface CenterMeetingDialogData {
   centerId: number;
@@ -221,7 +222,7 @@ export class CenterMeetingDialogComponent implements OnInit {
   readonly dayOptions = signal<CodeOption[]>([]);
 
   title = '';
-  startDate = new Date().toISOString();
+  startDate = toIsoDate(new Date());
   frequency = 2;
   interval = 1;
   typeId = 1;

--- a/src/app/features/centers/center-view.component.test.ts
+++ b/src/app/features/centers/center-view.component.test.ts
@@ -163,7 +163,10 @@ describe('CenterViewComponent', () => {
     create();
     flushCenter({ ...ACTIVE_CENTER, status: { id: 100, value: 'Pending' } });
 
-    dialog.open.mockResolvedValue({ date: '2026-02-01T00:00:00.000Z' });
+    // The dialogs seed their picker with `toIsoDate(new Date())` and bind an ion-datetime, so
+    // what comes back is a calendar date, not a UTC instant. A `...Z` fixture here used to pass
+    // only because both the fixture and the formatter agreed to read it as UTC — see #496.
+    dialog.open.mockResolvedValue({ date: '2026-02-01' });
     await component.onAction('activate');
 
     const request = http.expectOne(
@@ -183,7 +186,7 @@ describe('CenterViewComponent', () => {
     create();
     flushCenter();
 
-    dialog.open.mockResolvedValue({ date: '2026-03-02T00:00:00.000Z', closureReasonId: 9 });
+    dialog.open.mockResolvedValue({ date: '2026-03-02', closureReasonId: 9 });
     await component.onAction('close');
 
     const request = http.expectOne(
@@ -306,7 +309,7 @@ describe('CenterViewComponent', () => {
 
     dialog.open.mockResolvedValue({
       title: WEEKLY_COLLECTION,
-      startDate: '2026-04-06T00:00:00.000Z',
+      startDate: '2026-04-06',
       frequency: 2,
       interval: 1,
       typeId: 1,
@@ -338,7 +341,7 @@ describe('CenterViewComponent', () => {
 
     dialog.open.mockResolvedValue({
       title: 'Fortnightly collection',
-      startDate: '2026-04-06T00:00:00.000Z',
+      startDate: '2026-04-06',
       frequency: 1,
       interval: 2,
       typeId: 1,

--- a/src/app/features/clients/client-view.component.ts
+++ b/src/app/features/clients/client-view.component.ts
@@ -1384,7 +1384,7 @@ export class ClientViewComponent implements OnInit {
     // `proposeTransfer` requires a date and the locale/format that make it parseable;
     // `proposeAndAcceptTransfer` rejects `transferDate` outright, so neither is sent for it.
     if (mode === 'propose' && result.transferDate) {
-      body['transferDate'] = formatDateToFineract(new Date(result.transferDate));
+      body['transferDate'] = formatDateToFineract(result.transferDate);
       body['locale'] = FINERACT_LOCALE;
       body['dateFormat'] = FINERACT_DATE_FORMAT;
     }

--- a/src/app/features/groups/group-view.component.ts
+++ b/src/app/features/groups/group-view.component.ts
@@ -610,7 +610,7 @@ export class GroupViewComponent implements OnInit {
     if (!result) return;
 
     this.runCommand('activate', {
-      activationDate: formatDateToFineract(new Date(result.actionDate)),
+      activationDate: formatDateToFineract(result.actionDate),
       locale: FINERACT_LOCALE,
       dateFormat: FINERACT_DATE_FORMAT,
     });
@@ -626,7 +626,7 @@ export class GroupViewComponent implements OnInit {
     if (!result) return;
 
     this.runCommand('close', {
-      closureDate: formatDateToFineract(new Date(result.actionDate)),
+      closureDate: formatDateToFineract(result.actionDate),
       closureReasonId: result.closureReasonId,
       locale: FINERACT_LOCALE,
       dateFormat: FINERACT_DATE_FORMAT,

--- a/src/app/features/loans/loan-view.component.test.ts
+++ b/src/app/features/loans/loan-view.component.test.ts
@@ -21,12 +21,8 @@
 
 import { createSpyObj, SpyObj } from '../../testing/mocks';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  LOAN_TAB,
-  LoanViewComponent,
-  isoToFineractDate,
-  toEditableDate,
-} from './loan-view.component';
+import { LOAN_TAB, LoanViewComponent, toEditableDate } from './loan-view.component';
+import { formatDateToFineract } from '../../core/utils/date-formatter';
 import {
   LoansService,
   LoanBuyDownFeesService,
@@ -466,17 +462,17 @@ describe('LoanViewComponent', () => {
   });
 
   describe('date conversion for the disbursement command', () => {
-    it('reads a bare YYYY-MM-DD in local time', () => {
-      // `new Date('2026-08-01')` is UTC midnight, which `formatDateToFineract` then reads back
-      // with local getters — one day earlier for anyone west of Greenwich. The 1st of the month
-      // is the case that exposes it, because the shift crosses into the previous month.
-      expect(isoToFineractDate('2026-08-01')).toBe('01 August 2026');
-      expect(isoToFineractDate('2026-01-01')).toBe('01 January 2026');
+    it('reads the form value as the calendar date it spells', () => {
+      // The form binds a bare `YYYY-MM-DD`, which `formatDateToFineract` reads through its parts
+      // rather than as UTC midnight. See #496 — before that fix these came out a day early west
+      // of Greenwich, and the 1st of the month crossed into the previous one.
+      expect(formatDateToFineract('2026-08-01')).toBe('01 August 2026');
+      expect(formatDateToFineract('2026-01-01')).toBe('01 January 2026');
     });
 
     it('yields nothing for a value the command could not parse', () => {
-      expect(isoToFineractDate('')).toBe('');
-      expect(isoToFineractDate('not-a-date')).toBe('');
+      expect(formatDateToFineract('')).toBe('');
+      expect(formatDateToFineract('not-a-date')).toBe('');
     });
 
     it('accepts either shape the disbursement endpoint answers with', () => {

--- a/src/app/features/loans/loan-view.component.ts
+++ b/src/app/features/loans/loan-view.component.ts
@@ -137,19 +137,6 @@ export function toEditableDate(value: unknown): string {
   return typeof value === 'string' ? value.split('T', 1)[0] : '';
 }
 
-/**
- * Converts a `YYYY-MM-DD` form value into the `dd MMMM yyyy` Fineract is told to parse.
- *
- * The parts are split by hand rather than handed to `new Date(iso)`, which reads a bare
- * `YYYY-MM-DD` as UTC midnight while `formatDateToFineract` reads the day back in local time —
- * a combination that moves the date a day earlier for every user west of Greenwich.
- */
-export function isoToFineractDate(iso: string): string {
-  const [year, month, day] = (iso ?? '').split('-').map(Number);
-  if (!year || !month || !day) return '';
-  return formatDateToFineract([year, month, day]);
-}
-
 @Component({
   selector: 'app-loan-view',
   standalone: true,
@@ -1949,7 +1936,7 @@ export class LoanViewComponent implements OnInit {
   saveDisbursementDetail() {
     if (!this.editDisbId) return;
 
-    const updatedDate = isoToFineractDate(this.disbursementEditForm.expectedDisbursementDate);
+    const updatedDate = formatDateToFineract(this.disbursementEditForm.expectedDisbursementDate);
     if (!updatedDate) {
       this.notifications.error(this.translate.instant('LOANS.EXPECTED_DISBURSEMENT_REQUIRED'));
       return;
@@ -1957,7 +1944,8 @@ export class LoanViewComponent implements OnInit {
 
     this.disbursementDetailsService
       .putLoansLoanIdDisbursementsDisbursementId(this.loanId(), this.editDisbId, {
-        expectedDisbursementDate: isoToFineractDate(this.originalDisbursementDate) || updatedDate,
+        expectedDisbursementDate:
+          formatDateToFineract(this.originalDisbursementDate) || updatedDate,
         updatedExpectedDisbursementDate: updatedDate,
         updatedPrincipal: Number(this.disbursementEditForm.principal) || 0,
         dateFormat: FINERACT_DATE_FORMAT,
@@ -2079,7 +2067,7 @@ export class LoanViewComponent implements OnInit {
 
     this.runLoanCommand('disbursetosavings', {
       ...result,
-      actualDisbursementDate: formatDateToFineract(new Date(result.actualDisbursementDate)),
+      actualDisbursementDate: formatDateToFineract(result.actualDisbursementDate),
       dateFormat: FINERACT_DATE_FORMAT,
       locale: FINERACT_LOCALE,
     });
@@ -2093,7 +2081,7 @@ export class LoanViewComponent implements OnInit {
     if (!result) return;
 
     this.runLoanCommand('unassignloanofficer', {
-      unassignedDate: formatDateToFineract(new Date(result.unassignedDate)),
+      unassignedDate: formatDateToFineract(result.unassignedDate),
       dateFormat: FINERACT_DATE_FORMAT,
       locale: FINERACT_LOCALE,
     });

--- a/src/app/features/products/deposit-account-view.component.ts
+++ b/src/app/features/products/deposit-account-view.component.ts
@@ -947,9 +947,7 @@ export class DepositAccountViewComponent implements OnInit {
   }
 
   private commandDate(floor: unknown): string {
-    // Through the parts rather than through `new Date(iso)`, which parses as UTC midnight and
-    // then reads back in local time — a day out for anyone west of Greenwich.
-    return formatDateToFineract(this.commandDateIso(floor).split('-').map(Number));
+    return formatDateToFineract(this.commandDateIso(floor));
   }
 
   /** A date the platform stamped on this account, by timeline key. */

--- a/src/app/features/products/savings-account-view.component.ts
+++ b/src/app/features/products/savings-account-view.component.ts
@@ -51,7 +51,6 @@ import {
 } from './savings-undo-approval-dialog.component';
 import {
   formatDateToFineract,
-  toIsoDate,
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../core/utils/date-formatter';
@@ -964,7 +963,7 @@ export class SavingsAccountViewComponent implements OnInit {
     ).subscribe((confirmed) => {
       if (!confirmed) return;
       this.runCommand(command, {
-        [dateField]: formatDateToFineract(toIsoDate(new Date())),
+        [dateField]: formatDateToFineract(new Date()),
         dateFormat: FINERACT_DATE_FORMAT,
         locale: FINERACT_LOCALE,
       });
@@ -993,7 +992,7 @@ export class SavingsAccountViewComponent implements OnInit {
         if (!result) return;
         this.runCommand('assignSavingsOfficer', {
           toSavingsOfficerId: result.toSavingsOfficerId,
-          assignmentDate: formatDateToFineract(toIsoDate(new Date())),
+          assignmentDate: formatDateToFineract(new Date()),
           dateFormat: FINERACT_DATE_FORMAT,
           locale: FINERACT_LOCALE,
         });
@@ -1027,7 +1026,7 @@ export class SavingsAccountViewComponent implements OnInit {
           {
             transactionAmount: result.transactionAmount,
             reasonForBlock: result.reasonForBlock,
-            transactionDate: formatDateToFineract(toIsoDate(new Date())),
+            transactionDate: formatDateToFineract(new Date()),
             dateFormat: FINERACT_DATE_FORMAT,
             locale: FINERACT_LOCALE,
           } as never,

--- a/src/app/features/products/shares/share-account-view.component.ts
+++ b/src/app/features/products/shares/share-account-view.component.ts
@@ -468,7 +468,7 @@ export class ShareAccountViewComponent implements OnInit {
     const today = toIsoDate(new Date());
     const stamped = formatArrayDate(this.account()?.timeline?.[floorKey]);
     const iso = stamped !== '-' && stamped > today ? stamped : today;
-    return formatDateToFineract(iso.split('-').map(Number));
+    return formatDateToFineract(iso);
   }
 
   /** A dated command body, under the field name this particular command expects. */

--- a/src/app/features/security/audit-logs/audit-logs-list.component.ts
+++ b/src/app/features/security/audit-logs/audit-logs-list.component.ts
@@ -32,6 +32,7 @@ import { DialogService } from '../../../core/services/dialog.service';
 import { TooltipDirective } from '../../../shared/directives/tooltip.directive';
 import { DOWNLOAD, TranslatePipe } from '../../../core/adapters';
 import { toCsv } from '../../../core/utils/csv';
+import { toIsoDate } from '../../../core/utils/date-formatter';
 import {
   IonAccordion,
   IonAccordionGroup,
@@ -318,11 +319,14 @@ export class AuditLogsListComponent implements OnInit {
           const orderBy = this.currentSort.active;
           const sortOrder = this.currentSort.direction.toUpperCase() || 'DESC';
 
+          // Through `toIsoDate`, not `toISOString()`: the latter converts to UTC first, so a
+          // filter set to today reads as tomorrow for anyone east of Greenwich once the local
+          // clock passes the offset, and as yesterday for anyone west of it.
           const fromDate = this.activeFilters.makerDateTimeFrom
-            ? this.activeFilters.makerDateTimeFrom.toISOString().split('T', 1)[0]
+            ? toIsoDate(this.activeFilters.makerDateTimeFrom)
             : undefined;
           const toDate = this.activeFilters.makerDateTimeTo
-            ? this.activeFilters.makerDateTimeTo.toISOString().split('T', 1)[0]
+            ? toIsoDate(this.activeFilters.makerDateTimeTo)
             : undefined;
 
           return this.auditsService


### PR DESCRIPTION
Closes #496.

## What it does

`formatDateToFineract` handed every string to `new Date()`. ECMAScript parses a **date-only** string as UTC midnight, while the getters that build the output read **local** time, so at any negative offset the two disagree:

```
TZ=America/New_York  '2026-01-15'  ->  14 January 2026
TZ=America/New_York  '2026-01-01'  ->  31 December 2025
```

A string carrying a time or an explicit zone is still left to `new Date()`, which reads both correctly. Only the bare `YYYY-MM-DD` form changes.

## Proof it reached the ledger

Closing an Active group from a Chromium context pinned to `America/New_York`, at **07:31 local** — nowhere near midnight, so this is not an edge-of-day artifact. The dialog's own default date was left untouched, which is the case the issue describes.

The dialog on the pre-fix run:

![Close Group showing Sep 6, 2026](https://raw.githubusercontent.com/Aman-Mittal/fineract-backoffice-ui/assets/issue-screenshots/date-utc-shift-dialog-shows-today.png)

| | browser's local date | `closureDate` sent | platform recorded |
|---|---|---|---|
| `main` @ `e6b31e4d` | 2026-09-06 | `05 September 2026` | `[2026, 9, 5]` |
| this branch | 2026-09-06 | `06 September 2026` | `[2026, 9, 6]` |

The user saw "Sep 6, 2026" on screen and the group was closed on the 5th. Recordings: [before](https://github.com/Aman-Mittal/fineract-backoffice-ui/raw/assets/issue-screenshots/date-utc-shift-before.webm) · [after](https://github.com/Aman-Mittal/fineract-backoffice-ui/raw/assets/issue-screenshots/date-utc-shift-after.webm).

## The helper fix alone was not enough

Working through the 55 call sites turned up three more ways a date crossed the UTC boundary before or after the helper saw it. Each is in the second commit:

- **Five call sites wrapped the value in `new Date()` first** — `group-view` ×2, `loan-view` ×2, `client-view` ×1. The dialogs behind them return `toIsoDate(new Date())`, a bare `YYYY-MM-DD`, so that wrapper re-parsed it as UTC before the new branch could apply. This is the path the evidence above exercises.
- **Two dialogs seeded their picker from `new Date().toISOString()`** — `center-action-dialog` and `center-meeting-dialog`. Confirming without touching the picker sent a different calendar day than the one displayed. Both now use `toIsoDate(new Date())`, which the group and client action dialogs already did.
- **The audit-log filter built its range with `toISOString().split('T')`**, which `date-formatter`'s own doc comment warns against — "from today" read as tomorrow east of Greenwich and yesterday west of it.

## Three hand-rolled workarounds are collapsed

The defect was already known locally. `deposit-account-view` and `share-account-view` each split the ISO string into parts before formatting, both carrying a comment explaining why, and `loan-view` had a private `isoToFineractDate` doing the same. All three are the helper's own behaviour now.

## Range checking

`new Date(2026, 12, 45)` does not fail — it rolls forward to 14 February 2027. Since the caller sends the result to the platform as the user's chosen date, a malformed value is refused rather than silently becoming a real one. Previously `'2026-13-45'` returned `''`; it still does.

## The regression guard, and why it is a CI step

Nothing in this project tested west of Greenwich: the runner's clock is UTC and `playwright.config.ts` pins `Asia/Kolkata`. Every offset the suite exercises is ≥ 0, which is exactly why this shipped — and why no assertion running only at UTC can catch its return. The three new cases pass at UTC either way.

So `ci.yml` runs the unit suite a second time under `TZ=America/New_York`. Reverting only the helper and running that pass:

```
× is read as the calendar date it spells, not as UTC midnight
× does not roll back across a month or a year boundary
× agrees with the array form of the same date

AssertionError: expected '14 January 2026'   to be '15 January 2026'
AssertionError: expected '31 December 2025'  to be '01 January 2026'
```

It costs about a minute per PR and covers the whole application rather than the one helper. Happy to drop it to a single-file run if that trade is not wanted — say so and I will.

The pass also found four `...T00:00:00.000Z` fixtures in `center-view.component.test.ts` that no dialog in this application produces; they passed only because fixture and formatter agreed to read the value as UTC. They now carry the calendar date the dialogs actually return.

## Verification

| | |
|---|---|
| `npm run test:unit` | 236 files / 1419 tests, exit 0 |
| `TZ=America/New_York npm run test:unit` | 236 files / 1419 tests, exit 0 |
| `npm run build` | clean |
| `npm run lint` | clean — `date-formatter.ts` no longer needs its `unicorn/prefer-number-properties` suppression, pruned via `lint:prune` |

Under the negative offset the suite went 9 failures → 3 → 0 as each layer was fixed; the last three were the fixtures above.
