### PR TITLE
feat(ui): establish component boundary with accessible tabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,9 @@ Third-party surfaces the application must be able to replace are reached through
 
 - Tokens resolve to their default implementation with no provider needed; override in
   `app.config.ts` to swap one.
-- `<ion-*>` components are **not** restricted — they are the UI layer. Only Ionic's imperative
-  controllers are.
+- UI primitives are reached through `src/app/ui/`; direct Ionic imports outside that boundary
+  are a shrinking lint baseline. Add or migrate one primitive at a time with its browser test
+  contract. Imperative controllers still use OVERLAY. See `DOCS/adr/0005-ui-boundary.md`.
 - New keys must be added to `STORAGE_KEYS` (`core/adapters/storage/storage-keys.ts`); the type
   admits nothing else.
 - `npm run lint` fails on a new violation. The existing backlog is recorded in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,9 @@ The UI layer is **Ionic** (`@ionic/angular` v8) in `mode: 'md'`. Angular Materia
 removed and `npm run lint` blocks any import of it. `@angular/cdk` is retained for unstyled
 primitives. `STYLE.md` holds the full component mapping — the essentials:
 
-- Import individual components from `@ionic/angular/standalone` into the component's `imports`
-  array; never `IonicModule`.
+- New feature/shared code uses app-owned primitives from `src/app/ui/`; existing direct Ionic
+  imports are a shrinking lint baseline. Inside UI implementations, import individual vendor
+  components from `@ionic/angular/standalone`; never `IonicModule`.
 - `MatSnackBar` → `NotificationService`, `MatDialog` → `DialogService`
   (both in `src/app/core/services/`).
 - Icons are ionicons and **must** be registered in `src/app/core/icons.ts`, which `bootstrap.ts`

--- a/DOCS/adr/0003-adapter-boundary.md
+++ b/DOCS/adr/0003-adapter-boundary.md
@@ -23,6 +23,9 @@ under the License.
 - **Date:** 2026-08-02
 - **Deciders:** Maintainers of fineract-backoffice-ui
 
+> UI component migration is extended by [ADR 0005](0005-ui-boundary.md); the imperative
+> adapter decisions below remain unchanged.
+
 ## Context
 
 The application depends directly on several third-party surfaces, measured across the

--- a/DOCS/adr/0005-ui-boundary.md
+++ b/DOCS/adr/0005-ui-boundary.md
@@ -1,0 +1,119 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# ADR 0005: An application-owned UI and test boundary
+
+- **Status:** Proposed; first tab migration implemented for review
+- **Date:** 2026-09-10
+- **Discussion:** [#530](https://github.com/apache/fineract-backoffice-ui/issues/530)
+- **Scope:** One UI implementation at a time; incremental migration, not a second component library
+
+## Problem and decision
+
+ADR 0003 isolates imperative dependencies but deliberately leaves template components outside
+the boundary. A library swap still changes hundreds of templates, form-value semantics, and
+browser locators. This proposal extends that boundary to `src/app/ui/` and to the test contract.
+It does not declare the overall migration complete.
+
+Features import app-owned components from `src/app/ui/`; their public inputs, outputs, projected
+content, ARIA and value contracts name application concepts. Ionic may be used inside this
+directory while a primitive is being implemented. Behavioural primitives use CDK and native
+elements where possible. Existing OVERLAY, I18N, STORAGE and DOWNLOAD adapters remain in force.
+No dependency is added and no second vendor runs alongside Ionic.
+
+## Public contracts for the whole boundary
+
+| Tier                                       | App-owned contract                                                                                                                                                                                                 | Acceptance before migrating consumers                                                                                                                                                                                            |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Behavioural: tabs, popups, dialogs         | Values and dismissal reasons, focus entry/return, keyboard behaviour, roles and accessible names; no vendor events or controller handles                                                                           | Keyboard-only and pointer operation; disabled/empty/dynamic states; nested overlays; focus restored after close; browser checks at desktop and narrow widths                                                                     |
+| Form: input, select, date, checkbox/toggle | Angular ControlValueAccessor; `writeValue` never emits; disabled/touched/validation state; select preserves primitive identifiers; dates are ISO calendar strings, not UTC instants; explicit null/empty semantics | Shared CVA contract tests with reactive forms and ngModel; programmatic writes, reset, blur, disabled state; number/string identity and negative-timezone date round trips; the same browser helper against both implementations |
+| Cosmetic: cards, buttons, icons, layout    | Intent, label, disabled/busy state, content slots and app design tokens; buttons declare submit versus ordinary action                                                                                             | Accessible names, form submission, projected content, theme/density and responsive visual checks                                                                                                                                 |
+
+The form migration uses explicit value types: text is `string` (empty is `''`), numeric
+input is `number | null`, a single select is `string | number | null` without coercion,
+a multi-select is a readonly array of those non-null identifiers, and checkbox/toggle values
+are booleans. Calendar dates are valid `YYYY-MM-DD | null`; adapters must not round-trip them
+through UTC. Defaults, reset, required validation and backend conversion remain feature
+responsibilities. Every CVA shares disabled, blur/touched, `aria-invalid`, error-description
+and label tests; replacing the renderer must not change submitted payloads.
+
+New primitives use `app-*` selectors. Existing `ion-*` selectors remain only in unmigrated
+templates; no compatibility directive masquerades as an Ionic component. A consumer migration
+updates its import, template and test helper together. The ~770 form bindings are migrated by
+control type with contract tests, rather than being silently reinterpreted by a selector alias.
+
+Tests consume roles, accessible names, selected/expanded/disabled state and stable `data-testid`
+scopes. They never inspect vendor shadow DOM, CSS classes or `CustomEvent.detail`. Helpers in
+`e2e/utils/ui-locators.ts` are the new seam. Existing Ionic helpers stay for unmigrated controls;
+do not extend them for app-owned primitives. Stable hooks also apply to guided tours.
+
+Theme values flow from application design tokens into UI implementations. Primitives do not
+export Ionic CSS variables as public API. Deployment overrides retain the existing validated
+branding allowlist until each additional token has a documented type, fallback, accessibility
+constraint and validation test; this change does not remove that safety boundary. Dark mode,
+focus visibility, touch target size and overflow are part of each primitive's acceptance.
+
+## First independently verifiable increment
+
+`TabsComponent` is implemented without Ionic, using native buttons and CDK FocusKeyManager.
+Its `UiTab` values are strings; labels are translated by the caller. `value` is controlled by
+the feature and `valueChange` carries only a new enabled identifier. Arrow keys wrap and skip
+disabled tabs; Home/End work; RTL reverses horizontal navigation. Focus movement is separate
+from activation: Enter/Space or a click requests a value change. Tab leaves the strip normally.
+This avoids issuing data requests for every arrow key on a network-backed panel.
+
+Callers provide a stable, page-unique `idPrefix` and a tablist label. Each button has role `tab`,
+`aria-selected`, a roving tabindex and `aria-controls`. The caller renders one shared panel with
+role `tabpanel`, `tabindex=0`, `panelId()` and `aria-labelledby=tabId(selectedValue)`. This makes
+loading and panel lifecycle explicit rather than eagerly mounting every feature. A missing
+selected value leaves an enabled tab focusable, but never emits a fabricated selection.
+
+`EntityDatatablesComponent` is the first consumer. It sends the selected table name directly to
+its existing data-loading logic, with no Ionic event cast, and preserves the
+`entity-datatables-tabs` scope. Its rendered integration test and a group-detail browser test
+exercise both data loading and the ARIA panel relationship. The browser test also proves arrow
+navigation does not fetch a table until activation, and uses the app helper to switch back.
+
+## Enforcement and remaining rollout
+
+`no-restricted-imports` now rejects new `@ionic/angular` imports outside `src/app/ui/**`.
+Existing direct imports are seeded once in `eslint-suppressions.json`. CI's existing
+`--prune-suppressions` removes obsolete allowances. The UI exception permits Ionic only;
+Material and direct ngx-translate imports remain forbidden. Existing imperative adapters and
+composition roots (`app.config.ts`, test setup) retain their narrow architectural roles.
+The ESLint contract tests prove these boundaries with unsuppressed new-file examples.
+
+After review of this increment:
+
+1. Migrate the remaining entity/tab strips to the tab contract, updating guided tours and
+   Ionic-specific test hooks in the same change. Add per-screen acceptance tests where tabs
+   have conditional visibility or load data asynchronously.
+2. Move popup selection and remaining behavioural controls behind app contracts/CDK. Keep
+   the existing OVERLAY interface; preserve close reasons, focus return and backdrop behaviour.
+3. Implement each form CVA with the shared tests above, then migrate source and browser helpers
+   together. Demonstrate a second implementation in the contract fixture before calling a form
+   primitive replaceable; do not ship two libraries in production.
+4. Migrate cosmetic primitives and theme mappings; remove unused Ionic selectors, imports,
+   vendor-only helpers and suppression entries as their counts reach zero.
+5. Exercise all shared contracts against a replacement implementation with no feature/test
+   edits. Only then can the full library-swap acceptance criterion and #530 be closed.
+
+This PR establishes enforcement, the overall migration contract and one working behavioural
+primitive. It does not migrate all templates, form controls, popups, theme tokens or E2E specs.
+Those remain explicit work under #530, which this PR references without closing.

--- a/STYLE.md
+++ b/STYLE.md
@@ -53,7 +53,15 @@ The UI layer is **Ionic** (`@ionic/angular` v8). Ionic is configured in `mode: '
 > `@angular/cdk` is retained and is fine to use for unstyled primitives (`cdk-table`, virtual
 > scroll, a11y) — the shared data table is built on it.
 
-### Importing Ionic components
+### UI boundary
+
+New UI dependencies belong in `src/app/ui/`. Prefer its app-owned primitives; direct Ionic
+imports in existing features are a lint migration baseline. See
+[ADR 0005](DOCS/adr/0005-ui-boundary.md) for component, form-value, theme and browser-test
+contracts. Implementations inside `ui/` may use Ionic as described below; CDK behavioural
+primitives such as `app-tabs` do not need it.
+
+### Importing Ionic components inside UI implementations
 
 Always import individual components from the **standalone** entry point and list them in the
 component's own `imports` array. Never use `IonicModule`.

--- a/STYLE.md
+++ b/STYLE.md
@@ -49,7 +49,8 @@ The UI layer is **Ionic** (`@ionic/angular` v8). Ionic is configured in `mode: '
 (`src/app/app.config.ts`), so components render in Material Design styling.
 
 > Angular Material has been removed entirely, and `npm run lint` fails on any import of it.
-> The table below records the equivalents, which are also the conventions for new code.
+> The table below records vendor equivalents for UI implementations. New feature/shared code
+> uses the app-owned boundary described below.
 > `@angular/cdk` is retained and is fine to use for unstyled primitives (`cdk-table`, virtual
 > scroll, a11y) — the shared data table is built on it.
 

--- a/e2e/group-detail.spec.ts
+++ b/e2e/group-detail.spec.ts
@@ -35,6 +35,7 @@ import { Page, Request } from '@playwright/test';
 import { test, expect } from './fixtures';
 import { confirmDialog, modalFor } from './utils/ionic-locators';
 import { selectInDialog } from './utils/select-in-dialog';
+import { selectUiTab } from './utils/ui-locators';
 
 const HEAD_OFFICE = 'Head Office';
 const GROUP_ID = 7;
@@ -190,6 +191,54 @@ async function openGroup(page: Page): Promise<void> {
 }
 
 test.describe('Group detail', () => {
+  for (const width of [1280, 390]) {
+    test(`custom field tabs expose the app keyboard and panel contract at ${width}px`, async ({
+      page,
+    }) => {
+      await setup(page);
+      const fetched: string[] = [];
+      await page.route(/\/api\/v1\/datatables(?:\?|$)/, (route) =>
+        route.fulfill(
+          json([
+            { registeredTableName: 'GroupStats', columnHeaderData: [{ columnName: 'value' }] },
+            { registeredTableName: 'GroupNotes', columnHeaderData: [{ columnName: 'value' }] },
+          ]),
+        ),
+      );
+      await page.route(/\/api\/v1\/datatables\/Group(?:Stats|Notes)\/7(?:\?|$)/, (route) => {
+        const table = new URL(route.request().url()).pathname.split('/')[4];
+        fetched.push(table);
+        return route.fulfill(
+          json([{ value: table === 'GroupStats' ? 'Recorded statistics' : 'Recorded notes' }]),
+        );
+      });
+      await openGroup(page);
+      await page.getByTestId('group-tab-custom-fields').click();
+      const scope = page.getByTestId('entity-datatables-tabs');
+      const stats = scope.getByRole('tab', { name: 'GroupStats', exact: true });
+      const notes = scope.getByRole('tab', { name: 'GroupNotes', exact: true });
+      await expect(page.getByRole('cell', { name: 'Recorded statistics' })).toBeVisible();
+      await page.setViewportSize({ width, height: 844 });
+      await stats.focus();
+      await stats.press('ArrowRight');
+      await expect(notes).toBeFocused();
+      await expect(stats).toHaveAttribute('aria-selected', 'true');
+      expect(fetched).toEqual(['GroupStats']);
+      await notes.press('Enter');
+      await expect(notes).toHaveAttribute('aria-selected', 'true');
+      await expect(page.getByRole('cell', { name: 'Recorded notes' })).toBeVisible();
+      await notes.press('Tab');
+      await expect(page.getByRole('tabpanel', { name: 'GroupNotes', exact: true })).toBeFocused();
+      await selectUiTab(scope, 'GroupStats');
+      await expect(page.getByRole('cell', { name: 'Recorded statistics' })).toBeVisible();
+      await notes.focus();
+      await notes.press('Space');
+      await expect(notes).toHaveAttribute('aria-selected', 'true');
+      await expect(page.getByRole('cell', { name: 'Recorded notes' })).toBeVisible();
+      expect(fetched).toEqual(['GroupStats', 'GroupNotes', 'GroupStats', 'GroupNotes']);
+    });
+  }
+
   test('asks for the associations, and shows every member rather than only the active ones', async ({
     page,
   }) => {

--- a/e2e/group-detail.spec.ts
+++ b/e2e/group-detail.spec.ts
@@ -125,6 +125,10 @@ async function setup(
     ),
   );
 
+  await page.route('**/api/v1/businessdate**', (route) =>
+    route.fulfill(json([{ type: 'BUSINESS_DATE', date: [2026, 9, 10] }])),
+  );
+
   await page.route('**/api/v1/offices**', (route) =>
     route.fulfill(json([{ id: 1, name: HEAD_OFFICE, nameDecorated: HEAD_OFFICE, hierarchy: '.' }])),
   );
@@ -194,7 +198,7 @@ test.describe('Group detail', () => {
   for (const width of [1280, 390]) {
     test(`custom field tabs expose the app keyboard and panel contract at ${width}px`, async ({
       page,
-    }) => {
+    }, testInfo) => {
       await setup(page);
       const fetched: string[] = [];
       await page.route(/\/api\/v1\/datatables(?:\?|$)/, (route) =>
@@ -236,6 +240,12 @@ test.describe('Group detail', () => {
       await expect(notes).toHaveAttribute('aria-selected', 'true');
       await expect(page.getByRole('cell', { name: 'Recorded notes' })).toBeVisible();
       expect(fetched).toEqual(['GroupStats', 'GroupNotes', 'GroupStats', 'GroupNotes']);
+      const region = page.locator('app-entity-datatables .entity-datatables-container');
+      await expect(region.getByTestId('data-table-spinner')).toHaveCount(0);
+      await testInfo.attach(`custom-fields-${width}px`, {
+        body: await region.screenshot({ animations: 'disabled' }),
+        contentType: 'image/png',
+      });
     });
   }
 

--- a/e2e/utils/ui-locators.ts
+++ b/e2e/utils/ui-locators.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, Locator } from '@playwright/test';
+
+/** App-owned tab seam: callers depend on the scope, role, name and selected state only. */
+export async function selectUiTab(scope: Locator, name: string | RegExp): Promise<void> {
+  const tab = scope.getByRole('tab', { name, exact: typeof name === 'string' });
+  await tab.click();
+  await expect(tab).toHaveAttribute('aria-selected', 'true');
+}

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -41,67 +41,102 @@
   },
   "src/app/features/accounting/accounting-closure-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/accounting-closures-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/accounting/accounting-rule-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/accounting/accounting-rules-list.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/accounting/charges/charge-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/charges/charges-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/chart-of-accounts.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/accounting/financial-activity-mapping-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/accounting/financial-activity-mappings-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/accounting/frequent-postings.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/accounting/gl-account-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/journal-entries-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/journal-entry-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/accounting/journal-entry-view.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/accounting/opening-balances.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/accounting/provisioning-categories/provisioning-categories-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/provisioning-categories/provisioning-categories-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/provisioning-criteria/provisioning-criteria-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/provisioning-criteria/provisioning-criteria-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/provisioning-entries/provisioning-entries-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/accounting/provisioning-entries/provisioning-entries-list.component.ts": {
@@ -111,87 +146,112 @@
   },
   "src/app/features/accounting/run-accruals/run-accruals.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/admin/batch-operations/batch-operations.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/admin/cob-tools/cob-tools.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/admin/external-events/external-events.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/admin/inline-job/inline-job.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/admin/progressive-loan/progressive-loan-model.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/admin/wc-cob-tools/wc-cob-tools.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/auth/forgot-password/forgot-password.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/calendars/calendar-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/calendars/calendars-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/campaigns/email-campaigns/email-campaign-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/campaigns/email-campaigns/email-campaigns-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/campaigns/email-messages/email-messages.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/campaigns/sms-campaigns/sms-campaign-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/campaigns/sms-campaigns/sms-campaigns-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/centers/center-action-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/centers/center-form.component.ts": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/centers/center-groups-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/centers/center-meeting-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/centers/center-staff-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/centers/center-view.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/centers/centers-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/charges/client-charge-form.component.test.ts": {
@@ -201,7 +261,7 @@
   },
   "src/app/features/clients/charges/client-charge-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/charges/client-charges-list.component.test.ts": {
@@ -211,7 +271,7 @@
   },
   "src/app/features/clients/charges/client-charges-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/client-action-dialog.component.test.ts": {
@@ -231,10 +291,30 @@
   },
   "src/app/features/clients/client-form.component.ts": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/clients/client-savings-account-dialog.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/clients/client-search-v2.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/clients/client-staff-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/clients/client-transfer-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/clients/client-transfer-response-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -246,12 +326,12 @@
   },
   "src/app/features/clients/client-view.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/clients-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/collateral/client-collateral-form.component.test.ts": {
@@ -261,7 +341,7 @@
   },
   "src/app/features/clients/collateral/client-collateral-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/collateral/client-collateral-list.component.test.ts": {
@@ -271,12 +351,12 @@
   },
   "src/app/features/clients/collateral/client-collateral-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/kyc/client-address-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/kyc/client-document-form.component.test.ts": {
@@ -286,17 +366,17 @@
   },
   "src/app/features/clients/kyc/client-document-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/kyc/client-family-member-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/kyc/client-identifier-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/kyc/client-note-form.component.test.ts": {
@@ -306,12 +386,12 @@
   },
   "src/app/features/clients/kyc/client-note-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/tabs/client-addresses-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/tabs/client-documents-list.component.test.ts": {
@@ -321,22 +401,22 @@
   },
   "src/app/features/clients/tabs/client-documents-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/tabs/client-family-members-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/tabs/client-identifiers-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/tabs/client-notes-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/clients/transactions/client-transactions-list.component.test.ts": {
@@ -346,25 +426,35 @@
   },
   "src/app/features/clients/transactions/client-transactions-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/collection-sheet/collection-sheet.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/dashboard/system-status.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/errors/access-denied.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/fintech/asset-owner-view/asset-owner-view.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/fintech/asset-owners-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/groups/group-action-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -376,37 +466,77 @@
   },
   "src/app/features/groups/group-form.component.ts": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/groups/group-members-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/groups/group-note-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/groups/group-role-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/groups/group-staff-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/groups/group-view.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/groups/groups-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/groups/tabs/group-accounts-tab.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/groups/tabs/group-notes-list.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/interop/interop-account-view.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/interop/interop-health.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/interop/interop-party-lookup.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/interop/interop-quotes.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/interop/interop-transfers.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/bulk-reassignment/bulk-loan-reassignment.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/bulk-reassignment/bulk-reassignment.component.test.ts": {
@@ -416,22 +546,22 @@
   },
   "src/app/features/loans/bulk-reassignment/bulk-reassignment.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/charges/loan-charge-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/charges/loan-charges-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/cob-catchup/loan-cob-catchup.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/collateral/collateral-form.component.test.ts": {
@@ -441,7 +571,7 @@
   },
   "src/app/features/loans/collateral/collateral-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/collateral/collateral-list.component.test.ts": {
@@ -451,7 +581,7 @@
   },
   "src/app/features/loans/collateral/collateral-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/guarantors/guarantor-form.component.test.ts": {
@@ -461,7 +591,7 @@
   },
   "src/app/features/loans/guarantors/guarantor-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/guarantors/guarantors-list.component.test.ts": {
@@ -471,7 +601,7 @@
   },
   "src/app/features/loans/guarantors/guarantors-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/interest-pauses/interest-pause-form.component.test.ts": {
@@ -481,7 +611,7 @@
   },
   "src/app/features/loans/interest-pauses/interest-pause-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/interest-pauses/interest-pauses-list.component.test.ts": {
@@ -491,25 +621,40 @@
   },
   "src/app/features/loans/interest-pauses/interest-pauses-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/loan-account-lock/loan-account-lock.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/loans/loan-disburse-to-savings-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/loans/loan-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/loan-schedule-modify/loan-schedule-modify.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/loan-transaction-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/loans/loan-unassign-officer-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/loans/loan-undo-approval-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -521,17 +666,17 @@
   },
   "src/app/features/loans/loan-view.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/loans-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/point-in-time/loans-point-in-time.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "unicorn/prefer-number-properties": {
       "count": 1
@@ -544,7 +689,7 @@
   },
   "src/app/features/loans/post-dated-checks/post-dated-check-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/post-dated-checks/post-dated-checks-list.component.test.ts": {
@@ -554,15 +699,20 @@
   },
   "src/app/features/loans/post-dated-checks/post-dated-checks-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/rescheduling/reschedule-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/loans/rescheduling/reschedule-requests-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/loans/tabs/loan-delinquency-tab.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -579,87 +729,97 @@
   },
   "src/app/features/meetings/meeting-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/meetings/meetings-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/notifications/notifications-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/account-number-formats/account-number-format-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/account-number-formats/account-number-formats-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/currencies/currencies.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/funds/fund-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/funds/funds-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/group-levels/group-levels-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/organization/loan-portfolio-summary/loan-portfolio-summary.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/organization/office-transactions/office-transaction-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/office-transactions/office-transactions-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/offices/office-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/organization/offices/office-view.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/organization/offices/offices-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/payment-types/payment-type-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/payment-types/payment-types-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/staff/staff-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/organization/staff/staff-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/account-action-form.component.test.ts": {
@@ -669,12 +829,27 @@
   },
   "src/app/features/products/account-action-form.component.ts": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/products/accounting/advanced-accounting-mappings.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/products/accounting/gl-account-select.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/products/accounting/product-accounting-section.component.test.ts": {
     "unicorn/no-array-sort": {
       "count": 4
+    }
+  },
+  "src/app/features/products/accounting/product-accounting-section.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/app/features/products/collateral-management/collateral-management-form.component.test.ts": {
@@ -684,12 +859,12 @@
   },
   "src/app/features/products/collateral-management/collateral-management-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/collateral-management/collateral-management-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/deposit-account-view.component.test.ts": {
@@ -698,6 +873,16 @@
     }
   },
   "src/app/features/products/deposit-account-view.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/products/deposit-closure-dialog.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/products/fixed-deposit-transactions/fixed-deposit-transaction-form.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -719,7 +904,7 @@
   },
   "src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/fixed-deposits/fixed-deposit-product-form.component.test.ts": {
@@ -729,7 +914,7 @@
   },
   "src/app/features/products/fixed-deposits/fixed-deposit-product-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/fixed-deposits/fixed-deposit-products-list.component.test.ts": {
@@ -739,7 +924,7 @@
   },
   "src/app/features/products/fixed-deposits/fixed-deposit-products-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/fixed-deposits/fixed-deposits-list.component.test.ts": {
@@ -749,7 +934,7 @@
   },
   "src/app/features/products/fixed-deposits/fixed-deposits-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/floating-rates/floating-rate-form.component.test.ts": {
@@ -759,7 +944,7 @@
   },
   "src/app/features/products/floating-rates/floating-rate-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/floating-rates/floating-rates-list.component.test.ts": {
@@ -769,7 +954,7 @@
   },
   "src/app/features/products/floating-rates/floating-rates-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/interest-rate-charts/interest-rate-chart-form.component.test.ts": {
@@ -779,17 +964,17 @@
   },
   "src/app/features/products/interest-rate-charts/interest-rate-chart-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/interest-rate-charts/interest-rate-chart-slabs.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/interest-rate-charts/interest-rate-charts-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/loan-originators/loan-originator-form.component.test.ts": {
@@ -799,12 +984,12 @@
   },
   "src/app/features/products/loan-originators/loan-originator-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/loan-originators/loan-originators-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/loan-product-form.component.test.ts": {
@@ -814,17 +999,17 @@
   },
   "src/app/features/products/loan-product-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/loan-product-view.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/loan-products-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/on-hold-transactions/on-hold-transactions-list.component.test.ts": {
@@ -839,12 +1024,12 @@
   },
   "src/app/features/products/payment-credit-allocation-editor.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/product-mix/product-mix.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/rates/rate-form.component.test.ts": {
@@ -854,7 +1039,7 @@
   },
   "src/app/features/products/rates/rate-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/rates/rates-list.component.test.ts": {
@@ -864,7 +1049,7 @@
   },
   "src/app/features/products/rates/rates-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.test.ts": {
@@ -874,32 +1059,32 @@
   },
   "src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/recurring-deposits/recurring-deposit-product-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/recurring-deposits/recurring-deposit-products-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/recurring-deposits/recurring-deposits-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/savings-account-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/savings-account-transaction-form.component.test.ts": {
@@ -909,10 +1094,20 @@
   },
   "src/app/features/products/savings-account-transaction-form.component.ts": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/products/savings-account-view.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/products/savings-accounts-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/products/savings-block-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -924,20 +1119,30 @@
   },
   "src/app/features/products/savings-charges/savings-charge-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/savings-charges/savings-charges-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/products/savings-officer-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/products/savings-product-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/savings-products-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/products/savings-undo-approval-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -949,12 +1154,12 @@
   },
   "src/app/features/products/share-dividends/share-dividend-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/share-dividends/share-dividends-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/shares/share-account-form.component.test.ts": {
@@ -964,11 +1169,16 @@
   },
   "src/app/features/products/shares/share-account-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/shares/share-account-view.component.test.ts": {
     "unicorn/no-object-as-default-parameter": {
+      "count": 1
+    }
+  },
+  "src/app/features/products/shares/share-account-view.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -979,15 +1189,20 @@
   },
   "src/app/features/products/shares/share-accounts-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/shares/share-product-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/shares/share-products-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/products/shares/share-quantity-dialog.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -999,7 +1214,7 @@
   },
   "src/app/features/products/tax-components/tax-component-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/tax-components/tax-components-list.component.test.ts": {
@@ -1009,7 +1224,7 @@
   },
   "src/app/features/products/tax-components/tax-components-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/tax-groups/tax-group-form.component.test.ts": {
@@ -1019,7 +1234,7 @@
   },
   "src/app/features/products/tax-groups/tax-group-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/products/tax-groups/tax-groups-list.component.test.ts": {
@@ -1029,12 +1244,12 @@
   },
   "src/app/features/products/tax-groups/tax-groups-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/profile/user-profile.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/reporting/report-execution.service.test.ts": {
@@ -1044,7 +1259,7 @@
   },
   "src/app/features/reporting/reports-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/reporting/run-report.component.test.ts": {
@@ -1054,17 +1269,17 @@
   },
   "src/app/features/reporting/run-report.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/search/global-search.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/security/audit-logs/audit-logs-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "unicorn/prefer-logical-operator-over-ternary": {
       "count": 1
@@ -1075,22 +1290,22 @@
   },
   "src/app/features/security/roles/role-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/security/roles/roles-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/security/users/user-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/security/users/users-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/settings/edit-configuration-dialog.component.ts": {
@@ -1100,12 +1315,12 @@
   },
   "src/app/features/settings/global-configurations.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/settings/holiday-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/settings/holidays-list.component.ts": {
@@ -1115,22 +1330,22 @@
   },
   "src/app/features/settings/two-factor-config.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/settings/working-days.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/spm/likelihood/likelihood.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/spm/poverty-line/poverty-line.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/spm/scorecards/scorecards.component.ts": {
@@ -1140,42 +1355,42 @@
   },
   "src/app/features/spm/survey-responses/survey-responses.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/spm/surveys/spm-surveys-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/spm/surveys/spm-surveys-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/adhoc-query/adhoc-query-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/adhoc-query/adhoc-query-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/bulk-import/bulk-import.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/business-dates/business-dates.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/business-steps/business-steps.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "unicorn/no-array-sort": {
       "count": 1
@@ -1183,97 +1398,97 @@
   },
   "src/app/features/system/cache/cache.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/codes/code-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/codes/code-value-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/codes/code-values-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/codes/codes-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/credit-bureau-config/credit-bureau-config.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/data-tables/datatables-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/data-tables/datatables-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/delinquency/delinquency-management.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/entity-data-table-checks/entity-data-table-checks-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/entity-data-table-checks/entity-data-table-checks-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/entity-mapping/entity-mapping-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/entity-mapping/entity-mapping-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/external-events/external-events.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/external-services/external-services.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/field-configuration/field-configuration.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/hooks/hooks-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/hooks/hooks-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/instance-mode/instance-mode.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/loan-product-details/loan-product-details.component.ts": {
@@ -1283,102 +1498,132 @@
   },
   "src/app/features/system/notifications-config/notifications-config.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/oidc-config/oidc-config.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/password-preferences/password-preferences.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/permissions/permissions.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/system/report-definitions/report-definition-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/system/report-definitions/report-definitions-list.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/system/report-mailing-jobs/report-mailing-jobs-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/report-mailing-jobs/report-mailing-jobs-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/scheduler-jobs/scheduler-job-history.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/scheduler-jobs/scheduler-jobs-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/sms/sms-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/sms/sms-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/templates/template-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/system/templates/templates-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/tasks/checker-inbox/checker-inbox.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/tasks/checker-inbox/view-payload-dialog.component.ts": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/tasks/work-queues/work-queues.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/tellers/cashiers/cashier-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/tellers/cashiers/cashier-transaction-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/features/tellers/cashiers/cashier-transactions.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/tellers/cashiers/cashiers-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/tellers/teller-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/tellers/tellers-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/transfers/account-transfer-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/transfers/account-transfers-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/transfers/standing-instruction-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/transfers/standing-instruction-history.component.ts": {
@@ -1388,72 +1633,97 @@
   },
   "src/app/features/transfers/standing-instructions-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/breach/wc-breach-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/breach/wc-breach-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/loan-products/wc-loan-product-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/loan-products/wc-loan-products-list.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/loans/wc-account-lock/wc-loan-account-lock.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/working-capital/loans/wc-breach-action-form.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/working-capital/loans/wc-cob-catchup/wc-loan-cob-catchup.component.ts": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/working-capital/loans/wc-delinquency-action-form.component.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/working-capital/loans/wc-loan-action-form.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/working-capital/loans/wc-loan-charge-form.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/working-capital/loans/wc-loan-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/loans/wc-loan-view.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/loans/wc-loans-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/features/working-capital/loans/wc-near-breach-action-form.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/features/working-capital/near-breach/wc-near-breach-form.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/features/working-capital/near-breach/wc-near-breach-list.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/layout/breadcrumb.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/layout/header.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/layout/inactivity-dialog.component.test.ts": {
@@ -1466,6 +1736,11 @@
       "count": 2
     }
   },
+  "src/app/layout/main-layout.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/layout/sidebar.component.test.ts": {
     "no-restricted-imports": {
       "count": 1
@@ -1473,12 +1748,12 @@
   },
   "src/app/layout/sidebar.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/shared/components/client-search/client-search.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/shared/components/confirm-dialog/confirm-dialog.component.ts": {
@@ -1509,7 +1784,7 @@
   },
   "src/app/shared/components/data-table/data-table.component.ts": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "unicorn/no-array-sort": {
       "count": 5
@@ -1530,12 +1805,27 @@
       "count": 1
     }
   },
+  "src/app/shared/components/entity-documents/entity-documents.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/shared/components/entity-notes/entity-notes.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/shared/components/guidance-tour/guidance-tour.component.test.ts": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/shared/components/guidance-tour/guidance-tour.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/shared/components/help-icon/help-icon.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1546,6 +1836,16 @@
     }
   },
   "src/app/shared/components/paginator/paginator.component.ts": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/shared/components/search-filter/search-filter.component.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/shared/components/stepper/stepper.component.ts": {
     "no-restricted-imports": {
       "count": 1
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,26 @@ const local = {
   rules: { 'cognitive-complexity': cognitiveComplexity },
 };
 
+const restrictedImportPatterns = [
+  {
+    group: ['@angular/material', '@angular/material/*'],
+    message:
+      'Angular Material has been removed. Use app-owned primitives in src/app/ui. @angular/cdk is still allowed.',
+  },
+  // The existing imports are a migration baseline; new vendor dependencies belong
+  // only in the UI implementation or the existing imperative adapters.
+  {
+    group: ['@ionic/angular', '@ionic/angular/*'],
+    message:
+      "Use app-owned primitives from 'app/ui'; Ionic implementations belong inside src/app/ui. Use OVERLAY for controllers. See DOCS/adr/0005-ui-boundary.md.",
+  },
+  {
+    group: ['@ngx-translate/*'],
+    message:
+      "Use the I18N adapter (or the | appTranslate pipe) from 'app/core/adapters'. See DOCS/adr/0003-adapter-boundary.md.",
+  },
+];
+
 module.exports = tseslint.config(
   {
     // Build and report output, not source. coverage/ in particular holds one .html per
@@ -166,37 +186,7 @@ module.exports = tseslint.config(
       'no-restricted-imports': [
         'error',
         {
-          patterns: [
-            {
-              group: ['@angular/material', '@angular/material/*'],
-              message:
-                'Angular Material has been removed. Use Ionic (@ionic/angular/standalone) — see STYLE.md for the component mapping. @angular/cdk is still allowed.',
-            },
-            // Adapter boundary — DOCS/adr/0003-adapter-boundary.md.
-            //
-            // `<ion-*>` components are deliberately NOT restricted: they are the UI layer
-            // (AGENTS.md) and migrate one component at a time. What is restricted is Ionic's
-            // *imperative* surface, which services reach for and which has lifecycle
-            // semantics worth testing without a component library present.
-            {
-              group: ['@ionic/angular', '@ionic/angular/*'],
-              importNames: [
-                'ModalController',
-                'ToastController',
-                'AlertController',
-                'LoadingController',
-                'ActionSheetController',
-                'PopoverController',
-              ],
-              message:
-                "Use the OVERLAY adapter from 'app/core/adapters' instead of Ionic's controllers. Ion* components are unaffected. See DOCS/adr/0003-adapter-boundary.md.",
-            },
-            {
-              group: ['@ngx-translate/*'],
-              message:
-                "Use the I18N adapter (or the | appTranslate pipe) from 'app/core/adapters'. See DOCS/adr/0003-adapter-boundary.md.",
-            },
-          ],
+          patterns: restrictedImportPatterns,
         },
       ],
       // Web Storage is a trust boundary (security.md §4) and reached through globals rather
@@ -250,6 +240,20 @@ module.exports = tseslint.config(
       'no-restricted-imports': 'off',
       'no-restricted-globals': 'off',
       'no-restricted-properties': 'off',
+    },
+  },
+  {
+    // UI implementations may name their vendor, but retain the Material and i18n boundaries.
+    files: ['src/app/ui/**/*.ts', 'src/app/testing/ionic-testing.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: restrictedImportPatterns.filter(
+            (pattern) => !pattern.group.includes('@ionic/angular'),
+          ),
+        },
+      ],
     },
   },
   {

--- a/scripts/ui-boundary.test.mjs
+++ b/scripts/ui-boundary.test.mjs
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ESLint } from 'eslint';
+
+const eslint = new ESLint();
+async function importErrors(filePath, module, symbol) {
+  const [result] = await eslint.lintText(
+    `import { ${symbol} } from '${module}'; export const imported = ${symbol};`,
+    { filePath },
+  );
+  return result.messages.filter((message) => message.ruleId === 'no-restricted-imports');
+}
+
+test('new feature Ionic imports are rejected without suppression', async () => {
+  assert.equal(
+    (await importErrors('src/app/features/probe.ts', '@ionic/angular/standalone', 'IonButton'))
+      .length,
+    1,
+  );
+});
+test('UI implementations may use Ionic but cannot bypass other adapter boundaries', async () => {
+  assert.equal(
+    (await importErrors('src/app/ui/probe.ts', '@ionic/angular/standalone', 'IonButton')).length,
+    0,
+  );
+  assert.equal(
+    (await importErrors('src/app/ui/probe.ts', '@angular/material/button', 'MatButton')).length,
+    1,
+  );
+  assert.equal(
+    (await importErrors('src/app/ui/probe.ts', '@ngx-translate/core', 'TranslateService')).length,
+    1,
+  );
+});
+test('the existing composition roots and imperative adapter remain allowed', async () => {
+  for (const file of [
+    'src/app/app.config.ts',
+    'src/app/testing/ionic-testing.ts',
+    'src/app/core/adapters/overlay/ionic-overlay.adapter.ts',
+  ]) {
+    assert.equal((await importErrors(file, '@ionic/angular/standalone', 'IonButton')).length, 0);
+  }
+});

--- a/src/app/shared/components/entity-datatables/entity-datatables.component.test.ts
+++ b/src/app/shared/components/entity-datatables/entity-datatables.component.test.ts
@@ -171,9 +171,13 @@ describe('EntityDatatablesComponent', () => {
     fixture.detectChanges();
 
     // Trigger tab change to second tab
-    component.onTabChange(
-      new CustomEvent('ionChange', { detail: { value: 'm_client_more_details' } }),
-    );
+    const secondTab = fixture.nativeElement.querySelectorAll('[role=tab]')[1] as HTMLButtonElement;
+    secondTab.click();
+    fixture.detectChanges();
+    expect(secondTab.getAttribute('aria-selected')).toBe('true');
+    const panel = fixture.nativeElement.querySelector('[role=tabpanel]') as HTMLElement;
+    expect(panel.getAttribute('aria-labelledby')).toBe(secondTab.id);
+    expect(secondTab.getAttribute('aria-controls')).toBe(panel.id);
 
     expect(component.activeTable()).toEqual(mockDatatables[1]);
     expect(datatablesServiceSpy.getDatatablesDatatableApptableId).toHaveBeenCalledWith(

--- a/src/app/shared/components/entity-datatables/entity-datatables.component.ts
+++ b/src/app/shared/components/entity-datatables/entity-datatables.component.ts
@@ -17,16 +17,10 @@
  * under the License.
  */
 
-import { inject, input, signal, Component, OnInit } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
-import {
-  IonButton,
-  IonIcon,
-  IonSegment,
-  IonSegmentButton,
-  IonLabel,
-  IonSpinner,
-} from '@ionic/angular/standalone';
+import { computed, inject, input, signal, Component, OnInit } from '@angular/core';
+import { TranslatePipe } from '../../../core/adapters';
+import { TabsComponent, UiTab } from '../../../ui/tabs/tabs.component';
+import { IonButton, IonIcon, IonSpinner } from '@ionic/angular/standalone';
 import { DataTablesService, GetDataTablesResponse } from '../../../api';
 import { DialogService } from '../../../core/services/dialog.service';
 import { DataTableComponent, ColumnDef } from '../data-table/data-table.component';
@@ -37,16 +31,7 @@ const AUDIT_COLUMN_NAMES = new Set(['id', 'created_at', 'updated_at']);
 @Component({
   selector: 'app-entity-datatables',
   standalone: true,
-  imports: [
-    TranslateModule,
-    IonSegment,
-    IonSegmentButton,
-    IonLabel,
-    IonButton,
-    IonIcon,
-    IonSpinner,
-    DataTableComponent,
-  ],
+  imports: [TranslatePipe, TabsComponent, IonButton, IonIcon, IonSpinner, DataTableComponent],
   template: `
     <div class="entity-datatables-container">
       @if (isLoading()) {
@@ -56,21 +41,24 @@ const AUDIT_COLUMN_NAMES = new Set(['id', 'created_at', 'updated_at']);
       }
 
       @if (datatables().length > 0) {
-        <ion-segment
-          scrollable
+        <app-tabs
+          #tabs
           data-testid="entity-datatables-tabs"
+          [tabs]="tableTabs()"
+          [label]="'SYSTEM.DATA_TABLES' | appTranslate"
+          [idPrefix]="'entity-datatables-' + apptableName() + '-' + entityId()"
           [value]="activeTable()?.registeredTableName"
-          (ionChange)="onTabChange($event)"
-        >
-          @for (dt of datatables(); track dt.registeredTableName) {
-            <ion-segment-button [value]="dt.registeredTableName!">
-              <ion-label>{{ dt.registeredTableName }}</ion-label>
-            </ion-segment-button>
-          }
-        </ion-segment>
+          (valueChange)="onTabChange($event)"
+        />
 
         @if (activeTable(); as dt) {
-          <div class="tab-content">
+          <div
+            class="tab-content"
+            role="tabpanel"
+            tabindex="0"
+            [id]="tabs.panelId()"
+            [attr.aria-labelledby]="tabs.tabId(dt.registeredTableName!)"
+          >
             <app-data-table
               [columns]="getColumnDefs(dt)"
               [data]="tableData()"
@@ -84,13 +72,13 @@ const AUDIT_COLUMN_NAMES = new Set(['id', 'created_at', 'updated_at']);
                 (click)="onAddEntry(dt)"
               >
                 <ion-icon name="add-outline" slot="start"></ion-icon>
-                {{ 'SYSTEM.ADD_ENTRY' | translate }}
+                {{ 'SYSTEM.ADD_ENTRY' | appTranslate }}
               </ion-button>
             </app-data-table>
           </div>
         }
       } @else if (!isLoading()) {
-        <p class="no-data">{{ 'SYSTEM.NO_DATA_TABLES_REGISTERED' | translate }}</p>
+        <p class="no-data">{{ 'SYSTEM.NO_DATA_TABLES_REGISTERED' | appTranslate }}</p>
       }
     </div>
   `,
@@ -124,6 +112,11 @@ export class EntityDatatablesComponent implements OnInit {
   private readonly dialogService = inject(DialogService);
 
   readonly datatables = signal<GetDataTablesResponse[]>([]);
+  readonly tableTabs = computed<UiTab[]>(() =>
+    this.datatables()
+      .filter((table) => !!table.registeredTableName)
+      .map((table) => ({ value: table.registeredTableName!, label: table.registeredTableName! })),
+  );
   readonly isLoading = signal<boolean>(false);
 
   readonly tableData = signal<Record<string, unknown>[]>([]);
@@ -202,12 +195,10 @@ export class EntityDatatablesComponent implements OnInit {
       }));
   }
 
-  onTabChange(event: Event): void {
-    const detail = (event as CustomEvent<{ value?: string }>).detail;
-    const tableName = detail?.value ?? (event.target as HTMLInputElement)?.value;
-    if (!tableName) return;
-
-    this.activeTable.set(this.datatables().find((d) => d.registeredTableName === tableName));
+  onTabChange(tableName: string): void {
+    const table = this.datatables().find((dt) => dt.registeredTableName === tableName);
+    if (!table || table === this.activeTable()) return;
+    this.activeTable.set(table);
     this.loadTableData(tableName);
   }
 

--- a/src/app/ui/tabs/tabs.component.test.ts
+++ b/src/app/ui/tabs/tabs.component.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { Mock } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TabsComponent } from './tabs.component';
+
+describe('TabsComponent public contract', () => {
+  let fixture: ComponentFixture<TabsComponent>;
+  let changed: Mock<(value: string) => void>;
+  const tabs = [
+    { value: 'accounts', label: 'Accounts' },
+    { value: 'disabled', label: 'Unavailable', disabled: true },
+    { value: 'notes', label: 'Notes' },
+  ];
+  const buttons = (): HTMLButtonElement[] =>
+    Array.from(fixture.nativeElement.querySelectorAll('[role=tab]'));
+  function key(button: HTMLButtonElement, value: string, keyCode: number) {
+    button.dispatchEvent(
+      new KeyboardEvent('keydown', { key: value, keyCode, bubbles: true, cancelable: true }),
+    );
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [TabsComponent] }).compileComponents();
+    fixture = TestBed.createComponent(TabsComponent);
+    fixture.componentRef.setInput('tabs', tabs);
+    fixture.componentRef.setInput('value', 'accounts');
+    fixture.componentRef.setInput('label', 'Client records');
+    fixture.componentRef.setInput('idPrefix', 'client-7');
+    changed = vi.fn<(value: string) => void>();
+    fixture.componentInstance.valueChange.subscribe(changed);
+    fixture.detectChanges();
+  });
+
+  it('exposes a labelled tablist, stable panel links and exactly one tab stop without Ionic', () => {
+    const list = fixture.nativeElement.querySelector('[role=tablist]') as HTMLElement;
+    expect(list.getAttribute('aria-label')).toBe('Client records');
+    expect(buttons().map((tab) => tab.tabIndex)).toEqual([0, -1, -1]);
+    expect(buttons()[0].getAttribute('aria-selected')).toBe('true');
+    expect(buttons()[0].getAttribute('aria-controls')).toBe('client-7-panel');
+    expect(buttons()[0].id).toBe('client-7-tab-accounts');
+    expect(fixture.nativeElement.querySelector('ion-segment')).toBeNull();
+  });
+
+  it('moves focus with arrows, skips disabled tabs and wraps without changing selection', () => {
+    buttons()[0].focus();
+    key(buttons()[0], 'ArrowRight', 39);
+    expect(document.activeElement).toBe(buttons()[2]);
+    expect(buttons().map((tab) => tab.tabIndex)).toEqual([-1, -1, 0]);
+    expect(changed).not.toHaveBeenCalled();
+    expect(buttons()[0].getAttribute('aria-selected')).toBe('true');
+    key(buttons()[2], 'ArrowRight', 39);
+    expect(document.activeElement).toBe(buttons()[0]);
+  });
+
+  it('supports Home and End while allowing Tab to leave the strip', () => {
+    buttons()[0].focus();
+    key(buttons()[0], 'End', 35);
+    expect(document.activeElement).toBe(buttons()[2]);
+    key(buttons()[2], 'Home', 36);
+    expect(document.activeElement).toBe(buttons()[0]);
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      keyCode: 9,
+      bubbles: true,
+      cancelable: true,
+    });
+    buttons()[0].dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('leaves vertical arrows available for page scrolling in a horizontal tablist', () => {
+    buttons()[0].focus();
+    for (const [key, keyCode] of [
+      ['ArrowUp', 38],
+      ['ArrowDown', 40],
+    ] as const) {
+      const event = new KeyboardEvent('keydown', { key, keyCode, bubbles: true, cancelable: true });
+      buttons()[0].dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(false);
+      expect(document.activeElement).toBe(buttons()[0]);
+    }
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it('honours RTL horizontal navigation inherited from the host', () => {
+    fixture.nativeElement.style.direction = 'rtl';
+    buttons()[0].focus();
+    key(buttons()[0], 'ArrowLeft', 37);
+    expect(document.activeElement).toBe(buttons()[2]);
+  });
+
+  it('emits only an enabled new value and waits for the caller to select it', () => {
+    buttons()[0].click();
+    buttons()[1].click();
+    expect(changed).not.toHaveBeenCalled();
+    buttons()[2].click();
+    expect(changed).toHaveBeenCalledExactlyOnceWith('notes');
+    expect(buttons()[0].getAttribute('aria-selected')).toBe('true');
+    fixture.componentRef.setInput('value', 'notes');
+    fixture.detectChanges();
+    expect(buttons()[2].getAttribute('aria-selected')).toBe('true');
+    expect(buttons()[2].tabIndex).toBe(0);
+  });
+
+  it('updates the keyboard inventory when tabs are removed or disabled', () => {
+    fixture.componentRef.setInput('tabs', [{ value: 'new', label: 'New' }, tabs[2]]);
+    fixture.componentRef.setInput('value', 'notes');
+    fixture.detectChanges();
+    buttons()[1].focus();
+    key(buttons()[1], 'ArrowRight', 39);
+    expect(document.activeElement).toBe(buttons()[0]);
+    fixture.componentRef.setInput('tabs', [{ value: 'new', label: 'New', disabled: true }]);
+    fixture.detectChanges();
+    expect(buttons()[0].tabIndex).toBe(-1);
+    expect(buttons()[0].disabled).toBe(true);
+  });
+});

--- a/src/app/ui/tabs/tabs.component.ts
+++ b/src/app/ui/tabs/tabs.component.ts
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FocusKeyManager } from '@angular/cdk/a11y';
+import {
+  Component,
+  ElementRef,
+  inject,
+  input,
+  linkedSignal,
+  output,
+  viewChildren,
+} from '@angular/core';
+
+/** Values are application identifiers; labels are already translated by the caller. */
+export interface UiTab {
+  readonly value: string;
+  readonly label: string;
+  readonly disabled?: boolean;
+}
+
+/** Manual-activation tabs: moving focus never fetches or replaces panel contents. */
+@Component({
+  selector: 'app-tabs',
+  standalone: true,
+  template: `
+    <div role="tablist" [attr.aria-label]="label()" data-testid="ui-tabs">
+      @for (tab of tabs(); track tab.value; let index = $index) {
+        <button
+          #tabButton
+          type="button"
+          role="tab"
+          data-testid="ui-tab"
+          [id]="tabId(tab.value)"
+          [attr.aria-controls]="panelId()"
+          [attr.aria-selected]="tab.value === value()"
+          [attr.tabindex]="index === focusIndex() ? 0 : -1"
+          [disabled]="tab.disabled"
+          (focus)="focusIndex.set(index)"
+          (keydown)="onKeydown($event)"
+          (click)="select(tab)"
+        >
+          {{ tab.label }}
+        </button>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+        min-width: 0;
+      }
+      [role='tablist'] {
+        display: flex;
+        overflow-x: auto;
+        border-bottom: 1px solid var(--border-color);
+      }
+      button {
+        flex: 0 0 auto;
+        min-height: 44px;
+        padding: var(--space-3) var(--space-4);
+        border: 0;
+        border-bottom: 2px solid transparent;
+        background: transparent;
+        color: var(--text-secondary);
+        font: inherit;
+        cursor: pointer;
+      }
+      button[aria-selected='true'] {
+        color: var(--primary-color);
+        border-bottom-color: var(--primary-color);
+      }
+      button:hover {
+        background: var(--hover-bg);
+      }
+      button:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: -2px;
+      }
+      button:disabled {
+        color: var(--text-muted);
+        cursor: default;
+      }
+    `,
+  ],
+})
+export class TabsComponent {
+  readonly tabs = input.required<readonly UiTab[]>();
+  readonly value = input<string>();
+  readonly label = input.required<string>();
+  /** Stable, page-unique identifier; the same prefix binds the tablist and its shared panel. */
+  readonly idPrefix = input.required<string>();
+  readonly valueChange = output<string>();
+
+  private readonly element = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly buttons = viewChildren<ElementRef<HTMLButtonElement>>('tabButton');
+  protected readonly focusIndex = linkedSignal(() => {
+    const selected = this.tabs().findIndex((tab) => tab.value === this.value() && !tab.disabled);
+    return selected !== -1 ? selected : this.tabs().findIndex((tab) => !tab.disabled);
+  });
+
+  tabId(value: string): string {
+    return `${this.idPrefix()}-tab-${encodeURIComponent(value)}`;
+  }
+  panelId(): string {
+    return `${this.idPrefix()}-panel`;
+  }
+
+  protected select(tab: UiTab): void {
+    if (!tab.disabled && tab.value !== this.value()) this.valueChange.emit(tab.value);
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    // Rebuild from the current view so removed/reordered/disabled tabs cannot leave stale
+    // focus-manager entries. CDK owns wrapping, Home/End and horizontal RTL semantics.
+    const items = this.buttons().map(({ nativeElement: button }) => ({
+      disabled: button.disabled,
+      focus: () => button.focus(),
+    }));
+    const direction =
+      getComputedStyle(this.element.nativeElement).direction === 'rtl' ? 'rtl' : 'ltr';
+    const manager = new FocusKeyManager(items)
+      .withWrap()
+      .withVerticalOrientation(false)
+      .withHomeAndEnd()
+      .withHorizontalOrientation(direction);
+    manager.updateActiveItem(this.focusIndex());
+    manager.onKeydown(event);
+    manager.destroy();
+  }
+}


### PR DESCRIPTION
## What and why

Shared custom-field tabs now use an app-owned component and test contract. Arrow keys move focus without fetching a table; Enter/Space activates the selected table. Native buttons and CDK handle keyboard navigation, disabled items and RTL, while the feature receives a table-name string and owns loading the panel.

This also establishes the first migration increment from #530: ADR 0005 specifies the complete component/CVA value, keyboard/ARIA, browser-helper, theming and rollout contracts; the Ionic import ratchet records existing use while rejecting new unsuppressed dependencies outside UI implementations. Existing Material/i18n restrictions and other-rule allowances are preserved. AGENTS.md and STYLE.md direct new feature/shared code through app/ui.

Refs #530. Remaining tab strips, popup controls, form CVAs, cosmetic primitives, deployment-token expansion and legacy browser helpers remain under the overall migration issue. This PR delivers the boundary and one independently verifiable behavioural primitive; it does not close that issue.

## Verification

- Final head: `e992e9b88315455bcd310dc6941946e3804f7e49`.
- Local: 17 rendered Angular unit/integration tests and 3 ESLint boundary tests passed. App/E2E TypeScript checks, changed-source ESLint, formatting and git diff checks passed. Other lint-rule allowances were compared with the base and preserved.
- Full fork [CI](https://github.com/FenjuFu/fineract-backoffice-ui/actions/runs/34444465337) passed on this head, including full unit suites, full lint/suppression pruning, production/container builds, API drift, translations, security, GA and license/RAT checks.
- Full fork [E2E](https://github.com/FenjuFu/fineract-backoffice-ui/actions/runs/34444461409) passed on the same head: all mocked and real-Fineract shards, mobile and two-factor authentication. The new custom-field cases exercise the app-owned keyboard/panel contract at 1280px and 390px; they use mocked group data and attach screenshots after loading completes.
- All three PR commits have matching FenjuFu noreply sign-offs and valid GitHub signatures. No generated API files were hand-edited. The upstream [signed-commit check](https://github.com/apache/fineract-backoffice-ui/actions/runs/34445927919) passed.
- Upstream [CI](https://github.com/apache/fineract-backoffice-ui/actions/runs/34445928021), [E2E](https://github.com/apache/fineract-backoffice-ui/actions/runs/34445928047) and [CodeQL](https://github.com/apache/fineract-backoffice-ui/actions/runs/34445928007) still require maintainer approval. The fork results above are independent evidence.

## Screenshots

Unmodified image attachments from the passing new CI browser cases, showing the custom-field region after the panel finishes loading. Screenshots are stored on a separate review branch.

<details>
<summary>Desktop, 1280px viewport</summary>

![App-owned custom-field tabs on desktop](https://raw.githubusercontent.com/FenjuFu/fineract-backoffice-ui/5563f4dbcebabaefa90121ed8c85bbda05ef6e93/review-artifacts/ui-tabs-desktop.png)

</details>

<details>
<summary>Narrow, 390px viewport</summary>

![App-owned custom-field tabs on a narrow viewport](https://raw.githubusercontent.com/FenjuFu/fineract-backoffice-ui/5563f4dbcebabaefa90121ed8c85bbda05ef6e93/review-artifacts/ui-tabs-mobile.png)

</details>

## AI assistance (optional)

- Tool: Codex.
- Harness / workflow: assisted implementation and review, targeted local checks, and full fork GitHub Actions validation.

## Checklist

- [x] I did not hand-edit generated files under src/app/api/.
- [x] Feature translation uses the core adapter; DOM/focus behaviour is confined to the app/ui primitive.
- [x] User-facing static strings use translation keys; registered table names remain user data.
- [x] Added rendered unit, import-boundary and browser contract tests.
- [x] UI changes have browser coverage; full mocked and real-backend suites passed.
- [x] Commits are signed and contain matching sign-offs.
- [x] Followed the [AI-assisted contributions guidance](https://github.com/apache/fineract-backoffice-ui/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
