### PR TITLE
Send leftover audit trails path to the audits screen

### DIFF
--- a/e2e/feature-coverage.spec.ts
+++ b/e2e/feature-coverage.spec.ts
@@ -510,6 +510,12 @@ test.describe('Security', () => {
     await expect(page).toHaveURL('/security/audits');
     await expect(page.locator(CARD_TITLE).first()).toContainText(/Audit/i);
   });
+
+  test('leftover audit trails path lands on audits, not the dashboard', async ({ page }) => {
+    await page.goto('/security/audit-trails');
+    await expect(page).toHaveURL('/security/audits');
+    await expect(page.locator(CARD_TITLE).first()).toContainText(/Audit/i);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/app/features/security/security.routes.test.ts
+++ b/src/app/features/security/security.routes.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { SECURITY_ROUTES } from './security.routes';
+
+@Component({
+  standalone: true,
+  template: '',
+})
+class RouteStub {}
+
+describe('SECURITY_ROUTES', () => {
+  beforeEach(() => {
+    const routes = SECURITY_ROUTES.map((route) =>
+      route.redirectTo ? route : { path: route.path, component: RouteStub },
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'security', children: routes },
+          { path: 'dashboard', component: RouteStub },
+          { path: '**', redirectTo: 'dashboard' },
+        ]),
+      ],
+    });
+  });
+
+  it('keeps the audits screen on /security/audits', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/security/audits');
+
+    expect(TestBed.inject(Router).url).toBe('/security/audits');
+  });
+
+  it('sends leftover /security/audit-trails to the audits screen instead of the dashboard', async () => {
+    const harness = await RouterTestingHarness.create();
+
+    await harness.navigateByUrl('/security/audit-trails');
+
+    expect(TestBed.inject(Router).url).toBe('/security/audits');
+  });
+});

--- a/src/app/features/security/security.routes.ts
+++ b/src/app/features/security/security.routes.ts
@@ -72,4 +72,11 @@ export const SECURITY_ROUTES: Routes = [
     loadComponent: () =>
       import('./audit-logs/audit-logs-list.component').then((m) => m.AuditLogsListComponent),
   },
+  {
+    // Leftover bookmarks and docs used this path. Without an alias the catch-all
+    // dumped people on the dashboard with no explanation.
+    path: 'audit-trails',
+    redirectTo: 'audits',
+    pathMatch: 'full',
+  },
 ];


### PR DESCRIPTION
## What and why

The audits screen lives at /security/audits. The leftover audit trails path did not match anything, so the catch all dumped people on the dashboard with no explanation.

This adds a redirect to the audits screen so that leftover URL still hits the existing READ_AUDIT check instead of looking like the feature vanished.

Fixes #528

## Verification

Ran the new security routes unit test. The leftover path now lands on /security/audits, not the dashboard.

## Screenshots

Not applicable. Routing only.

## Checklist

I did not hand edit generated files under src/app/api/.
No new adapters.
No new user facing strings.
Added a unit test for the leftover path.
No UI workflow change so no e2e.
Commits are signed.