### PR TITLE
fix(clients): keep date picker IDs unique

### DIFF
--- a/src/app/features/clients/client-form.component.test.ts
+++ b/src/app/features/clients/client-form.component.test.ts
@@ -146,6 +146,34 @@ describe('ClientFormComponent', () => {
       expect(routerSpy.navigate).toHaveBeenCalledWith(['/clients']);
     });
 
+    it('uses unique date picker IDs across client form instances', () => {
+      const secondFixture = TestBed.createComponent(ClientFormComponent);
+
+      const datetimeReferences = (element: HTMLElement) =>
+        Array.from(element.querySelectorAll('ion-datetime-button')).map(
+          (button) => (button as HTMLIonDatetimeButtonElement).datetime,
+        );
+      const datetimeIds = (element: HTMLElement) =>
+        Array.from(element.querySelectorAll('ion-datetime')).map((picker) => picker.id);
+      const firstPickerIds = [
+        component.submittedOnDatePickerId,
+        component.activationDatePickerId,
+        component.dateOfBirthPickerId,
+      ];
+      const secondComponent = secondFixture.componentInstance;
+      const secondPickerIds = [
+        secondComponent.submittedOnDatePickerId,
+        secondComponent.activationDatePickerId,
+        secondComponent.dateOfBirthPickerId,
+      ];
+
+      expect(datetimeReferences(fixture.nativeElement)).toEqual(firstPickerIds);
+      expect(datetimeIds(fixture.nativeElement)).toEqual(firstPickerIds);
+      expect(new Set([...firstPickerIds, ...secondPickerIds]).size).toBe(6);
+
+      secondFixture.destroy();
+    });
+
     it('shows the wizard stepper and only the first step initially', () => {
       expect(component.showWizard()).toBe(true);
       expect(component.currentStep()).toBe(0);

--- a/src/app/features/clients/client-form.component.ts
+++ b/src/app/features/clients/client-form.component.ts
@@ -60,6 +60,8 @@ import {
   toIsoDate,
 } from '../../core/utils/date-formatter';
 
+let nextClientFormId = 0;
+
 @Component({
   selector: 'app-client-form',
   standalone: true,
@@ -187,11 +189,11 @@ import {
               <!-- Submitted On Date -->
               <ion-item fill="outline" [appTooltip]="'HELP.SUBMITTED_ON_DESC' | translate">
                 <ion-label position="stacked">{{ 'COMMON.SUBMITTED_ON' | translate }}</ion-label>
-                <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                <ion-datetime-button [datetime]="submittedOnDatePickerId"></ion-datetime-button>
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
-                      id="submittedOnDate-picker"
+                      [id]="submittedOnDatePickerId"
                       data-testid="submittedOnDate-picker"
                       presentation="date"
                       name="submittedOnDate"
@@ -207,11 +209,11 @@ import {
               <!-- Activation Date -->
               <ion-item fill="outline" [appTooltip]="'HELP.ACTIVATION_DATE_DESC' | translate">
                 <ion-label position="stacked">{{ 'COMMON.ACTIVATION_DATE' | translate }}</ion-label>
-                <ion-datetime-button datetime="activationDate-picker"></ion-datetime-button>
+                <ion-datetime-button [datetime]="activationDatePickerId"></ion-datetime-button>
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
-                      id="activationDate-picker"
+                      [id]="activationDatePickerId"
                       data-testid="activationDate-picker"
                       presentation="date"
                       name="activationDate"
@@ -276,11 +278,11 @@ import {
                   <ion-label position="stacked">{{
                     'CLIENTS.DATE_OF_BIRTH' | translate
                   }}</ion-label>
-                  <ion-datetime-button datetime="dateOfBirth-picker"></ion-datetime-button>
+                  <ion-datetime-button [datetime]="dateOfBirthPickerId"></ion-datetime-button>
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
-                        id="dateOfBirth-picker"
+                        [id]="dateOfBirthPickerId"
                         data-testid="dateOfBirth-picker"
                         presentation="date"
                         name="dateOfBirth"
@@ -436,6 +438,11 @@ export class ClientFormComponent implements OnInit {
   private readonly LIST_PATH = '/clients';
   private readonly DATE_FORMAT = 'yyyy-MM-dd';
   private readonly LOCALE_EN = 'en';
+  private readonly datePickerIdSuffix = ++nextClientFormId;
+
+  readonly submittedOnDatePickerId = `submittedOnDate-picker-${this.datePickerIdSuffix}`;
+  readonly activationDatePickerId = `activationDate-picker-${this.datePickerIdSuffix}`;
+  readonly dateOfBirthPickerId = `dateOfBirth-picker-${this.datePickerIdSuffix}`;
 
   clientId: number | null = null;
   readonly isEditMode = signal(false);


### PR DESCRIPTION
## What changed

- assign each client-form instance a stable unique suffix for its submitted, activation, and date-of-birth picker IDs
- bind every `ion-datetime-button` to the matching generated `ion-datetime` ID while preserving the existing test IDs
- add a regression test that creates two client-form instances and verifies all six picker IDs are distinct and the rendered button/picker pairs match

## Why

Ionic navigation can keep the previous client form alive, and these modals deliberately use `keepContentsMounted`. Reopening the create form therefore left duplicate fixed IDs in the document. `ion-datetime-button` could then resolve the wrong or missing picker, producing the reported `No ion-datetime instance found` error. This change removes that collision without changing date values or submission behavior.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run i18n:check`
- `npm run check:icons`
- `npm run check:a11y-names`
- `npm run api:surface`
- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --watch=false` — 241 files, 1465 tests passed
- `npm run build`
- `bash scripts/check-license.sh`

Fixes #541

## AI assistance

Codex assisted with root-cause analysis, implementation, tests, and validation. I reviewed the final diff and verified the behavior locally.