### PR TITLE
fix: keep client stepper visible on mobile

### DIFF
--- a/e2e/mobile-shell.spec.ts
+++ b/e2e/mobile-shell.spec.ts
@@ -174,6 +174,38 @@ test.describe('the shell at a phone viewport', () => {
     expect(styles.labelFits).toBe(true);
   });
 
+  test('keeps every client-creation step reachable on a phone viewport', async ({ page }) => {
+    await page.route(/\/api\/v1\/offices/, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    );
+    await page.goto('/clients/create');
+
+    const stepper = page.locator('app-stepper .stepper');
+    await expect(stepper).toBeVisible();
+    await expect(stepper.locator('.step')).toHaveCount(3);
+    await expect(stepper.locator('.step-active')).toHaveAttribute('aria-current', 'step');
+    await expect(stepper.locator('.step-label').nth(0)).toBeVisible();
+    await expect(stepper.locator('.step-label').nth(1)).toBeHidden();
+    await expect(stepper.locator('.step-label').nth(2)).toBeHidden();
+
+    const layout = await stepper.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+      viewportWidth: document.documentElement.clientWidth,
+      markerEdges: Array.from(element.querySelectorAll<HTMLElement>('.step-marker'), (marker) => {
+        const box = marker.getBoundingClientRect();
+        return { left: box.left, right: box.right };
+      }),
+    }));
+
+    expect(layout.scrollWidth).toBeLessThanOrEqual(layout.clientWidth);
+    expect(layout.markerEdges).toHaveLength(3);
+    for (const edge of layout.markerEdges) {
+      expect(edge.left).toBeGreaterThanOrEqual(0);
+      expect(edge.right).toBeLessThanOrEqual(layout.viewportWidth);
+    }
+  });
+
   describe_drawer();
 
   test('renders tables as cards instead of a sideways scroll', async ({ page }) => {

--- a/src/app/shared/components/stepper/stepper.component.ts
+++ b/src/app/shared/components/stepper/stepper.component.ts
@@ -38,6 +38,8 @@ import { TranslatePipe } from '../../../core/adapters';
           class="step"
           [class.step-done]="i < currentIndex()"
           [class.step-active]="i === currentIndex()"
+          [attr.aria-label]="label | appTranslate"
+          [attr.aria-current]="i === currentIndex() ? 'step' : null"
         >
           <span class="step-marker">
             @if (i < currentIndex()) {
@@ -107,6 +109,26 @@ import { TranslatePipe } from '../../../core/adapters';
         height: 2px;
         margin: 0 12px;
         background: var(--border-color, #ccc);
+      }
+      @media (max-width: 600px) {
+        .step {
+          min-width: 0;
+        }
+        .step:last-child {
+          flex: 1;
+        }
+        .step-label {
+          display: none;
+        }
+        .step-active .step-label {
+          display: block;
+          min-width: 0;
+          white-space: normal;
+          overflow-wrap: anywhere;
+        }
+        .step-connector {
+          margin: 0 6px;
+        }
       }
     `,
   ],

--- a/src/app/shared/components/stepper/stepper.component.ts
+++ b/src/app/shared/components/stepper/stepper.component.ts
@@ -110,7 +110,7 @@ import { TranslatePipe } from '../../../core/adapters';
         margin: 0 12px;
         background: var(--border-color, #ccc);
       }
-      @media (max-width: 600px) {
+      @media (max-width: 768px) {
         .step {
           min-width: 0;
         }


### PR DESCRIPTION
## What and why

At mobile widths, the client-creation stepper rendered every non-wrapping label in one row, while the surrounding Ionic card clipped the overflow. This keeps all numbered markers in view, gives layout space only to the active label at the shared 768px mobile breakpoint, and exposes each translated label plus the current step to assistive technology. Wider layouts keep the existing presentation.

Closes #489

## Verification

- `npm run check:responsive`
- `WATCHPACK_POLLING=true CHOKIDAR_USEPOLLING=true npm run test:e2e -- e2e/mobile-shell.spec.ts --project=mobile --grep 'keeps every client-creation step reachable'` — passed against the mocked backend with the Pixel 7 profile
- `npm test -- --watch=false` — 1,461 tests passed across 239 files
- `npm run lint`
- `npm run format:check`
- `npm run check:icons`
- `npm run i18n:check`
- `npm run build`

## Screenshots

The before state is captured in #489. The focused mobile browser test verifies the fixed geometry by asserting that the stepper does not overflow and all three markers remain within the viewport.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs.
- [x] User-facing strings use translation keys.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant.
- [x] Commits are signed — see [Commit Signing](CONTRIBUTING.md#commit-signing) in CONTRIBUTING.md.
