### PR TITLE
fix(clients): keep create-form date pickers usable on revisit

### DIFF
--- a/e2e/client-date-picker-revisit.spec.ts
+++ b/e2e/client-date-picker-revisit.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+const HEAD_OFFICE = 'Head Office';
+
+/**
+ * Regression cover for #541. `ion-datetime-button` resolves its `ion-datetime` once, at load, and
+ * never retries, so a revisit to the create form used to leave every date control blank and dead.
+ * The failure only appears on the *second* visit — the first one is masked by the lazy Ionic chunk
+ * load — which is why this walks a full create before checking.
+ */
+test.describe('Client form date pickers', () => {
+  let createdClients: Record<string, unknown>[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    createdClients = [];
+
+    await page.route('**/config.json*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ fineractApiUrl: '/api/v1', defaultTenant: 'default' }),
+      }),
+    );
+
+    await page.route('**/api/v1/authentication**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          username: 'mifos',
+          userId: 1,
+          base64EncodedAuthenticationKey: 'YmFzZTY0',
+          authenticated: true,
+          officeId: 1,
+          officeName: HEAD_OFFICE,
+          roles: [{ id: 1, name: 'Super User', description: 'Super user' }],
+          permissions: ['ALL_FUNCTIONS'],
+        }),
+      }),
+    );
+
+    await page.route('**/api/v1/offices**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 1,
+            name: HEAD_OFFICE,
+            nameDecorated: HEAD_OFFICE,
+            externalId: '1',
+            openingDate: [2009, 1, 1],
+            hierarchy: '.',
+          },
+        ]),
+      }),
+    );
+
+    await page.route('**/api/v1/clients', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      const body = JSON.parse(route.request().postData() || '{}');
+      const created = {
+        id: Date.now(),
+        accountNo: '000000001',
+        displayName: `${body.firstname} ${body.lastname}`,
+        firstname: body.firstname,
+        lastname: body.lastname,
+        status: { value: 'Active' },
+        officeName: HEAD_OFFICE,
+      };
+      createdClients.push(created);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clientId: created.id, resourceId: created.id }),
+      });
+    });
+
+    await page.route('**/api/v1/clients?**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          totalFilteredRecords: createdClients.length,
+          pageItems: createdClients,
+        }),
+      }),
+    );
+
+    await page.goto('/login');
+    if (!page.url().includes('/dashboard')) {
+      await page.locator('#tenantId').fill('default');
+      await page.locator('#username').fill('mifos');
+      await page.locator('#password').fill('password');
+      await page.getByRole('button', { name: 'Sign In' }).click();
+      await expect(page).toHaveURL('/dashboard');
+    }
+  });
+
+  test('stay usable on a second visit to the create form', async ({ page }) => {
+    const ionicErrors: string[] = [];
+    page.on('console', (message) => {
+      const text = message.text();
+      if (text.includes('[ion-datetime-button]')) ionicErrors.push(text);
+    });
+
+    // Ionic renders the button's date into its shadow root, so the host's textContent is always
+    // empty and cannot tell a bound control from a dead one.
+    const renderedDates = () =>
+      page.evaluate(() =>
+        Array.from(document.querySelectorAll('ion-datetime-button')).map((button) =>
+          (button.shadowRoot?.textContent ?? '').trim(),
+        ),
+      );
+
+    const openCreateForm = async (legalForm: 'Person' | 'Entity') => {
+      await page.getByRole('button', { name: 'Create Client', exact: true }).click();
+      await expect(page).toHaveURL('/clients/create');
+      await page.locator('ion-select[name="legalFormId"]').click();
+      await page.locator('ion-alert, ion-popover').getByRole('radio', { name: legalForm }).click();
+      await page.locator('ion-select[name="officeId"]').click();
+      await page.locator('ion-alert, ion-popover').getByRole('radio').first().click();
+      await page.getByRole('button', { name: 'Next' }).click();
+    };
+
+    await page.getByRole('link', { name: 'Clients' }).click();
+    await expect(page).toHaveURL('/clients');
+
+    // First client, created in full so the second visit starts from a torn-down form.
+    await openCreateForm('Person');
+    await page.locator('input[name="firstname"]').fill(`DatePicker${Date.now()}`);
+    await page.locator('input[name="lastname"]').fill('E2E');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page).toHaveURL('/clients');
+
+    // Second visit, with a different legal form, as reported.
+    await openCreateForm('Entity');
+
+    await expect
+      .poll(async () => (await renderedDates()).filter((date) => date === '').length)
+      .toBe(0);
+    expect(ionicErrors).toEqual([]);
+  });
+});

--- a/src/app/features/clients/client-form.component.ts
+++ b/src/app/features/clients/client-form.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, afterNextRender, computed, inject, signal } from '@angular/core';
 
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -187,7 +187,9 @@ import {
               <!-- Submitted On Date -->
               <ion-item fill="outline" [appTooltip]="'HELP.SUBMITTED_ON_DESC' | translate">
                 <ion-label position="stacked">{{ 'COMMON.SUBMITTED_ON' | translate }}</ion-label>
-                <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -207,7 +209,9 @@ import {
               <!-- Activation Date -->
               <ion-item fill="outline" [appTooltip]="'HELP.ACTIVATION_DATE_DESC' | translate">
                 <ion-label position="stacked">{{ 'COMMON.ACTIVATION_DATE' | translate }}</ion-label>
-                <ion-datetime-button datetime="activationDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="activationDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -276,7 +280,9 @@ import {
                   <ion-label position="stacked">{{
                     'CLIENTS.DATE_OF_BIRTH' | translate
                   }}</ion-label>
-                  <ion-datetime-button datetime="dateOfBirth-picker"></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="dateOfBirth-picker"></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -465,6 +471,21 @@ export class ClientFormComponent implements OnInit {
   readonly activationDate = signal(toIsoDate(new Date()));
   readonly dateOfBirth = signal<string | null>(null);
   readonly offices = signal<GetOfficesResponse[]>([]);
+
+  /**
+   * `ion-datetime-button` resolves its target `ion-datetime` exactly once, in `componentWillLoad`,
+   * through a global `getElementById`, and gives up for good when that lookup misses. The pickers
+   * it points at live inside `ion-modal[keepContentsMounted]`, whose contents Angular mounts later
+   * in the change-detection pass. On a first visit the button's lazy Ionic chunk is still loading,
+   * which delays it past that point; on a revisit the chunk is cached, the button initializes
+   * first, finds nothing, and renders a blank control that never opens (#541). Holding the buttons
+   * back one render puts the pickers in the DOM before the buttons look for them.
+   */
+  readonly pickersReady = signal(false);
+
+  constructor() {
+    afterNextRender(() => this.pickersReady.set(true));
+  }
 
   ngOnInit() {
     this.loadOffices();


### PR DESCRIPTION
## What changed

- hold the client form's three `ion-datetime-button` elements back one render, behind an `@if (pickersReady())` fed by `afterNextRender`
- add an e2e spec that walks a full client create and then reopens the form, asserting every date button still renders a date

Picker IDs are unchanged.

## Why

`ion-datetime-button` resolves its target `ion-datetime` exactly once, in `componentWillLoad`, through a global `getElementById`, and gives up for good when that lookup misses. The pickers it points at live inside `ion-modal[keepContentsMounted]`, whose contents Angular mounts later in the change-detection pass.

On a first visit the button's lazy Ionic chunk is still loading, which delays it past that point. On a revisit the chunk is cached, so the button initializes first, finds nothing, and renders a blank control that never opens — no way to enter submitted-on, activation or date-of-birth. Deferring the buttons one render puts the pickers in the DOM before the buttons look for them.

Worth recording, since it is the natural first guess: this is not an ID collision. When the second form fails, the document holds exactly one `app-client-form` and one of each picker — the previous form is fully destroyed before the new one mounts. Making the IDs unique per instance does not fix it; the button then bails on its *first* guard instead (`An ID associated with an ion-datetime instance is required to function properly`), because a `[datetime]` property binding is not yet applied at `componentWillLoad`. The control stays blank either way. More detail in #544.

## Testing

Reproduced and verified in a real browser, both directions:

- with the fix, the reopened form renders `Sep 12, 2026` on every button and logs no Ionic errors
- with the component change stashed, the new spec fails with exactly the errors from the issue:
  ```
  [ion-datetime-button] - No ion-datetime instance found for ID 'submittedOnDate-picker'
  [ion-datetime-button] - No ion-datetime instance found for ID 'activationDate-picker'
  ```

The spec reads the button's shadow root rather than its `textContent`, which is always empty and cannot tell a bound control from a dead one.

Also run: `npx playwright test client-date-picker-revisit --project=mocked`, `npm run typecheck:e2e`, `prettier --check`.

## Follow-ups, not in this PR

The same defect is present wherever this pattern sits on a **routed page**, which I measured rather than assumed:

- **51 routed components, 75 buttons** carry it. Confirmed on a second, unrelated page — `/organization/offices/create` renders its opening-date picker on the first visit and a dead blank control on every visit after, with the same console error. No submit required; Cancel and re-enter is enough.
- **11 dialog components are not affected.** Opening `create-office-dialog` three times in a row renders correctly each time and logs nothing, so overlay-hosted forms resolve their pickers in time.

Picker ID names are also shared across files (`transactionDate-picker` in 8, `submittedOnDate-picker` in 7), so two such pages alive at once would collide. Latent today and separate from this bug — see #544.

Fixes #541