### PR TITLE
fix(a11y): meet WCAG AA contrast in the shipped default theme

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -33,6 +33,9 @@ const TENANT_INPUT_SELECTOR = '#tenantId';
 const USERNAME_INPUT_SELECTOR = '#username';
 const PASSWORD_INPUT_SELECTOR = '#password';
 const CARD_SELECTOR = 'ion-card';
+const BANNER_SELECTOR = '.header';
+const CONTENT_SELECTOR = '.content-area';
+const TOAST_SELECTOR = 'ion-toast';
 const CARD_TITLE_SELECTOR = 'ion-card-title';
 const ACTIVE_MODAL_SELECTOR = 'ion-modal:not(.ion-datetime-button-overlay)';
 const BUTTON_ROLE = 'button';
@@ -61,6 +64,32 @@ const CLIENT_FORM_BASELINE = new Set([
   'role-img-alt|.help-icon[name="help-circle-outline"]',
 ]);
 const CREATE_OFFICE_DIALOG_BASELINE = new Set(['aria-allowed-attr|#office-parent >> #ion-sel-*']);
+/**
+ * Pre-existing failures in the banner and on the dashboard that this scan inherits rather than
+ * introduces. Both are unrelated to the contrast work in #484 and want their own fix.
+ *
+ * `role-img-alt` is the Ionic behaviour already carried in CLIENT_LIST_BASELINE: `ion-icon`
+ * renders with `role="img"` and no accessible name of its own. Every entry here is decorative
+ * beside a visible text label, so it is a naming defect rather than lost information.
+ *
+ * `scrollable-region-focusable` on `main` is a genuine keyboard-access finding and is listed
+ * here so it stays visible in the diff rather than disappearing. It is not caused by this
+ * change: `.content-area` scrolls today and did before.
+ */
+const SHELL_BASELINE = new Set([
+  'role-img-alt|.flip-rtl',
+  'role-img-alt|ion-icon[name="moon-outline"]',
+  'role-img-alt|ion-icon[name="settings-outline"]',
+  'role-img-alt|ion-icon[name="people-outline"]',
+  'role-img-alt|ion-icon[name="wallet-outline"]',
+  'role-img-alt|ion-icon[name="card-outline"]',
+  'role-img-alt|ion-icon[name="hardware-chip-outline"]',
+  'role-img-alt|ion-icon[name="time-outline"]',
+  'role-img-alt|ion-icon[name="checkmark-circle-outline"]',
+  'role-img-alt|.chart-card:nth-child(1) > ion-card-header > ion-card-title > ion-icon[name="pie-chart-outline"]',
+  'role-img-alt|.chart-card:nth-child(2) > ion-card-header > ion-card-title > ion-icon[name="pie-chart-outline"]',
+  'scrollable-region-focusable|main',
+]);
 
 function targetParts(target: unknown): string[] {
   if (Array.isArray(target)) {
@@ -79,6 +108,19 @@ function violationFingerprint(ruleId: string, target: unknown): string {
 }
 
 async function mockSession(page: Page): Promise<void> {
+  // Everything the dashboard widgets ask for beyond the specific routes below. Without it their
+  // requests fail, the app raises an error toast per failure, and the toast overlay sits on top
+  // of the page: axe then reports `color-contrast` as *incomplete* ("background color could not
+  // be determined because it is overlapped by another element") for almost every node rather
+  // than passing or failing it. A scan that cannot see the page is not a scan, which is what
+  // `expectScanWasNotBlind` below exists to catch.
+  //
+  // Registered first on purpose. Playwright matches routes in reverse registration order, so a
+  // catch-all added last would swallow the authentication and offices mocks too.
+  await page.route(/\/api\/v1\//, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+
   await page.route('**/config.json*', async (route) => {
     await route.fulfill({
       status: 200,
@@ -140,15 +182,37 @@ async function login(page: Page): Promise<void> {
   await expect(page).toHaveURL(DASHBOARD_ROUTE);
 }
 
+/**
+ * Asserts the scan actually evaluated the page rather than giving up on it.
+ *
+ * axe reports a rule it could not resolve as *incomplete* rather than as a pass or a violation,
+ * and an overlay covering the page puts almost every node there — the run then comes back with
+ * an empty `violations` array and asserts nothing at all. That is the failure mode this suite is
+ * most exposed to, because Ionic renders error toasts as full-width overlays and one unmocked
+ * request is enough to raise them.
+ *
+ * A green run with zero passes is the signature. Checking for passes turns it from a silent
+ * false negative into a failure that names the cause.
+ */
+function expectScanWasNotBlind(results: { passes: unknown[]; incomplete: unknown[] }): void {
+  expect(
+    results.passes.length,
+    'axe evaluated nothing on this page, so a green result here means nothing. An overlay ' +
+      '(usually an ion-toast from an unmocked request) is the usual cause; see mockSession.',
+  ).toBeGreaterThan(0);
+}
+
 async function expectNoBlockingAccessibilityViolations(
   page: Page,
-  include: string,
+  include: string | readonly string[],
   baseline: ReadonlySet<string>,
 ): Promise<void> {
-  const results = await new AxeBuilder({ page })
-    .include(include)
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-    .analyze();
+  const builder = new AxeBuilder({ page });
+  for (const selector of typeof include === 'string' ? [include] : include) {
+    builder.include(selector);
+  }
+  const results = await builder.withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']).analyze();
+  expectScanWasNotBlind(results);
   const violations = results.violations
     .filter((violation) => violation.impact != null && BLOCKING_IMPACTS.has(violation.impact))
     .map((violation) => ({
@@ -194,6 +258,36 @@ test.describe('Runtime accessibility', () => {
     await expect(page.locator(CARD_TITLE_SELECTOR).first()).toContainText(CREATE_CLIENT_TITLE);
 
     await expectNoBlockingAccessibilityViolations(page, CARD_SELECTOR, CLIENT_FORM_BASELINE);
+  });
+
+  /**
+   * The banner and the routed content on the dashboard.
+   *
+   * The other tests here scope their scan to `ion-card` or to an open modal, so nothing outside a
+   * card had ever been scanned: not the header, and not the dashboard route at all.
+   * `color-contrast` is part of `wcag2aa` and has been running the whole time — it was simply
+   * never pointed anywhere it could see the application chrome, which is how six AA contrast
+   * failures in the shipped light theme went unreported (#484).
+   *
+   * `app-sidebar` is deliberately not in scope. It has two pre-existing blocking failures that
+   * have nothing to do with this change and should not be baselined away silently here:
+   * `role-img-alt` on around sixty `ion-icon` nav glyphs, the same Ionic behaviour already
+   * carried in CLIENT_LIST_BASELINE, and `scrollable-region-focusable` on the nav's own scroll
+   * container, which is a real keyboard-access bug. Both want their own issue and their own fix.
+   */
+  test('banner and dashboard content have no blocking violations', async ({ page }) => {
+    await page.goto(DASHBOARD_ROUTE);
+    await expect(page.locator(BANNER_SELECTOR)).toBeVisible();
+    await expect(page.locator(CARD_TITLE_SELECTOR).first()).toBeVisible();
+    // An overlay would put color-contrast into axe's `incomplete` bucket for the whole page and
+    // the assertion below would pass without having looked at anything.
+    await expect(page.locator(TOAST_SELECTOR)).toHaveCount(0);
+
+    await expectNoBlockingAccessibilityViolations(
+      page,
+      [BANNER_SELECTOR, CONTENT_SELECTOR],
+      SHELL_BASELINE,
+    );
   });
 
   test('create office dialog has no blocking violations', async ({ page }) => {

--- a/src/app/core/services/branding.service.ts
+++ b/src/app/core/services/branding.service.ts
@@ -41,9 +41,16 @@ export const BRANDABLE_TOKENS: readonly string[] = [
   'text-color',
   'text-muted',
   'error-color',
+  'error-strong',
   'success-color',
   'warning-color',
   'border-color',
+  // The on-surface text variants. Brandable for the same reason their base colours are: a
+  // deployment that recolours the palette and cannot recolour these ends up with its own blue
+  // everywhere except the header title, which is the branding-coverage gap rather than a fix.
+  'primary-text',
+  'warning-text',
+  'success-text',
   // Shape and density
   'border-radius',
   'header-height',
@@ -71,6 +78,12 @@ const THEME_SCOPED = new Set([
   'text-color',
   'text-muted',
   'border-color',
+  // These invert between themes: dark on white in light, light on near-black in dark. A light
+  // value carried into dark mode paints navy text on a dark card, which is the same failure
+  // --secondary-color has.
+  'primary-text',
+  'warning-text',
+  'success-text',
 ]);
 
 /**
@@ -96,7 +109,7 @@ export const MIN_PRIMARY_CONTRAST = 4.5;
  * 4.5:1 AA threshold. No colour can fail, so a floor there would be unreachable code. The payoff
  * is in dark mode, where a lighter accent is normal and a white-only rule would forbid it.
  */
-const REQUIRES_WHITE_TEXT = new Set(['secondary-color', 'primary-strong']);
+const REQUIRES_WHITE_TEXT = new Set(['secondary-color', 'primary-strong', 'error-strong']);
 
 /** `#rgb` or `#rrggbb` — the two forms a colour input and a human both produce. */
 const HEX = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;

--- a/src/app/features/dashboard/system-status.component.ts
+++ b/src/app/features/dashboard/system-status.component.ts
@@ -355,11 +355,11 @@ import {
         color: var(--text-muted);
       }
       .widget-trend.highlight {
-        color: var(--warning-color);
+        color: var(--warning-text);
         font-weight: 600;
       }
       .healthy {
-        color: var(--success-color);
+        color: var(--success-text);
       }
       .dashboard-layout {
         display: grid;

--- a/src/app/layout/header.component.ts
+++ b/src/app/layout/header.component.ts
@@ -388,7 +388,7 @@ type HeaderSearchResult =
         text-transform: uppercase;
       }
       .system-info .value {
-        color: var(--primary-color);
+        color: var(--primary-text);
         font-family: 'Roboto Mono', monospace;
       }
       .toggle-btn {
@@ -444,7 +444,7 @@ type HeaderSearchResult =
       .app-title {
         font-size: 1.25rem;
         font-weight: 600;
-        color: var(--primary-color);
+        color: var(--primary-text);
       }
       .header-actions {
         display: flex;
@@ -473,7 +473,7 @@ type HeaderSearchResult =
       }
       .logout-btn {
         padding: 0.5rem 1rem;
-        background-color: var(--error-color);
+        background-color: var(--error-strong);
         color: white;
         border: none;
         border-radius: 4px;
@@ -504,7 +504,7 @@ type HeaderSearchResult =
         align-items: center;
         gap: 6px;
         padding: 0.5rem 0.75rem;
-        background-color: var(--primary-dark);
+        background-color: var(--primary-strong);
         color: white;
         border: none;
         border-radius: 4px;

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -26,12 +26,29 @@
      WCAG AA minimum for body-sized text; this clears it at 5.3:1. Keep
      --primary-color for accents, borders and text on light backgrounds. */
   --primary-strong: #2471a3;
+  /* Use wherever a palette colour is drawn as *text* on a page or card surface, as opposed to
+     as a fill behind white. The palette is chosen for fills, and a colour that reads well as a
+     button background is usually too light to read as words on white: --primary-color is 3.15:1
+     there, --warning-color 2.19:1 and --success-color 2.10:1, all short of the 4.5:1 WCAG AA
+     minimum. These carry the same hue at a weight that clears it.
+
+     Theme-scoped, because the requirement inverts: on the dark card the shipped palette values
+     already clear AA comfortably (5.29:1, 7.60:1 and 7.93:1) and darkening them would fail. The
+     dark block below restores the bright values deliberately. Same reasoning as
+     --guidance-highlight-color. */
+  --primary-text: #2471a3;
+  --warning-text: #b45309;
+  --success-text: #1e8449;
   --secondary-color: #2c3e50;
   --bg-color: #f0f2f5;
   --card-bg: #ffffff;
   --text-color: #333333;
   --text-muted: #666666;
   --error-color: #e74c3c;
+  /* The --primary-strong of the error palette: white on --error-color is 3.82:1, short of the
+     4.5:1 AA minimum for the Logout button's label. Not theme-scoped, because a fill carries its
+     own contrast against the white drawn on it whatever the page behind it is doing. */
+  --error-strong: #c0392b;
   --success-color: #2ecc71;
   --warning-color: #f39c12;
   /* The guided tour's highlight outline. Themed because one colour cannot serve both: measured
@@ -85,6 +102,11 @@
 [data-theme='dark'] {
   --primary-color: #3498db;
   --primary-dark: #2980b9;
+  /* The light theme darkens these to clear AA on white; on #1e1e1e the shipped palette values
+     are already 5.29:1, 7.60:1 and 7.93:1 and the darkened ones would fail. See :root above. */
+  --primary-text: #3498db;
+  --warning-text: #f39c12;
+  --success-text: #2ecc71;
   --secondary-color: #ecf0f1;
   --bg-color: #121212;
   --card-bg: #1e1e1e;


### PR DESCRIPTION
## What and why

Six elements in the header and on the dashboard fail WCAG AA contrast in the shipped light theme. All six reproduce, and the fix completes a pattern already in the codebase rather than adding a new one.

Closes #484

Two things in the issue did not hold up when I checked them, and one changes the shape of the fix:

**The values are not outside the branding system.** The issue says they are hardcoded outside `BRANDABLE_TOKENS` and that a deployer cannot fix them. All six sites read `var(--token)` today, and all five distinct tokens (`primary-color`, `primary-dark`, `error-color`, `warning-color`, `success-color`) are already on the allow-list. `branded-deployment.spec.ts` asserts a deployment's palette reaches the chrome and passes. So there is no branding-coverage defect to fix.

**One ratio is off.** `.system-info .value` is given as 3.48:1 against `#2c3e50`. Its background is `--hover-bg`, `rgba(44, 62, 80, 0.06)`, composited over `--card-bg` `#ffffff`, which resolves to `#f2f3f5`. Measured live it is **2.83:1**. Looks like the rgba's own channels were used instead of compositing over the ancestor. The other five reproduce exactly.

**What is actually going on is in the test suite.** `accessibility.spec.ts` runs axe with `wcag2aa`, which includes `color-contrast`, and always has. Every scan is scoped to `ion-card` or an open modal, on `/clients` and `/clients/create`. The header is not inside an `ion-card` and `/dashboard` is never visited, so the rule has been running the whole time pointed somewhere it could not see the application chrome.

## The fix

`--primary-strong` already carries the idea: its comment says `--primary-color` holds white at 3.15:1 and `--primary-dark` at 4.31:1, both short of AA. `.tour-btn` sets `color: white` on `--primary-dark`, which is exactly the case that comment warns about, so one of the six needs no new value at all.

Completing that pattern instead of patching six CSS sites:

- **Fills carrying white text**, theme-independent, since a fill carries its own contrast: `.tour-btn` moves to `--primary-strong`; new `--error-strong: #c0392b` for `.logout-btn`.
- **Palette drawn as text on a surface**, theme-scoped, because the requirement inverts: new `--primary-text`, `--warning-text`, `--success-text`. Light takes darkened values (`#2471a3`, reusing the `--primary-strong` value; `#b45309`, the value already proven for light in `--guidance-highlight-color`; `#1e8449`). Dark keeps the shipped palette, which already clears AA on `#1e1e1e` at 5.29, 7.60 and 7.93. Same reasoning already written down for `--guidance-highlight-color`.

One genuinely new hex across the change.

All four go on `BRANDABLE_TOKENS`, the three text ones on `THEME_SCOPED`, and `error-strong` on `REQUIRES_WHITE_TEXT` so an override of it gets the same 4.5:1 floor `primary-strong` gets. Without that last part a deployment that recolours the palette would find its own blue everywhere except the header title, which would introduce the coverage gap the issue was worried about rather than remove it.

| Element | Before | After (light) | After (dark) | Needs |
|---|---|---|---|---|
| `.app-title` | 3.15 | 5.30 | 5.29 | 4.5 |
| `.system-info .value` | 2.83 | 4.77 | 4.98 | 4.5 |
| `.tour-btn` | 4.30 | 5.30 | 5.30 | 4.5 |
| `.logout-btn` | 3.82 | 5.44 | 5.44 | 4.5 |
| `.widget-trend.highlight` | 2.19 | 5.02 | 7.60 | 4.5 |
| `.widget-value.healthy` | 2.10 | 4.72 | 7.93 | 3.0 (36px/700) |

**Happy to do this the other way if you would rather.** The alternative is darkening the light-theme values of `--primary-color`, `--warning-color` and `--success-color` directly and adding no tokens. Smaller diff, but it recolours every accent, border, chart segment and `ion-color-*` that derives from them, including things that currently pass. I went with the tokens because it changes nothing that already works, but these become public API and it is your architecture, so say the word.

## Verification

Mocked, on a dev server, Chromium at 1366x900. No real backend; this is presentational and none of it touches a request.

- **Negative control.** With the new test in place and the colour changes reverted, it fails naming exactly those six with exactly the ratios above, and the other three a11y tests stay green. Restored: 4 passed.
- Contrast measured live in both themes, computed foreground against the first opaque ancestor. Confirmed the theme-scoped tokens resolve to the bright values under `[data-theme='dark']`. Dark is verified by computed styles plus the WCAG formula; the suite scans the light theme only, as before.
- Unit tests: 239 files, **1461 passed**.
- e2e mocked: `accessibility.spec.ts` and `branded-deployment.spec.ts`, **13 passed**. The branded-deployment suite is the one that would catch a branding-coverage regression.
- `npm run lint` and `prettier --check src e2e` clean.

### About the new test

It needed a catch-all `/api/v1/` mock, and that turned out to be the most important detail. Without one the dashboard widgets' requests fail, the app raises an error toast per failure, and the Ionic toast overlay covers the page. axe then reports `color-contrast` as *incomplete* for nearly every node, with "background color could not be determined because it is overlapped by another element", and returns an **empty violations array**. The test would have passed while looking at nothing.

So there is an `expectScanWasNotBlind` assertion: a green run with zero passes is the signature of that, and it now fails with a message naming the cause. The catch-all is registered first because Playwright matches routes in reverse registration order and a catch-all added last swallows the authentication and offices mocks.

`app-sidebar` is deliberately out of scope, with a comment saying why. It has two pre-existing blocking failures that are not this issue's: `role-img-alt` on around sixty `ion-icon` nav glyphs, the same Ionic behaviour already carried in `CLIENT_LIST_BASELINE`, and `scrollable-region-focusable` on the nav's scroll container. Baselining sixty selectors to make an unrelated area green seemed the wrong trade.

`SHELL_BASELINE` carries eleven `role-img-alt` entries for icons in the banner and dashboard cards, plus `scrollable-region-focusable|main`. That last one is a real keyboard-access finding on `.content-area`, unrelated to this change and true before it. Listed rather than hidden, and I am happy to open a separate issue for it and for the sidebar pair if useful.

## Screenshots

Not added. The change is a set of measured contrast ratios rather than a layout change, and the numbers in the table are the evidence; a screenshot of slightly darker text is easy to misread as no change. Happy to add before/after captures if you would like them.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] New component or service code uses the adapter boundary in `src/app/core/adapters/` instead of direct browser globals or imperative third-party APIs. No new component or service code; this is token definitions, six `var()` references and a test.
- [x] User-facing strings use translation keys. No new strings.
- [x] I added or updated tests appropriate to this change, or explained why tests were not needed.
- [x] UI workflow changes include suitable e2e coverage, including real-backend testing where relevant. Covered by the new mocked e2e scan; no workflow or request behaviour changes, so no real-backend testing.
- [x] Commits are signed.
