### PR TITLE
fix(config): only fetch the branding overlay when a deployment ships one

### DIFF
--- a/DOCS/CUSTOMIZATION.md
+++ b/DOCS/CUSTOMIZATION.md
@@ -52,6 +52,32 @@ start, so anything you put there is erased on the next restart.
 Layers are deep-merged, so naming one key does not discard the rest. Arrays are replaced, not
 concatenated — writing `nav.hidden` means "hide exactly these".
 
+### L3 is only read when the deployment says it exists
+
+`brandingOverlayEnabled` gates whether the app asks for `branding/config.json` and
+`branding/i18n/` at all. It defaults to `false`, and **the container entrypoint sets it for you**
+by looking for the directory — so the `COPY branding/` above is the whole declaration and there
+is nothing extra to remember.
+
+It is the one setting that cannot live in L3: a file cannot announce its own absence.
+
+The flag exists because an install with no overlay is the normal, supported case, and probing for
+it anyway put two 404s in the browser console on every page load. The application can decline to
+_report_ a 404, and does — but it cannot stop the browser writing it. A supported configuration
+should not look like a broken one.
+
+If you serve `dist/` from your own web server rather than the container image, set it yourself
+alongside `fineractApiUrl`:
+
+```json
+{
+  "fineractApiUrl": "/api/v1",
+  "brandingOverlayEnabled": true
+}
+```
+
+Leave it off and `branding/` is never read, whatever it contains.
+
 ## Getting started
 
 Point your editor at the schema and it will autocomplete and validate as you type:

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -106,16 +106,30 @@ for pair in "RBAC_ENABLED:$FINERACT_UI_RBAC" "DEVELOPER_TOOLS_ENABLED:$FINERACT_
   fi
 done
 
+# Whether this image carries a branding overlay, which is a fact about the container's own
+# filesystem and so exactly what this heredoc is for — the deployer already declared it by
+# doing the `COPY branding/ ...` in DOCS/CUSTOMIZATION.md, and should not have to say it twice.
+#
+# The app cannot work this out for itself. Asking for a file that is absent on every default
+# install put a 404 in the browser console on every page load, and a 404 is a network-level
+# event the application can decline to report but cannot suppress.
+if [ -d "$HTML_ROOT/branding" ]; then
+  FINERACT_UI_BRANDING=true
+else
+  FINERACT_UI_BRANDING=false
+fi
+
 cat > "$HTML_ROOT/config.json" <<EOF
 {
   "fineractApiUrl": "/api/v1",
   "defaultTenant": "$FINERACT_UI_TENANT",
   "rbacEnabled": $FINERACT_UI_RBAC,
   "institutionType": "$FINERACT_UI_INSTITUTION",
-  "developerToolsEnabled": $FINERACT_UI_DEVTOOLS
+  "developerToolsEnabled": $FINERACT_UI_DEVTOOLS,
+  "brandingOverlayEnabled": $FINERACT_UI_BRANDING
 }
 EOF
 
-echo "entrypoint: tenant ${FINERACT_UI_TENANT}, rbacEnabled ${FINERACT_UI_RBAC}, developerTools ${FINERACT_UI_DEVTOOLS}"
+echo "entrypoint: tenant ${FINERACT_UI_TENANT}, rbacEnabled ${FINERACT_UI_RBAC}, developerTools ${FINERACT_UI_DEVTOOLS}, brandingOverlay ${FINERACT_UI_BRANDING}"
 
 exec "$@"

--- a/e2e/branded-deployment.spec.ts
+++ b/e2e/branded-deployment.spec.ts
@@ -71,7 +71,14 @@ async function deployBrandedInstitution(page: Page): Promise<void> {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ fineractApiUrl: '/api/v1', defaultTenant: TENANT, rbacEnabled: true }),
+      body: JSON.stringify({
+        fineractApiUrl: '/api/v1',
+        defaultTenant: TENANT,
+        rbacEnabled: true,
+        // This fixture always mounts an overlay, so the layer beneath it says so — which is what
+        // the container entrypoint does after finding the directory the deployer copied in.
+        brandingOverlayEnabled: true,
+      }),
     });
   });
   // Registered before the `en.json` handler on purpose: Playwright matches routes in reverse

--- a/e2e/deployment-customization.spec.ts
+++ b/e2e/deployment-customization.spec.ts
@@ -53,7 +53,16 @@ async function mockBackend(page: Page, overlay: Overlay): Promise<void> {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ fineractApiUrl: '/api/v1', defaultTenant: TENANT, rbacEnabled: true }),
+      body: JSON.stringify({
+        fineractApiUrl: '/api/v1',
+        defaultTenant: TENANT,
+        rbacEnabled: true,
+        // The container entrypoint sets this by detecting the mounted directory, so a fixture
+        // serving an overlay has to declare it too — otherwise it models a deployment that
+        // shipped `branding/` and never told the application, which is not a state the
+        // entrypoint can produce. See AppConfig.brandingOverlayEnabled.
+        brandingOverlayEnabled: overlay !== null,
+      }),
     });
   });
   await page.route('**/branding/config.json*', async (route) => {
@@ -129,6 +138,24 @@ test.describe('with no overlay mounted', () => {
     expect(await token(page, 'primary-color')).toBe('#3498db');
     await expect(page.locator('.app-title')).toHaveText('Fineract Backoffice UI');
     await expect(sidebar(page).getByRole('link', { name: 'Clients', exact: true })).toBeVisible();
+  });
+
+  /**
+   * The fix for #487. The two overlay files are absent on every default install, and asking for
+   * them anyway put a 404 in the browser console on every route. The application can decline to
+   * *report* a 404 and does, but the browser writes it regardless — so the only thing that
+   * settles it is not making the request, and the only place that can be asserted is here.
+   */
+  test('does not ask for an overlay this deployment has not declared', async ({ page }) => {
+    const asked: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/branding/')) asked.push(request.url());
+    });
+
+    await deployWith(page, null);
+    await expect(page.locator('.app-title')).toBeVisible();
+
+    expect(asked).toEqual([]);
   });
 
   test('logs no federation parse error on load', async ({ page }) => {

--- a/public/config.json
+++ b/public/config.json
@@ -3,5 +3,6 @@
   "defaultTenant": "default",
   "rbacEnabled": true,
   "institutionType": "universal",
-  "developerToolsEnabled": false
+  "developerToolsEnabled": false,
+  "brandingOverlayEnabled": false
 }

--- a/src/app/core/adapters/i18n/deployment-translate.loader.test.ts
+++ b/src/app/core/adapters/i18n/deployment-translate.loader.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TranslationObject } from '@ngx-translate/core';
+import { DeploymentTranslateLoader } from './deployment-translate.loader';
+import { ConfigService } from '../../services/config.service';
+
+const SHIPPED = 'assets/i18n/en.json';
+const OVERLAY = 'branding/i18n/en.json';
+
+describe('DeploymentTranslateLoader', () => {
+  let http: HttpTestingController;
+
+  /** Builds the loader with the overlay flag the deployment's `config.json` would have set. */
+  function create(brandingOverlayEnabled: boolean): DeploymentTranslateLoader {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        DeploymentTranslateLoader,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ConfigService,
+          useValue: { brandingOverlayEnabled: () => brandingOverlayEnabled },
+        },
+      ],
+    });
+    http = TestBed.inject(HttpTestingController);
+    return TestBed.inject(DeploymentTranslateLoader);
+  }
+
+  afterEach(() => http.verify());
+
+  it('serves the shipped catalogue untouched when no overlay is declared', async () => {
+    const loader = create(false);
+    const catalogue = new Promise<TranslationObject>((resolve) =>
+      loader.getTranslation('en').subscribe(resolve),
+    );
+
+    http.expectOne(SHIPPED).flush({ COMMON: { CLIENTS: 'Clients' } });
+    expect(await catalogue).toEqual({ COMMON: { CLIENTS: 'Clients' } });
+  });
+
+  /**
+   * The reason the flag exists. `branding/i18n/` is absent on every default install, so asking
+   * for it put a 404 in the console on every load — one the application can decline to report
+   * but cannot stop the browser writing. See #487.
+   */
+  it('does not ask for an overlay the deployment has not declared', async () => {
+    const loader = create(false);
+    const catalogue = new Promise<TranslationObject>((resolve) =>
+      loader.getTranslation('en').subscribe(resolve),
+    );
+
+    // Checked before the shipped catalogue is flushed: if the request were going to be made at
+    // all, it would already be queued alongside it.
+    expect(http.match(OVERLAY).length).toBe(0);
+
+    http.expectOne(SHIPPED).flush({});
+    await catalogue;
+  });
+
+  it('layers the deployment strings over the shipped ones once declared', async () => {
+    const loader = create(true);
+    const catalogue = new Promise<TranslationObject>((resolve) =>
+      loader.getTranslation('en').subscribe(resolve),
+    );
+
+    http.expectOne(SHIPPED).flush({ COMMON: { CLIENTS: 'Clients', SAVE: 'Save' } });
+    http.expectOne(OVERLAY).flush({ COMMON: { CLIENTS: 'Members' } });
+
+    // Deep-merged: restating one key must not discard its siblings.
+    expect(await catalogue).toEqual({ COMMON: { CLIENTS: 'Members', SAVE: 'Save' } });
+  });
+
+  it('falls back to the shipped catalogue when a declared overlay lacks that language', async () => {
+    const loader = create(true);
+    const catalogue = new Promise<TranslationObject>((resolve) =>
+      loader.getTranslation('en').subscribe(resolve),
+    );
+
+    http.expectOne(SHIPPED).flush({ COMMON: { CLIENTS: 'Clients' } });
+    http.expectOne(OVERLAY).flush(null, { status: 404, statusText: 'Not Found' });
+
+    expect(await catalogue).toEqual({ COMMON: { CLIENTS: 'Clients' } });
+  });
+});

--- a/src/app/core/adapters/i18n/deployment-translate.loader.ts
+++ b/src/app/core/adapters/i18n/deployment-translate.loader.ts
@@ -17,11 +17,12 @@
  * under the License.
  */
 
-import { inject } from '@angular/core';
+import { Injector, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { TranslateLoader, type TranslationObject } from '@ngx-translate/core';
 import { Observable, forkJoin, map, of, catchError } from 'rxjs';
 import { skipErrorToast, skipLoading } from '../../http/http-context';
+import { ConfigService } from '../../services/config.service';
 
 const SHIPPED_PREFIX = 'assets/i18n/';
 
@@ -58,7 +59,11 @@ function deepMerge(
  * loses — which it did. Returning one already-merged catalogue removes the race rather than
  * timing around it, and means no component has to re-render to pick the overlay up.
  *
- * A missing overlay is the normal case and resolves to `{}`.
+ * The overlay is only *requested* when the deployment says it ships one — the container
+ * entrypoint sets `brandingOverlayEnabled` by looking for the directory. Probing regardless put
+ * a 404 in the console of every default install, and a 404 is a network-level event this side
+ * can decline to report but cannot suppress. A missing overlay still resolves to `{}`, so a
+ * deployment that sets the flag and then ships an incomplete `branding/i18n/` is unaffected.
  *
  * Lives inside the adapter boundary because it is a ngx-translate implementation detail: the
  * `TranslateLoader` contract is the library's, and ADR-0003 keeps that surface here rather than
@@ -66,18 +71,30 @@ function deepMerge(
  */
 export class DeploymentTranslateLoader extends TranslateLoader {
   private readonly http = inject(HttpClient);
+  /**
+   * `ConfigService` is resolved on use, not on construction, because injecting it as a field
+   * closes a cycle: `ConfigService` needs `HttpClient`, whose `errorInterceptor` needs `I18N`,
+   * which needs this loader — Angular reports the loop as NG0200 during bootstrap and the app
+   * renders nothing at all. Reading it inside `getTranslation` breaks the loop, and costs
+   * nothing: the first call happens after the initializer has already built the service.
+   */
+  private readonly injector = inject(Injector);
 
   override getTranslation(lang: string): Observable<TranslationObject> {
     const shipped = this.http.get<TranslationObject>(`${SHIPPED_PREFIX}${lang}.json`, {
       context: skipLoading(skipErrorToast()),
     });
 
-    const overlay = this.http
-      .get<TranslationObject>(`${OVERLAY_PREFIX}${lang}.json`, {
-        context: skipLoading(skipErrorToast()),
-      })
-      // Absent is expected. Reporting it would train operators to ignore the console.
-      .pipe(catchError(() => of({} as TranslationObject)));
+    // `loadConfig()` runs in the app initializer, which resolves before the first `use(lang)`,
+    // so the flag is settled by the time this is read.
+    const overlay = this.injector.get(ConfigService).brandingOverlayEnabled()
+      ? this.http
+          .get<TranslationObject>(`${OVERLAY_PREFIX}${lang}.json`, {
+            context: skipLoading(skipErrorToast()),
+          })
+          // A deployment that sets the flag may still not translate every language.
+          .pipe(catchError(() => of({} as TranslationObject)))
+      : of({} as TranslationObject);
 
     return forkJoin([shipped, overlay]).pipe(
       map(

--- a/src/app/core/services/config.service.test.ts
+++ b/src/app/core/services/config.service.test.ts
@@ -96,12 +96,15 @@ describe('ConfigService', () => {
    * Runs a full load cycle: `body` as config.json, `overlay` as the deployment's own layer.
    *
    * The overlay defaults to absent, which is what almost every deployment serves and therefore
-   * the case most of these tests are about.
+   * the case most of these tests are about. Passing one implies `brandingOverlayEnabled`, since
+   * the base layer is what decides whether the overlay is fetched at all — a deployment that
+   * ships `branding/` without the flag is covered by its own case below.
    */
   async function load(body: Partial<AppConfig>, overlay?: Partial<AppConfig>): Promise<void> {
+    const base = overlay ? { brandingOverlayEnabled: true, ...body } : body;
     const loading = service.loadConfig();
-    await flushNext(isBaseConfig, body);
-    await (overlay ? flushNext(isOverlay, overlay) : flushNext(isOverlay, null, NOT_FOUND));
+    await flushNext(isBaseConfig, base);
+    if (overlay) await flushNext(isOverlay, overlay);
     await loading;
   }
 
@@ -138,7 +141,6 @@ describe('ConfigService', () => {
   it('should fall back to defaults when config.json cannot be read', async () => {
     const loading = service.loadConfig();
     await flushNext(isBaseConfig, null, NOT_FOUND);
-    await flushNext(isOverlay, null, NOT_FOUND);
     await loading;
 
     // Bootstrap must not depend on either file being present.
@@ -161,11 +163,57 @@ describe('ConfigService', () => {
   });
 
   it('should keep the base layer when the overlay is absent', async () => {
-    // The state every existing deployment is in: a 404 means "said nothing", not "reset".
+    // The state every existing deployment is in: nothing is asked for, and nothing is reset.
     await load({ fineractApiUrl: '/api/v1', defaultTenant: TEST_TENANT, rbacEnabled: false });
 
     expect(service.config().defaultTenant).toBe(TEST_TENANT);
     expect(service.rbacEnabled()).toBe(false);
+  });
+
+  /**
+   * The overlay is absent on every default install, so probing for it reported a 404 in the
+   * browser console on every load. The application can decline to *report* a 404 and does, but
+   * the browser writes it regardless — the only fix is not to make the request. See #487.
+   */
+  describe('the branding overlay probe', () => {
+    it('is not issued when the deployment has not declared an overlay', async () => {
+      const loading = service.loadConfig();
+      await flushNext(isBaseConfig, { fineractApiUrl: '/api/v1' });
+      await loading;
+
+      // `httpMock.verify()` in afterEach would fail on an outstanding request, but this says
+      // what is being asserted rather than relying on a teardown to imply it.
+      expect(httpMock.match(isOverlay).length).toBe(0);
+    });
+
+    it('is not issued when the deployment declares it off', async () => {
+      const loading = service.loadConfig();
+      await flushNext(isBaseConfig, { fineractApiUrl: '/api/v1', brandingOverlayEnabled: false });
+      await loading;
+
+      expect(httpMock.match(isOverlay).length).toBe(0);
+    });
+
+    it('is issued once the deployment declares an overlay', async () => {
+      await load(
+        { fineractApiUrl: '/api/v1', brandingOverlayEnabled: true },
+        { branding: { appName: 'Any Community Bank' } },
+      );
+
+      expect(service.config().branding?.appName).toBe('Any Community Bank');
+      expect(service.brandingOverlayEnabled()).toBe(true);
+    });
+
+    it('still tolerates a declared overlay that is not actually there', async () => {
+      // A misdeployed overlay is a real error the deployer wants to see, and it is now
+      // distinguishable from the ordinary "no overlay" case — which is the point of the flag.
+      const loading = service.loadConfig();
+      await flushNext(isBaseConfig, { defaultTenant: TEST_TENANT, brandingOverlayEnabled: true });
+      await flushNext(isOverlay, null, NOT_FOUND);
+      await loading;
+
+      expect(service.config().defaultTenant).toBe(TEST_TENANT);
+    });
   });
 
   it('should not raise a toast or a progress bar while bootstrapping', async () => {
@@ -177,7 +225,6 @@ describe('ConfigService', () => {
     expect(base.request.context.get(SKIP_ERROR_TOAST)).toBe(true);
     base.flush(mockConfig);
 
-    await flushNext(isOverlay, null, NOT_FOUND);
     await loading;
   });
 

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -138,6 +138,22 @@ export interface AppConfig {
    * matrix; supply it to change what a type means for this deployment.
    */
   institutionFeatures?: Record<InstitutionType, InstitutionFeature[]>;
+  /**
+   * Whether this deployment ships a `branding/` overlay at all.
+   *
+   * The overlay is absent on every default install, so probing for it made a fresh deployment
+   * report two 404s on every page load — one for `branding/config.json` and one for the
+   * language catalogue. A 404 is a network-level event: the application can decline to *report*
+   * it, and does, but it cannot stop the browser writing it to the console. The only way for a
+   * supported configuration to stop looking like a misconfiguration is not to make the request.
+   *
+   * The container entrypoint sets this by looking for the directory, so a deployment following
+   * `DOCS/CUSTOMIZATION.md` gets it without doing anything. A deployment serving `dist/` from
+   * its own web server sets it in `config.json` alongside `fineractApiUrl`.
+   *
+   * Off by default, which is what an install with no overlay wants.
+   */
+  brandingOverlayEnabled?: boolean;
   /** Deployment-specific navigation adjustments. */
   nav?: NavOverrides;
   /** Deployment-specific appearance. See {@link BrandingConfig}. */
@@ -233,6 +249,7 @@ const DEFAULT_CONFIG: AppConfig = {
   rbacEnabled: true,
   institutionType: 'universal',
   developerToolsEnabled: false,
+  brandingOverlayEnabled: false,
 };
 
 /**
@@ -303,6 +320,15 @@ export class ConfigService {
    */
   readonly developerToolsEnabled = computed(() => this._config().developerToolsEnabled === true);
 
+  /**
+   * Whether this deployment ships a `branding/` overlay. See
+   * {@link AppConfig.brandingOverlayEnabled}.
+   *
+   * Read by the translation loader as well as by {@link loadConfig}: both probe the same
+   * directory, and both are silent on a default install because of this flag.
+   */
+  readonly brandingOverlayEnabled = computed(() => this._config().brandingOverlayEnabled === true);
+
   /** Navigation entries this deployment hides, as a set of `labelKey`s. */
   readonly hiddenNavKeys = computed(() => new Set(this._config().nav?.hidden));
 
@@ -315,9 +341,14 @@ export class ConfigService {
    */
   async loadConfig(): Promise<void> {
     const base = await this.fetchLayer(CONFIG_URL, { required: true });
-    // The overlay is expected to be absent on most deployments, so a 404 is a normal outcome and
-    // not worth a console error. See DEPLOYMENT_OVERLAY_URL for why it is a second file at all.
-    const overlay = await this.fetchLayer(DEPLOYMENT_OVERLAY_URL, { required: false });
+    // Only asked for when the deployment says it has one. Probing unconditionally meant a 404
+    // in the console of every default install, which no amount of handling on this side can
+    // suppress — see {@link AppConfig.brandingOverlayEnabled}. The flag has to come from the
+    // layer below, since a file cannot announce its own absence.
+    const overlay =
+      (base.brandingOverlayEnabled ?? DEFAULT_CONFIG.brandingOverlayEnabled)
+        ? await this.fetchLayer(DEPLOYMENT_OVERLAY_URL, { required: false })
+        : {};
 
     // Merged, not assigned: a config.json listing only the keys a deployment cares about must not
     // blank out the rest, and an overlay naming one key must not discard the layer beneath it.


### PR DESCRIPTION
Closes #487.

## What it does

`branding/config.json` and `branding/i18n/{lang}.json` were requested on every load. They are absent on every default install — the documented, correct state — so a fresh deployment reported two 404s in the browser console on every route.

The application already declined to *report* those failures: both fetches carry `skipErrorToast` and both resolve to `{}`. That is as far as this side can reach. A 404 is a network-level event the browser writes regardless, so the only way for a supported configuration to stop looking like a misconfiguration is not to make the request.

## The flag, and where it has to live

`brandingOverlayEnabled` gates both fetches. It cannot live in the overlay itself — a file cannot announce its own absence — so it belongs in the layer below.

**The container entrypoint sets it for you**, by looking for the directory the deployer already declared with the `COPY branding/ ...` line in `DOCS/CUSTOMIZATION.md`. There is nothing new to remember, and it satisfies that heredoc's own stated rule:

> the rule for this heredoc is narrow: it carries only what the *container environment* is the right source for

Whether this image carries a branding overlay is a fact about the container's filesystem, which is exactly that. A deployment serving `dist/` from its own web server sets it in `config.json` alongside `fineractApiUrl`; that case is documented.

The flag also makes a distinction the old code could not: "no overlay configured" versus "overlay configured but misdeployed". The second is a real error a deployer wants to see, and it still surfaces — a declared overlay that 404s is tolerated in the merge but is no longer indistinguishable from the ordinary case.

## Verified against a running app

Console across `/dashboard`, `/clients`, `/loans`, `/notifications`, capturing every line.

Before, on `main`:

```
failed net::ERR_CONNECTION_REFUSED  http://localhost:4201/remoteEntry.json
http 404  /branding/config.json
http 404  /branding/i18n/en.json
```

After, on this branch:

```
failed net::ERR_CONNECTION_REFUSED  http://localhost:4201/remoteEntry.json
```

What remains is the microfrontend remote, which is simply not running in a plain `ng serve`.

And the positive path, with the flag on and a real overlay in place:

```
branding requests: 200 /branding/config.json?cb=... | 200 /branding/i18n/en.json
brand text:        Any Community Bank
```

The overlay's `appName` renders and the language overlay is merged, so the flag gates the probe without disabling the feature. The temporary overlay used for that check was removed; `npm run check:branding-path` passes.

## One trap worth flagging in review

The loader resolves `ConfigService` **on use**, not as a field. Injecting it at construction closes a cycle — `ConfigService` needs `HttpClient`, whose `errorInterceptor` needs `I18N`, which needs the loader. Angular reports it as NG0200 during bootstrap and the app renders nothing at all.

The unit tests do not catch that, because they provide `ConfigService` directly. I found it by loading the application; `login.spec.ts` would have caught it in CI. Worth knowing before anyone tidies that `inject(Injector)` back into a field — the comment on it says so.

## Verification

| | |
|---|---|
| `npm run test:unit` | 237 files / 1427 tests, exit 0 |
| `TZ=America/New_York npm run test:unit` | 237 files / 1427 tests, exit 0 |
| `npm run build` | clean |
| `npm run lint` | clean |
| `bash scripts/check-license.sh` | clean |
| `node scripts/check-branding-path.mjs` | `public/branding/` is reserved and empty |
| `bash -n deploy/entrypoint.sh` | clean |

New coverage: four cases on `ConfigService` for the probe (not declared, declared off, declared on, declared but missing) and a new `deployment-translate.loader.test.ts` with four more, including that the overlay request is not issued when undeclared.

Rebased on `f18d9592`.
