### PR TITLE
fix: redirect blank section routes

### DIFF
--- a/e2e/feature-coverage.spec.ts
+++ b/e2e/feature-coverage.spec.ts
@@ -184,6 +184,21 @@ test.describe('Navigation & Sidebar', () => {
     }
   });
 
+  test('navigating to /accounting redirects to /accounting/chart-of-accounts', async ({ page }) => {
+    await page.goto('/accounting');
+    await expect(page).toHaveURL(/\/accounting\/chart-of-accounts$/);
+  });
+
+  test('navigating to /organization redirects to /organization/offices', async ({ page }) => {
+    await page.goto('/organization');
+    await expect(page).toHaveURL(/\/organization\/offices$/);
+  });
+
+  test('navigating to /system redirects to /system/data-tables', async ({ page }) => {
+    await page.goto('/system');
+    await expect(page).toHaveURL(/\/system\/data-tables$/);
+  });
+
   test('header shows logged-in user info', async ({ page }) => {
     await expect(page.getByText(TEST_USER)).toBeVisible();
     await expect(page.getByText('Business Date:')).toBeVisible();

--- a/src/app/features/accounting/accounting.routes.test.ts
+++ b/src/app/features/accounting/accounting.routes.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { ACCOUNTING_ROUTES } from './accounting.routes';
+
+@Component({
+  standalone: true,
+  template: '',
+})
+class RouteStub {}
+
+describe('ACCOUNTING_ROUTES', () => {
+  beforeEach(() => {
+    const routes = ACCOUNTING_ROUTES.map((route) =>
+      route.redirectTo ? route : { path: route.path, component: RouteStub },
+    );
+
+    TestBed.configureTestingModule({
+      providers: [provideRouter([{ path: 'accounting', children: routes }])],
+    });
+  });
+
+  it('redirects the feature root to chart-of-accounts', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/accounting');
+
+    expect(TestBed.inject(Router).url).toBe('/accounting/chart-of-accounts');
+  });
+});

--- a/src/app/features/accounting/accounting.routes.ts
+++ b/src/app/features/accounting/accounting.routes.ts
@@ -23,6 +23,11 @@ import { Routes } from '@angular/router';
 
 export const ACCOUNTING_ROUTES: Routes = [
   {
+    path: '',
+    redirectTo: 'chart-of-accounts',
+    pathMatch: 'full',
+  },
+  {
     path: 'chart-of-accounts',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_GLACCOUNT' },

--- a/src/app/features/organization/organization.routes.test.ts
+++ b/src/app/features/organization/organization.routes.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { ORGANIZATION_ROUTES } from './organization.routes';
+
+@Component({
+  standalone: true,
+  template: '',
+})
+class RouteStub {}
+
+describe('ORGANIZATION_ROUTES', () => {
+  beforeEach(() => {
+    const routes = ORGANIZATION_ROUTES.map((route) =>
+      route.redirectTo ? route : { path: route.path, component: RouteStub },
+    );
+
+    TestBed.configureTestingModule({
+      providers: [provideRouter([{ path: 'organization', children: routes }])],
+    });
+  });
+
+  it('redirects the feature root to offices', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/organization');
+
+    expect(TestBed.inject(Router).url).toBe('/organization/offices');
+  });
+});

--- a/src/app/features/organization/organization.routes.ts
+++ b/src/app/features/organization/organization.routes.ts
@@ -23,6 +23,11 @@ import { authGuard } from '../../core/guards/auth.guard';
 
 export const ORGANIZATION_ROUTES: Routes = [
   {
+    path: '',
+    redirectTo: 'offices',
+    pathMatch: 'full',
+  },
+  {
     path: 'offices',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_OFFICE' },

--- a/src/app/features/system/system.routes.test.ts
+++ b/src/app/features/system/system.routes.test.ts
@@ -20,7 +20,7 @@
 import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
-import { TitleStrategy, provideRouter } from '@angular/router';
+import { TitleStrategy, provideRouter, Router } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { SYSTEM_ROUTES } from './system.routes';
 import { TranslatedTitleStrategy } from '../../core/router/translated-title.strategy';
@@ -56,11 +56,15 @@ describe('SYSTEM_ROUTES', () => {
   beforeEach(() => {
     // The guards are not under test here, and permissionGuard would reject every
     // navigation without an authenticated user.
-    const routes = SYSTEM_ROUTES.map(({ path, title }) => ({
-      path,
-      title,
-      component: RouteStub,
-    }));
+    const routes = SYSTEM_ROUTES.map((route) =>
+      route.redirectTo
+        ? route
+        : {
+            path: route.path,
+            title: route.title,
+            component: RouteStub,
+          },
+    );
 
     const adapters = provideFakeAdapters();
     i18n = adapters.i18n;
@@ -83,22 +87,24 @@ describe('SYSTEM_ROUTES', () => {
    * place for that: 49 administrative screens that all read "System".
    */
   it('gives every route its own title', () => {
-    const untitled = SYSTEM_ROUTES.filter((route) => !route.title).map((route) => route.path);
+    const untitled = SYSTEM_ROUTES.filter((route) => !route.redirectTo && !route.title).map(
+      (route) => route.path,
+    );
 
     expect(untitled).toEqual([]);
   });
 
   it('titles routes with translation keys rather than phrases', () => {
-    const notKeys = SYSTEM_ROUTES.filter((route) => !isTranslationKey(route.title)).map(
-      (route) => route.path,
-    );
+    const notKeys = SYSTEM_ROUTES.filter(
+      (route) => !route.redirectTo && !isTranslationKey(route.title),
+    ).map((route) => route.path);
 
     expect(notKeys).toEqual([]);
   });
 
   it('gives no two routes the same title', () => {
     const seen = new Map<string, string[]>();
-    for (const route of SYSTEM_ROUTES) {
+    for (const route of SYSTEM_ROUTES.filter((route) => !route.redirectTo)) {
       const key = String(route.title);
       seen.set(key, [...(seen.get(key) ?? []), String(route.path)]);
     }
@@ -108,6 +114,14 @@ describe('SYSTEM_ROUTES', () => {
     expect(collisions).toEqual([]);
   });
 
+  it('redirects the feature root to data-tables', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/system');
+
+    expect(TestBed.inject(Router).url).toBe('/system/data-tables');
+  });
+
   /**
    * The shapes this file contributes. `codes/:codeId/values` is the one that needed a
    * judgement: its heading is the code's own name, bound at runtime, so the route takes the
@@ -115,7 +129,6 @@ describe('SYSTEM_ROUTES', () => {
    * configuration screens, which is why this file needed no new translation keys at all.
    */
   const cases = [
-    { url: '/system', key: SECTION_KEY, name: SECTION_NAME },
     { url: '/system/codes', key: 'CODES.TITLE', name: 'Codes' },
     { url: '/system/codes/7/values', key: 'CODE_VALUES.TITLE', name: 'Code Values' },
     {

--- a/src/app/features/system/system.routes.ts
+++ b/src/app/features/system/system.routes.ts
@@ -23,6 +23,11 @@ import { authGuard } from '../../core/guards/auth.guard';
 
 export const SYSTEM_ROUTES: Routes = [
   {
+    path: '',
+    redirectTo: 'data-tables',
+    pathMatch: 'full',
+  },
+  {
     path: 'data-tables',
     canActivate: [authGuard, permissionGuard],
     data: { permissions: 'READ_DATATABLE' },


### PR DESCRIPTION
## What and why

Add default redirects for the Accounting, Organization, and System section routes so navigating to `/accounting`, `/organization`, or `/system` opens the first available screen instead of rendering a blank page.

Closes #527

## Verification

- Added regression tests for the three section-root redirects using Angular RouterTestingHarness.
- Feature route tests: 34/34 passed.
- ESLint: 0 errors, 0 warnings.
- Prettier format check passed.
- Route permission static check passed.
- Navigation ID check passed.
- UI was not manually exercised; redirect behavior is covered by the route tests.

## Screenshots

Not applicable — this change fixes route behavior and does not introduce a new UI.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [ ] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. Not applicable; this is a route-level redirect covered by Angular router tests.
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.