### PR TITLE
fix(loans): send an unusable interest-pause id back to the list

### DIFF
--- a/src/app/features/loans/interest-pauses/interest-pause-form.component.test.ts
+++ b/src/app/features/loans/interest-pauses/interest-pause-form.component.test.ts
@@ -94,6 +94,18 @@ describe('InterestPauseFormComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'interest-pauses']);
   });
 
+  it.each(['abc', '0', '-1', '1.5', ' '])(
+    'should not enter edit mode for the unusable variation id %p',
+    async (variationId) => {
+      await setup({ loanId: '1', variationId });
+
+      expect(component.isEditMode()).toBe(false);
+      expect(component.variationId).toBeNull();
+      expect(serviceSpy.getLoansLoanIdInterestPauses).not.toHaveBeenCalled();
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/loans', 1, 'interest-pauses']);
+    },
+  );
+
   it('should load and pre-fill the selected pause in edit mode', async () => {
     await setup({ loanId: '1', variationId: '7' }, [
       { id: 6, startDate: '2026-03-10', endDate: '2026-03-20' },

--- a/src/app/features/loans/interest-pauses/interest-pause-form.component.ts
+++ b/src/app/features/loans/interest-pauses/interest-pause-form.component.ts
@@ -48,6 +48,19 @@ import {
 } from '../../../core/utils/date-formatter';
 
 /**
+ * Parses a route segment that is meant to be a database id. Returns null for
+ * anything that cannot be one, which `+value` would otherwise turn into NaN or
+ * into a number the API cannot address.
+ */
+function toRouteId(value: string | null): number | null {
+  if (value === null || value.trim() === '') {
+    return null;
+  }
+  const id = Number(value);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+/**
  * Create or edit an interest pause period on a loan. Submits a start/end date pair formatted
  * with the Fineract date format and locale. The loan and variation ids come from the route.
  */
@@ -171,14 +184,24 @@ export class InterestPauseFormComponent implements OnInit {
   ngOnInit(): void {
     const loanId = this.route.snapshot.paramMap.get('loanId');
     const variationId = this.route.snapshot.paramMap.get('variationId');
-    if (loanId) {
-      this.loanId = +loanId;
+    this.loanId = toRouteId(loanId);
+    if (variationId === null) {
+      return;
     }
-    if (variationId) {
-      this.variationId = +variationId;
-      this.isEditMode.set(true);
-      this.loadPause();
+
+    // The route puts no constraint on the segment, so `edit/abc` used to give
+    // `+'abc'` -> NaN. NaN is falsy, so `loadPause` and the save branch both
+    // skipped it while `isEditMode` stayed true: the screen said Edit, the
+    // pickers were empty, and Save created a second pause. Send an id that
+    // cannot address a pause back to the list instead.
+    this.variationId = toRouteId(variationId);
+    if (this.variationId === null) {
+      this.onCancel();
+      return;
     }
+
+    this.isEditMode.set(true);
+    this.loadPause();
   }
 
   private loadPause(): void {


### PR DESCRIPTION
The route puts no constraint on `:variationId`, so `edit/abc` gave `+'abc'` and left `variationId` as `NaN`. `isEditMode` was set from the presence of the segment, but `loadPause` and the save branch both test the id itself, and `NaN` is falsy. The screen therefore said Edit Interest Pause, the pickers sat on today, and Save posted a create. Nothing on screen said so, which is the part that makes it worth fixing rather than leaving to the API.

`toRouteId` now parses the segment and returns null for anything that cannot be a pause id: non-numeric, empty, zero, negative, fractional. An id that fails that check sends the user back to `/loans/{loanId}/interest-pauses`, the same place Cancel and a successful save go. That felt more honest than quietly rendering the create form under an `/edit/` URL. If you would rather show an error and stay put, say so and I will change it.

The same helper reads `loanId`, so a non-numeric loan id no longer produces `NaN` there either.

Five parameterized cases in the existing spec cover `abc`, `0`, `-1`, `1.5` and a blank segment, asserting edit mode stays off, no pause fetch is issued and the navigation happens. Against the current component all five fail:

    src/app/features/loans/interest-pauses/interest-pause-form.component.test.ts (10 tests | 5 failed)

and they pass with the change.

The full `ng run fineract-backoffice-ui:unit-test` run has pre-existing failures in `web-storage.adapter`, `auth.service`, `config.service`, `institution-config.service`, `navigation-config.service`, `client-form` and `has-institution-feature.directive`. They fail the same way on `main` without this branch, and the count moves a little between runs, so they look environment-dependent rather than related. `interest-pause-form` is not among them either way. Prettier is clean on both changed files.

Closes #512