### PR TITLE
refactor(working-capital): use array date formatter

### DIFF
--- a/src/app/features/working-capital/loan-products/wc-loan-product-form.component.test.ts
+++ b/src/app/features/working-capital/loan-products/wc-loan-product-form.component.test.ts
@@ -74,6 +74,19 @@ describe('WcLoanProductFormComponent', () => {
     expect(component.repaymentFrequencyTypeOptions()).toHaveLength(1);
   });
 
+  it('should format an array close date when loading a product', () => {
+    serviceSpy.getWorkingCapitalLoanProductsProductId.mockReturnValue(
+      of({ closeDate: [2026, 1, 5] }) as unknown as ReturnType<
+        WorkingCapitalLoanProductsService['getWorkingCapitalLoanProductsProductId']
+      >,
+    );
+    component.productId = 42;
+
+    component.load();
+
+    expect(component.closeDate()).toBe('2026-01-05');
+  });
+
   it('should post on create and navigate to the list', () => {
     serviceSpy.postWorkingCapitalLoanProducts.mockReturnValue(
       of({}) as unknown as ReturnType<

--- a/src/app/features/working-capital/loan-products/wc-loan-product-form.component.ts
+++ b/src/app/features/working-capital/loan-products/wc-loan-product-form.component.ts
@@ -54,6 +54,7 @@ import {
 import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
+  formatArrayDate,
   formatDateToFineract,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
@@ -677,9 +678,7 @@ export class WcLoanProductFormComponent implements OnInit {
       if (data.closeDate) {
         const cd = data.closeDate as unknown as number[];
         this.closeDate.set(
-          Array.isArray(cd)
-            ? toIsoDate(new Date(cd[0], cd[1] - 1, cd[2]))
-            : toIsoDate(new Date(data.closeDate)),
+          Array.isArray(cd) ? formatArrayDate(cd) : toIsoDate(new Date(data.closeDate)),
         );
       }
     });


### PR DESCRIPTION
## What and why

This completes the remaining working-capital slice of #257. The edit form now uses the shared `formatArrayDate` helper for Fineract array dates instead of rebuilding a local `Date`, while retaining the existing non-array fallback.

Part of #257 (working-capital slice).

## Verification

- `npm test -- --watch=false` on Node 24.21.0: 241 files and 1,465 tests passed
- `npm run lint`
- `npm run format:check`
- `npm run build` on Node 24.21.0
- `git diff --check`

The UI was not manually exercised because this is a behavior-preserving date-formatting refactor with focused unit coverage.

## Screenshots

Not applicable; there is no visual change.

## AI assistance (optional)

- Tool / model: OpenAI Codex
- Harness / workflow: Codex desktop agent for repository inspection, implementation, and local validation; I reviewed the final diff and remain responsible for the contribution.

## Checklist

- [x] I did not hand-edit generated files under `src/app/api/`.
- [x] Adapter-boundary changes are not applicable; no new component, service, browser global, or third-party API was introduced.
- [x] User-facing strings are not applicable; no text changed.
- [x] I added focused coverage for loading an array close date.
- [x] E2E coverage is not applicable; no UI workflow or behavior changed.
- [x] The commit is signed and GitHub reports a valid SSH signature.
- [x] I followed the AI-assisted contributions guidance.