### PR TITLE
fix(ui): keep date pickers usable on every routed form visit

### DIFF
--- a/e2e/client-date-picker-revisit.spec.ts
+++ b/e2e/client-date-picker-revisit.spec.ts
@@ -145,7 +145,9 @@ test.describe('Client form date pickers', () => {
       await page.getByRole('button', { name: 'Next' }).click();
     };
 
-    await page.getByRole('link', { name: 'Clients' }).click();
+    // Reached by URL rather than through the sidebar, which is collapsed at phone width. The
+    // revisit that triggers the bug still happens in-app, via the list page's create button.
+    await page.goto('/clients');
     await expect(page).toHaveURL('/clients');
 
     // First client, created in full so the second visit starts from a torn-down form.

--- a/e2e/date-picker-revisit.spec.ts
+++ b/e2e/date-picker-revisit.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, expect } from './fixtures';
+
+const HEAD_OFFICE = 'Head Office';
+
+/**
+ * Regression cover for #541, rolled out across the routed forms.
+ *
+ * `ion-datetime-button` resolves its `ion-datetime` once, at load, and never retries, so a form
+ * reached a second time through the router used to render blank, dead date controls. The failure
+ * needs a *revisit* to show up — the first visit is masked by the lazy Ionic chunk load — which is
+ * why each page here is entered three times without a reload in between.
+ *
+ * Runs at both viewports (see DUAL_VIEWPORT_SPECS in playwright.config.ts): the defect is a
+ * lifecycle race rather than a layout concern, so it reproduces identically at phone width, and
+ * the mobile shell reaches these forms through the same list-page buttons.
+ */
+test.describe('Date pickers on revisited forms', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/config.json*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ fineractApiUrl: '/api/v1', defaultTenant: 'default' }),
+      }),
+    );
+
+    await page.route('**/api/v1/authentication**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          username: 'mifos',
+          userId: 1,
+          base64EncodedAuthenticationKey: 'YmFzZTY0',
+          authenticated: true,
+          officeId: 1,
+          officeName: HEAD_OFFICE,
+          roles: [{ id: 1, name: 'Super User', description: 'Super user' }],
+          permissions: ['ALL_FUNCTIONS'],
+        }),
+      }),
+    );
+
+    await page.route('**/api/v1/offices**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 1,
+            name: HEAD_OFFICE,
+            nameDecorated: HEAD_OFFICE,
+            externalId: '1',
+            openingDate: [2009, 1, 1],
+            hierarchy: '.',
+          },
+        ]),
+      }),
+    );
+
+    await page.route('**/api/v1/staff**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    );
+
+    await page.goto('/login');
+    if (!page.url().includes('/dashboard')) {
+      await page.locator('#tenantId').fill('default');
+      await page.locator('#username').fill('mifos');
+      await page.locator('#password').fill('password');
+      await page.getByRole('button', { name: 'Sign In' }).click();
+      await expect(page).toHaveURL('/dashboard');
+    }
+  });
+
+  /**
+   * Ionic renders a datetime button's text into its shadow root, so the host's `textContent` is
+   * always empty and cannot tell a bound control from a dead one.
+   */
+  const blankPickers = (page: import('@playwright/test').Page) =>
+    page.evaluate(
+      () =>
+        Array.from(document.querySelectorAll('ion-datetime-button')).filter(
+          (button) => (button.shadowRoot?.textContent ?? '').trim() === '',
+        ).length,
+    );
+
+  const cases = [
+    {
+      name: 'office',
+      listUrl: '/organization/offices',
+      createButton: 'Create Office',
+      // The shared list header renders its create action as a button; the staff list wires its
+      // own `ion-button` to a routerLink, which Ionic renders as an anchor.
+      createRole: 'button' as const,
+    },
+    {
+      name: 'staff',
+      listUrl: '/organization/staff',
+      createButton: 'Create Staff Member',
+      createRole: 'link' as const,
+    },
+  ];
+
+  for (const { name, listUrl, createButton, createRole } of cases) {
+    test(`${name} form keeps its pickers usable on every visit`, async ({ page }) => {
+      const pickerErrors: string[] = [];
+      page.on('console', (message) => {
+        const text = message.text();
+        if (text.includes('[ion-datetime-button]')) pickerErrors.push(text);
+      });
+
+      await page.goto(listUrl);
+
+      for (const visit of [1, 2, 3]) {
+        await page.getByRole(createRole, { name: createButton, exact: true }).click();
+        await expect(page).toHaveURL(`${listUrl}/create`);
+        await expect(page.locator('ion-datetime-button').first()).toBeAttached();
+
+        await expect
+          .poll(() => blankPickers(page), { message: `visit ${visit} left a picker unbound` })
+          .toBe(0);
+
+        await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+        await expect(page).toHaveURL(listUrl);
+      }
+
+      expect(pickerErrors).toEqual([]);
+    });
+  }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,7 +50,7 @@ const MOBILE_SPECS = ['mobile-shell.spec.ts'];
  * describe-level viewport guards, so the half that does not apply at the current width is
  * skipped rather than asserting the opposite of the intended behaviour.
  */
-const DUAL_VIEWPORT_SPECS = ['guidance-tour.spec.ts'];
+const DUAL_VIEWPORT_SPECS = ['guidance-tour.spec.ts', '**/*date-picker-revisit.spec.ts'];
 
 const BACKEND_SPECS = [
   'batch-api-operations.spec.ts',

--- a/src/app/features/accounting/accounting-closure-form.component.ts
+++ b/src/app/features/accounting/accounting-closure-form.component.ts
@@ -46,6 +46,7 @@ import {
   IonTextarea,
 } from '@ionic/angular/standalone';
 import { toIsoDate } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Component for closing an accounting period for an office.
@@ -104,7 +105,9 @@ import { toIsoDate } from '../../core/utils/date-formatter';
               <!-- Closing Date -->
               <ion-item fill="outline">
                 <ion-label position="stacked">Closing Date</ion-label>
-                <ion-datetime-button datetime="closingDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="closingDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -174,6 +177,9 @@ import { toIsoDate } from '../../core/utils/date-formatter';
   ],
 })
 export class AccountingClosureFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly closureService = inject(AccountingClosureService);
   private readonly officeService = inject(OfficesService);
   private readonly router = inject(Router);

--- a/src/app/features/accounting/frequent-postings.component.ts
+++ b/src/app/features/accounting/frequent-postings.component.ts
@@ -54,6 +54,7 @@ import {
   formatDateToFineract,
   toIsoDate,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Posting a journal entry from a saved accounting rule.
@@ -159,7 +160,9 @@ import {
                 <ion-label position="stacked">{{
                   'JOURNAL_ENTRIES.TRANSACTION_DATE' | appTranslate
                 }}</ion-label>
-                <ion-datetime-button datetime="frequent-posting-date"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="frequent-posting-date"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -265,6 +268,9 @@ import {
   ],
 })
 export class FrequentPostingsComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly rulesService = inject(AccountingRulesService);
   private readonly journalEntriesService = inject(JournalEntriesService);
   private readonly currencyService = inject(CurrencyService);

--- a/src/app/features/accounting/journal-entries-list.component.ts
+++ b/src/app/features/accounting/journal-entries-list.component.ts
@@ -53,6 +53,7 @@ import {
   FINERACT_LOCALE,
   formatDateToFineract,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 interface JournalEntryFilters {
   officeId?: number;
@@ -165,7 +166,9 @@ function defaultFilters(): JournalEntryFilters {
 
               <ion-item fill="outline">
                 <ion-label position="stacked">{{ 'COMMON.FROM_DATE' | appTranslate }}</ion-label>
-                <ion-datetime-button datetime="journal-fromDate-picker" />
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="journal-fromDate-picker" />
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -180,7 +183,9 @@ function defaultFilters(): JournalEntryFilters {
 
               <ion-item fill="outline">
                 <ion-label position="stacked">{{ 'COMMON.TO_DATE' | appTranslate }}</ion-label>
-                <ion-datetime-button datetime="journal-toDate-picker" />
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="journal-toDate-picker" />
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -279,6 +284,9 @@ function defaultFilters(): JournalEntryFilters {
   ],
 })
 export class JournalEntriesListComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   /** True when the last load failed, so the table offers a retry instead of an empty list. */
   readonly hasError = signal(false);
 

--- a/src/app/features/accounting/journal-entry-form.component.ts
+++ b/src/app/features/accounting/journal-entry-form.component.ts
@@ -54,6 +54,7 @@ import {
   IonTextarea,
 } from '@ionic/angular/standalone';
 import { toIsoDate } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Component for creating manual accounting journal entries.
@@ -134,7 +135,9 @@ import { toIsoDate } from '../../core/utils/date-formatter';
               <!-- Transaction Date -->
               <ion-item fill="outline">
                 <ion-label position="stacked">Transaction Date</ion-label>
-                <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -336,6 +339,9 @@ import { toIsoDate } from '../../core/utils/date-formatter';
   ],
 })
 export class JournalEntryFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly journalService = inject(JournalEntriesService);
   private readonly glAccountService = inject(GeneralLedgerAccountService);
   private readonly officeService = inject(OfficesService);

--- a/src/app/features/accounting/provisioning-entries/provisioning-entries-form.component.ts
+++ b/src/app/features/accounting/provisioning-entries/provisioning-entries-form.component.ts
@@ -37,6 +37,7 @@ import {
   IonModal,
   IonSpinner,
 } from '@ionic/angular/standalone';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Generates a new provisioning entry for a given date, optionally creating the
@@ -74,7 +75,9 @@ import {
               <ion-label position="stacked">{{
                 'PROVISIONING_ENTRIES.DATE' | translate
               }}</ion-label>
-              <ion-datetime-button datetime="date-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="date-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -131,6 +134,9 @@ import {
   ],
 })
 export class ProvisioningEntriesFormComponent {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly entriesService = inject(ProvisioningEntriesService);
   private readonly router = inject(Router);
 

--- a/src/app/features/accounting/run-accruals/run-accruals.component.ts
+++ b/src/app/features/accounting/run-accruals/run-accruals.component.ts
@@ -39,6 +39,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Single action screen that triggers periodic accrual accounting up to a chosen date.
@@ -79,7 +80,9 @@ import {
           <form #accrualForm="ngForm" (ngSubmit)="onSubmit()" class="accrual-form">
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'RUN_ACCRUALS.TILL_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="tillDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="tillDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -140,6 +143,9 @@ import {
   ],
 })
 export class RunAccrualsComponent {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly accrualService = inject(PeriodicAccrualAccountingService);
 
   tillDate: string | null = null;

--- a/src/app/features/calendars/calendar-form.component.ts
+++ b/src/app/features/calendars/calendar-form.component.ts
@@ -44,6 +44,7 @@ import {
   formatDateToFineract,
   toIsoDate,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Create / edit form for a group/center calendar. The entity type and entity id come
@@ -95,7 +96,9 @@ import {
 
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'CALENDARS.START_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -165,6 +168,9 @@ import {
   ],
 })
 export class CalendarFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly calendarService = inject(CalendarService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/campaigns/email-campaigns/email-campaign-form.component.ts
+++ b/src/app/features/campaigns/email-campaigns/email-campaign-form.component.ts
@@ -40,6 +40,7 @@ import {
   IonSelectOption,
   IonTextarea,
 } from '@ionic/angular/standalone';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-email-campaign-form',
@@ -127,7 +128,9 @@ import {
 
             <ion-item fill="outline" class="full-width">
               <ion-label position="stacked">{{ 'EMAIL_CAMPAIGNS.SCHEDULE' | translate }}</ion-label>
-              <ion-datetime-button datetime="scheduledStartDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="scheduledStartDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -185,6 +188,9 @@ import {
   ],
 })
 export class EmailCampaignFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly api = inject(DefaultService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);

--- a/src/app/features/centers/center-form.component.ts
+++ b/src/app/features/centers/center-form.component.ts
@@ -50,6 +50,7 @@ import {
   PutCentersCenterIdRequest,
   GetOfficesResponse,
 } from '../../api';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Component for creating and editing community centers.
@@ -132,7 +133,9 @@ import {
                   <ion-label position="stacked">{{
                     'COMMON.ACTIVATION_DATE' | translate
                   }}</ion-label>
-                  <ion-datetime-button datetime="activationDate-picker"></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="activationDate-picker"></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -232,6 +235,9 @@ import {
   ],
 })
 export class CenterFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly centersService = inject(CentersService);
   private readonly officesService = inject(OfficesService);
   private readonly route = inject(ActivatedRoute);

--- a/src/app/features/clients/kyc/client-family-member-form.component.ts
+++ b/src/app/features/clients/kyc/client-family-member-form.component.ts
@@ -46,6 +46,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-client-family-member-form',
@@ -237,7 +238,9 @@ import {
                     <ion-label position="stacked">{{
                       'CLIENTS.DATE_OF_BIRTH' | translate
                     }}</ion-label>
-                    <ion-datetime-button datetime="family-dob-picker"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button datetime="family-dob-picker"></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -306,6 +309,9 @@ import {
   `,
 })
 export class ClientFamilyMemberFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly familyService = inject(ClientFamilyMemberService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);

--- a/src/app/features/collection-sheet/collection-sheet.component.ts
+++ b/src/app/features/collection-sheet/collection-sheet.component.ts
@@ -49,6 +49,7 @@ import {
   IonSelectOption,
   IonSpinner,
 } from '@ionic/angular/standalone';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-collection-sheet',
@@ -103,7 +104,9 @@ import {
 
             <ion-item fill="outline" class="full-width">
               <ion-label position="stacked">{{ 'COLLECTION_SHEET.DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -185,6 +188,9 @@ import {
   ],
 })
 export class CollectionSheetComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private collectionSheetService = inject(CollectionSheetService);
   private officesService = inject(OfficesService);
   private notifications = inject(NotificationService);

--- a/src/app/features/groups/group-form.component.ts
+++ b/src/app/features/groups/group-form.component.ts
@@ -50,6 +50,7 @@ import {
   PutGroupsGroupIdRequest,
   GetOfficesResponse,
 } from '../../api';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Component for creating and editing self-help groups.
@@ -129,7 +130,9 @@ import {
                   <ion-label position="stacked">{{
                     'COMMON.ACTIVATION_DATE' | translate
                   }}</ion-label>
-                  <ion-datetime-button datetime="activationDate-picker"></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="activationDate-picker"></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -229,6 +232,9 @@ import {
   ],
 })
 export class GroupFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly groupsService = inject(GroupsService);
   private readonly officesService = inject(OfficesService);
   private readonly router = inject(Router);

--- a/src/app/features/loans/charges/loan-charge-form.component.ts
+++ b/src/app/features/loans/charges/loan-charge-form.component.ts
@@ -47,6 +47,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Create form for a loan charge. The available charge options come from the loan charges
@@ -110,7 +111,9 @@ import {
 
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'LOAN_CHARGES.DUE_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="dueDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="dueDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -162,6 +165,9 @@ import {
   ],
 })
 export class LoanChargeFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly loanChargesService = inject(LoanChargesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/loans/guarantors/guarantor-form.component.ts
+++ b/src/app/features/loans/guarantors/guarantor-form.component.ts
@@ -45,6 +45,7 @@ import {
   IonSelectOption,
   IonSpinner,
 } from '@ionic/angular/standalone';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Create / edit form for a loan guarantor. The guarantor-type options come from the
@@ -178,7 +179,9 @@ import {
 
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'GUARANTORS.DOB' | translate }}</ion-label>
-              <ion-datetime-button datetime="dobDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="dobDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -231,6 +234,9 @@ import {
   ],
 })
 export class GuarantorFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly guarantorsService = inject(GuarantorsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/loans/interest-pauses/interest-pause-form.component.ts
+++ b/src/app/features/loans/interest-pauses/interest-pause-form.component.ts
@@ -46,6 +46,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Parses a route segment that is meant to be a database id. Returns null for
@@ -97,7 +98,9 @@ function toRouteId(value: string | null): number | null {
               <ion-label position="stacked">{{
                 'INTEREST_PAUSES.START_DATE' | translate
               }}</ion-label>
-              <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -115,7 +118,9 @@ function toRouteId(value: string | null): number | null {
 
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'INTEREST_PAUSES.END_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="endDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="endDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -169,6 +174,9 @@ function toRouteId(value: string | null): number | null {
   ],
 })
 export class InterestPauseFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly pauseService = inject(LoanInterestPauseService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/loans/loan-form.component.ts
+++ b/src/app/features/loans/loan-form.component.ts
@@ -68,6 +68,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
 
@@ -206,7 +207,9 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
                 <!-- Submitted On -->
                 <ion-item fill="outline" [appTooltip]="'HELP.SUBMITTED_ON_DESC' | translate">
                   <ion-label position="stacked">{{ 'COMMON.SUBMITTED_ON' | translate }}</ion-label>
-                  <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -230,9 +233,11 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
                   <ion-label position="stacked">{{
                     'LOANS.EXPECTED_DISBURSEMENT' | translate
                   }}</ion-label>
-                  <ion-datetime-button
-                    datetime="expectedDisbursementDate-picker"
-                  ></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button
+                      datetime="expectedDisbursementDate-picker"
+                    ></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -467,9 +472,11 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
                   <ion-label position="stacked">{{
                     'LOANS.REPAYMENTS_STARTING_FROM_DATE' | translate
                   }}</ion-label>
-                  <ion-datetime-button
-                    datetime="repaymentsStartingFromDate-picker"
-                  ></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button
+                      datetime="repaymentsStartingFromDate-picker"
+                    ></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -554,6 +561,9 @@ const OPERATION_FAILED_MESSAGE = 'Operation failed. Please try again.';
   ],
 })
 export class LoanFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly loansService = inject(LoansService);
   private readonly productService = inject(LoanProductsService);
   private readonly router = inject(Router);

--- a/src/app/features/loans/loan-transaction-form.component.ts
+++ b/src/app/features/loans/loan-transaction-form.component.ts
@@ -52,6 +52,7 @@ import {
 } from '@ionic/angular/standalone';
 import { toIsoDate } from '../../core/utils/date-formatter';
 import { TooltipDirective } from '../../shared/directives/tooltip.directive';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 const TRANSACTION_TITLE_KEYS: Record<string, string> = {
   repayment: 'LOANS.REPAYMENT',
@@ -176,7 +177,9 @@ const CONFIRM_MESSAGE_KEYS: Record<string, string> = {
                         : ('COMMON.TRANSACTION_DATE' | translate)
                     }}
                   </ion-label>
-                  <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -350,6 +353,9 @@ const CONFIRM_MESSAGE_KEYS: Record<string, string> = {
   ],
 })
 export class LoanTransactionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly transactionService = inject(LoanTransactionsService);
   private readonly loansService = inject(LoansService);
   private readonly router = inject(Router);

--- a/src/app/features/loans/point-in-time/loans-point-in-time.component.ts
+++ b/src/app/features/loans/point-in-time/loans-point-in-time.component.ts
@@ -43,6 +43,7 @@ import {
   RetrieveLoansPointInTimeRequest,
   LoanPointInTimeData,
 } from '../../../api';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-loans-point-in-time',
@@ -75,7 +76,9 @@ import {
         <div class="search-form">
           <ion-item fill="outline">
             <ion-label position="stacked">{{ 'LOANS_POINT_IN_TIME.DATE' | translate }}</ion-label>
-            <ion-datetime-button datetime="searchDate-picker"></ion-datetime-button>
+            @if (pickersReady()) {
+              <ion-datetime-button datetime="searchDate-picker"></ion-datetime-button>
+            }
             <ion-modal [keepContentsMounted]="true">
               <ng-template>
                 <ion-datetime
@@ -199,6 +202,9 @@ import {
   ],
 })
 export class LoansPointInTimeComponent {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   searchDate = toIsoDate(new Date());
   loanIdsInput = '';
   readonly results = signal<LoanPointInTimeData[]>([]);

--- a/src/app/features/loans/post-dated-checks/post-dated-check-form.component.ts
+++ b/src/app/features/loans/post-dated-checks/post-dated-check-form.component.ts
@@ -46,6 +46,7 @@ import {
   formatDateToFineract,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Edit-only form for a post-dated check on a loan. Loads the existing check from the
@@ -119,7 +120,9 @@ import {
 
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'POST_DATED_CHECKS.DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="date-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="date-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -173,6 +176,9 @@ import {
   ],
 })
 export class PostDatedCheckFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly checkService = inject(RepaymentWithPostDatedChecksService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/loans/rescheduling/reschedule-form.component.ts
+++ b/src/app/features/loans/rescheduling/reschedule-form.component.ts
@@ -51,6 +51,7 @@ import {
   CodesService,
   CodeValuesService,
 } from '../../../api';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Component for requesting a loan rescheduling.
@@ -158,7 +159,9 @@ import {
               <!-- Submitted On Date -->
               <ion-item fill="outline">
                 <ion-label position="stacked">Submitted On Date</ion-label>
-                <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -176,7 +179,9 @@ import {
               <!-- Adjusted Due Date (Optional) -->
               <ion-item fill="outline">
                 <ion-label position="stacked">Adjusted Due Date (Optional)</ion-label>
-                <ion-datetime-button datetime="adjustedDueDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="adjustedDueDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -298,6 +303,9 @@ import {
   ],
 })
 export class RescheduleFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly rescheduleService = inject(RescheduleLoansService);
   private readonly loansService = inject(LoansService);
   private readonly codesService = inject(CodesService);

--- a/src/app/features/meetings/meeting-form.component.ts
+++ b/src/app/features/meetings/meeting-form.component.ts
@@ -42,6 +42,7 @@ import {
   formatDateToFineract,
   toIsoDate,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Create / edit form for a group/center meeting. The entity type and entity id come
@@ -80,7 +81,9 @@ import {
           <form #meetingForm="ngForm" (ngSubmit)="onSubmit()" class="meeting-form">
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'MEETINGS.MEETING_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="meetingDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="meetingDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -146,6 +149,9 @@ import {
   ],
 })
 export class MeetingFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly meetingsService = inject(MeetingsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/organization/loan-portfolio-summary/loan-portfolio-summary.component.ts
+++ b/src/app/features/organization/loan-portfolio-summary/loan-portfolio-summary.component.ts
@@ -47,6 +47,7 @@ import {
 } from '../../../core/utils/date-formatter';
 import { AdHocSearchQueryData, LoanProductData, OfficeData, SearchAPIService } from '../../../api';
 import { ColumnDef, DataTableComponent, HelpIconComponent } from '../../../shared';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /** The four amount-comparison shapes the platform's search endpoint understands. */
 type ComparisonCondition = 'between' | '<=' | '>=' | '<' | '>' | '=';
@@ -258,7 +259,9 @@ function buildSearchPayload(filters: PortfolioFilters, fromDate: string, toDate:
                   <ion-label position="stacked">{{
                     'ORGANIZATION.FROM_DATE' | appTranslate
                   }}</ion-label>
-                  <ion-datetime-button datetime="fromDate-picker" />
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="fromDate-picker" />
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -278,7 +281,9 @@ function buildSearchPayload(filters: PortfolioFilters, fromDate: string, toDate:
                   <ion-label position="stacked">{{
                     'ORGANIZATION.TO_DATE' | appTranslate
                   }}</ion-label>
-                  <ion-datetime-button datetime="toDate-picker" />
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="toDate-picker" />
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -503,6 +508,9 @@ function buildSearchPayload(filters: PortfolioFilters, fromDate: string, toDate:
   ],
 })
 export class LoanPortfolioSummaryComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly searchService = inject(SearchAPIService);
   private readonly notifications = inject(NotificationService);
   private readonly i18n = inject(I18N);

--- a/src/app/features/organization/office-transactions/office-transaction-form.component.ts
+++ b/src/app/features/organization/office-transactions/office-transaction-form.component.ts
@@ -44,6 +44,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-office-transaction-form',
@@ -128,7 +129,9 @@ import {
                 <ion-label position="stacked">{{
                   'OFFICE_TRANSACTIONS.DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -197,6 +200,9 @@ import {
   ],
 })
 export class OfficeTransactionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly api = inject(DefaultService);
   private readonly router = inject(Router);
   private readonly notifications = inject(NotificationService);

--- a/src/app/features/organization/offices/office-form.component.ts
+++ b/src/app/features/organization/offices/office-form.component.ts
@@ -46,6 +46,7 @@ import {
   PutOfficesOfficeIdRequest,
   GetOfficesResponse,
 } from '../../../api';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-office-form',
@@ -122,7 +123,9 @@ import {
 
               <ion-item fill="outline" [appTooltip]="'HELP.OPENING_DATE_DESC' | translate">
                 <ion-label position="stacked">{{ 'OFFICES.OPENING_DATE' | translate }}</ion-label>
-                <ion-datetime-button datetime="openingDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="openingDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -182,6 +185,9 @@ import {
   ],
 })
 export class OfficeFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly officesService = inject(OfficesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/organization/staff/staff-form.component.ts
+++ b/src/app/features/organization/staff/staff-form.component.ts
@@ -52,6 +52,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Drops optional fields the user left empty.
@@ -176,7 +177,9 @@ function withoutBlanks<T extends Record<string, unknown>>(payload: T): T {
                 <ion-label position="stacked">{{
                   'ACTIONS.ACTIVATION_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="joiningDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="joiningDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -250,6 +253,9 @@ function withoutBlanks<T extends Record<string, unknown>>(payload: T): T {
   ],
 })
 export class StaffFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly staffService = inject(StaffService);
   private readonly officesService = inject(OfficesService);
   private readonly router = inject(Router);

--- a/src/app/features/products/fixed-deposit-transactions/fixed-deposit-transaction-form.component.ts
+++ b/src/app/features/products/fixed-deposit-transactions/fixed-deposit-transaction-form.component.ts
@@ -47,6 +47,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * One payment-type option as the transactions template actually returns it.
@@ -123,7 +124,9 @@ type DepositRequest = PostFixedDepositAccountsFixedDepositAccountIdTransactionsR
               <ion-label position="stacked">{{
                 'FIXED_DEPOSIT_TRANSACTIONS.DATE' | appTranslate
               }}</ion-label>
-              <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -212,6 +215,9 @@ type DepositRequest = PostFixedDepositAccountsFixedDepositAccountIdTransactionsR
   ],
 })
 export class FixedDepositTransactionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly transactionsService = inject(FixedDepositAccountTransactionsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
+++ b/src/app/features/products/fixed-deposits/fixed-deposit-form.component.ts
@@ -56,6 +56,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Component for creating and managing individual fixed deposit accounts.
@@ -177,7 +178,9 @@ import {
               <!-- Submitted On -->
               <ion-item fill="outline" [appTooltip]="'HELP.SUBMITTED_ON_DESC' | translate">
                 <ion-label position="stacked">{{ 'COMMON.SUBMITTED_ON' | translate }}</ion-label>
-                <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -295,6 +298,9 @@ import {
   ],
 })
 export class FixedDepositAccountFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   /** Service for term deposit operations */
   private readonly fixedDepositService = inject(FixedDepositAccountService);
   /** Router for post-op navigation */

--- a/src/app/features/products/floating-rates/floating-rate-form.component.ts
+++ b/src/app/features/products/floating-rates/floating-rate-form.component.ts
@@ -47,6 +47,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /** A single editable rate period row in the form. */
 interface RatePeriodRow {
@@ -128,7 +129,9 @@ interface RatePeriodRow {
                     <ion-label position="stacked">{{
                       'FLOATING_RATES.FROM_DATE' | translate
                     }}</ion-label>
-                    <ion-datetime-button datetime="periodfromDate-picker"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button datetime="periodfromDate-picker"></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -225,6 +228,9 @@ interface RatePeriodRow {
   ],
 })
 export class FloatingRateFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly floatingRatesService = inject(FloatingRatesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/products/interest-rate-charts/interest-rate-chart-form.component.ts
+++ b/src/app/features/products/interest-rate-charts/interest-rate-chart-form.component.ts
@@ -47,6 +47,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Create / edit form for an interest rate chart's core fields. On create the chart's
@@ -117,7 +118,9 @@ import {
                 <ion-label position="stacked">{{
                   'INTEREST_RATE_CHARTS.FROM_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="fromDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="fromDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -172,6 +175,9 @@ import {
   ],
 })
 export class InterestRateChartFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly chartService = inject(InterestRateChartService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.ts
+++ b/src/app/features/products/recurring-deposit-transactions/recurring-deposit-transaction-form.component.ts
@@ -47,6 +47,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Transaction form for a single recurring deposit account. The account id and command are read
@@ -93,7 +94,9 @@ import {
               <ion-label position="stacked">{{
                 'RECURRING_DEPOSIT_TRANSACTIONS.DATE' | translate
               }}</ion-label>
-              <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -175,6 +178,9 @@ import {
   ],
 })
 export class RecurringDepositTransactionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly transactionsService = inject(RecurringDepositAccountTransactionsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
+++ b/src/app/features/products/recurring-deposits/recurring-deposit-form.component.ts
@@ -57,6 +57,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Component for creating and managing individual recurring deposit accounts.
@@ -190,7 +191,9 @@ import {
               <!-- Submitted On -->
               <ion-item fill="outline" [appTooltip]="'HELP.SUBMITTED_ON_DESC' | translate">
                 <ion-label position="stacked">{{ 'COMMON.SUBMITTED_ON' | translate }}</ion-label>
-                <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -365,6 +368,9 @@ import {
   ],
 })
 export class RecurringDepositAccountFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   /** Service for term deposit operations */
   private readonly rdService = inject(RecurringDepositAccountService);
   /** Router for post-op navigation */

--- a/src/app/features/products/savings-account-form.component.ts
+++ b/src/app/features/products/savings-account-form.component.ts
@@ -56,6 +56,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-savings-account-form',
@@ -156,7 +157,9 @@ import {
               <!-- Submitted On -->
               <ion-item fill="outline" [appTooltip]="'HELP.SUBMITTED_ON_DESC' | translate">
                 <ion-label position="stacked">{{ 'COMMON.SUBMITTED_ON' | translate }}</ion-label>
-                <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -236,6 +239,9 @@ import {
   ],
 })
 export class SavingsAccountFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly savingsService = inject(SavingsAccountService);
   private readonly productService = inject(SavingsProductService);
   private readonly router = inject(Router);

--- a/src/app/features/products/savings-account-transaction-form.component.ts
+++ b/src/app/features/products/savings-account-transaction-form.component.ts
@@ -47,6 +47,7 @@ import {
   SavingsAccountTransactionsService,
   PostSavingsAccountTransactionsRequest,
 } from '../../api';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-savings-account-transaction-form',
@@ -95,7 +96,9 @@ import {
                 <ion-label position="stacked">{{
                   'COMMON.TRANSACTION_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -201,6 +204,9 @@ import {
   ],
 })
 export class SavingsAccountTransactionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly transactionService = inject(SavingsAccountTransactionsService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);

--- a/src/app/features/products/savings-charges/savings-charge-form.component.ts
+++ b/src/app/features/products/savings-charges/savings-charge-form.component.ts
@@ -47,6 +47,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Create form for a savings account charge. The available charge options come from the
@@ -111,7 +112,9 @@ import {
 
             <ion-item fill="outline">
               <ion-label position="stacked">{{ 'SAVINGS_CHARGES.DUE_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="dueDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="dueDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -163,6 +166,9 @@ import {
   ],
 })
 export class SavingsChargeFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly savingsChargesService = inject(SavingsChargesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/products/share-dividends/share-dividend-form.component.ts
+++ b/src/app/features/products/share-dividends/share-dividend-form.component.ts
@@ -41,6 +41,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Create form for a share product dividend. The share product id is read from the route
@@ -91,7 +92,11 @@ import {
               <ion-label position="stacked">{{
                 'SHARE_DIVIDENDS.PERIOD_START_DATE' | translate
               }}</ion-label>
-              <ion-datetime-button datetime="dividendPeriodStartDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button
+                  datetime="dividendPeriodStartDate-picker"
+                ></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -110,7 +115,9 @@ import {
               <ion-label position="stacked">{{
                 'SHARE_DIVIDENDS.PERIOD_END_DATE' | translate
               }}</ion-label>
-              <ion-datetime-button datetime="dividendPeriodEndDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="dividendPeriodEndDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -163,6 +170,9 @@ import {
   ],
 })
 export class ShareDividendFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly selfDividendService = inject(SelfDividendService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/reporting/run-report.component.ts
+++ b/src/app/features/reporting/run-report.component.ts
@@ -60,6 +60,7 @@ import {
   ReportSelectOption,
   offersAllOption,
 } from './report-execution.service';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 const SUPPORTED_DISPLAY_TYPES = new Set(['select', 'date', 'text', 'none']);
 
@@ -228,11 +229,13 @@ interface ReportParameterView {
                   <div class="parameter-field">
                     <ion-item fill="outline" [attr.data-testid]="view.testId" [id]="view.controlId">
                       <ion-label position="stacked">{{ view.parameter.label }}</ion-label>
-                      <ion-datetime-button
-                        [id]="view.controlId + '-button'"
-                        [attr.data-testid]="view.testId + '-button'"
-                        [datetime]="view.datePickerId"
-                      ></ion-datetime-button>
+                      @if (pickersReady()) {
+                        <ion-datetime-button
+                          [id]="view.controlId + '-button'"
+                          [attr.data-testid]="view.testId + '-button'"
+                          [datetime]="view.datePickerId"
+                        ></ion-datetime-button>
+                      }
                       <ion-modal [keepContentsMounted]="true">
                         <ng-template>
                           <ion-datetime
@@ -424,6 +427,9 @@ interface ReportParameterView {
   ],
 })
 export class RunReportComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly reportExecution = inject(ReportExecutionService);
   private readonly download = inject(DOWNLOAD);
   private readonly route = inject(ActivatedRoute);

--- a/src/app/features/security/audit-logs/audit-logs-list.component.ts
+++ b/src/app/features/security/audit-logs/audit-logs-list.component.ts
@@ -47,6 +47,7 @@ import {
   IonSelect,
   IonSelectOption,
 } from '@ionic/angular/standalone';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 export interface AuditFilters {
   actionName: string;
@@ -132,9 +133,11 @@ export interface AuditFilters {
 
               <ion-item fill="outline">
                 <ion-label position="stacked">Maker Date From</ion-label>
-                <ion-datetime-button
-                  datetime="activeFiltersmakerDateTimeFrom-picker"
-                ></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button
+                    datetime="activeFiltersmakerDateTimeFrom-picker"
+                  ></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -150,9 +153,11 @@ export interface AuditFilters {
 
               <ion-item fill="outline">
                 <ion-label position="stacked">Maker Date To</ion-label>
-                <ion-datetime-button
-                  datetime="activeFiltersmakerDateTimeTo-picker"
-                ></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button
+                    datetime="activeFiltersmakerDateTimeTo-picker"
+                  ></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -263,6 +268,9 @@ export interface AuditFilters {
   ],
 })
 export class AuditLogsListComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   /** True when the last load failed, so the table offers a retry instead of an empty list. */
   readonly hasError = signal(false);
 

--- a/src/app/features/settings/holiday-form.component.ts
+++ b/src/app/features/settings/holiday-form.component.ts
@@ -47,6 +47,7 @@ import {
   PostHolidaysRequest,
   GetOfficesResponse,
 } from '../../api';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-holiday-form',
@@ -125,7 +126,9 @@ import {
                 [appTooltip]="'HELP.FROM_DATE_DESC' | translate"
               >
                 <ion-label position="stacked">{{ 'HOLIDAYS.FROM_DATE' | translate }}</ion-label>
-                <ion-datetime-button datetime="fromDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="fromDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -146,7 +149,9 @@ import {
                 [appTooltip]="'HELP.TO_DATE_DESC' | translate"
               >
                 <ion-label position="stacked">{{ 'HOLIDAYS.TO_DATE' | translate }}</ion-label>
-                <ion-datetime-button datetime="toDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="toDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -191,9 +196,11 @@ import {
                   <ion-label position="stacked">{{
                     'HOLIDAYS.REPAYMENTS_RESCHEDULED_TO' | translate
                   }}</ion-label>
-                  <ion-datetime-button
-                    datetime="repaymentsRescheduledTo-picker"
-                  ></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button
+                      datetime="repaymentsRescheduledTo-picker"
+                    ></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -270,6 +277,9 @@ import {
   ],
 })
 export class HolidayFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly holidaysService = inject(HolidaysService);
   private readonly officesService = inject(OfficesService);
   private readonly router = inject(Router);

--- a/src/app/features/system/business-dates/business-dates.component.ts
+++ b/src/app/features/system/business-dates/business-dates.component.ts
@@ -46,6 +46,7 @@ import {
   FINERACT_LOCALE,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-business-dates',
@@ -93,7 +94,9 @@ import {
             </p>
             <ion-item fill="outline" class="full-width">
               <ion-label position="stacked">{{ 'BUSINESS_DATES.NEW_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="businessDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="businessDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -134,7 +137,9 @@ import {
             </p>
             <ion-item fill="outline" class="full-width">
               <ion-label position="stacked">{{ 'BUSINESS_DATES.NEW_DATE' | translate }}</ion-label>
-              <ion-datetime-button datetime="cobDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="cobDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -191,6 +196,9 @@ import {
   ],
 })
 export class BusinessDatesComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private businessDateService = inject(BusinessDateManagementService);
   private notifications = inject(NotificationService);
 

--- a/src/app/features/tellers/cashiers/cashier-form.component.ts
+++ b/src/app/features/tellers/cashiers/cashier-form.component.ts
@@ -50,6 +50,7 @@ import {
   PostTellersTellerIdCashiersRequest,
   StaffData,
 } from '../../../api';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 @Component({
   selector: 'app-cashier-form',
@@ -114,7 +115,11 @@ import {
                 <ion-col size="12" size-md="6">
                   <ion-item fill="outline">
                     <ion-label position="stacked">{{ 'TELLERS.START_DATE' | translate }}</ion-label>
-                    <ion-datetime-button datetime="cashier-start-date-picker"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button
+                        datetime="cashier-start-date-picker"
+                      ></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -132,7 +137,9 @@ import {
                 <ion-col size="12" size-md="6">
                   <ion-item fill="outline">
                     <ion-label position="stacked">{{ 'TELLERS.END_DATE' | translate }}</ion-label>
-                    <ion-datetime-button datetime="cashier-end-date-picker"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button datetime="cashier-end-date-picker"></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -211,6 +218,9 @@ import {
   `,
 })
 export class CashierFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly tellerService = inject(TellerCashManagementService);
   private readonly staffService = inject(StaffService);
   private readonly router = inject(Router);

--- a/src/app/features/tellers/cashiers/cashier-transaction-form.component.ts
+++ b/src/app/features/tellers/cashiers/cashier-transaction-form.component.ts
@@ -54,6 +54,7 @@ import {
   FINERACT_LOCALE,
   formatDateToFineract,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Which side of the vault the transaction moves cash to.
@@ -149,7 +150,9 @@ export type CashierTransactionCommand = 'allocate' | 'settle';
                 <ion-col size="12" size-md="6">
                   <ion-item fill="outline">
                     <ion-label position="stacked">{{ 'COMMON.DATE' | appTranslate }}</ion-label>
-                    <ion-datetime-button datetime="cashier-txn-date-picker"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button datetime="cashier-txn-date-picker"></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -213,6 +216,9 @@ export type CashierTransactionCommand = 'allocate' | 'settle';
   `,
 })
 export class CashierTransactionFormComponent {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly tellerService = inject(TellerCashManagementService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);

--- a/src/app/features/tellers/teller-form.component.ts
+++ b/src/app/features/tellers/teller-form.component.ts
@@ -51,6 +51,7 @@ import {
   PutTellersRequest,
   GetOfficesResponse,
 } from '../../api';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 /**
  * Component for creating and editing branch tellers.
@@ -166,7 +167,11 @@ import {
                 <ion-col size="12" size-md="6">
                   <ion-item fill="outline" [appTooltip]="'HELP.TELLER_START_DATE_DESC' | translate">
                     <ion-label position="stacked">{{ 'TELLERS.START_DATE' | translate }}</ion-label>
-                    <ion-datetime-button datetime="teller-start-date-picker"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button
+                        datetime="teller-start-date-picker"
+                      ></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -276,6 +281,9 @@ import {
   ],
 })
 export class TellerFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   /** Service for teller management API calls */
   private readonly tellerService = inject(TellerCashManagementService);
   /** Service for retrieving office hierarchy */

--- a/src/app/features/transfers/account-transfer-form.component.ts
+++ b/src/app/features/transfers/account-transfer-form.component.ts
@@ -53,6 +53,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 export interface MiniAccount {
   id: number;
@@ -295,7 +296,9 @@ export interface MiniAccount {
 
               <ion-item fill="outline">
                 <ion-label position="stacked">{{ 'CLIENTS.TRANSFER_DATE' | translate }}</ion-label>
-                <ion-datetime-button datetime="transfer-date-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="transfer-date-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -387,6 +390,9 @@ export interface MiniAccount {
   ],
 })
 export class AccountTransferFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly transfersService = inject(AccountTransfersService);
   private readonly officesService = inject(OfficesService);
   private readonly clientService = inject(ClientService);

--- a/src/app/features/transfers/standing-instruction-form.component.ts
+++ b/src/app/features/transfers/standing-instruction-form.component.ts
@@ -52,6 +52,7 @@ import {
   formatArrayDate,
   toIsoDate,
 } from '../../core/utils/date-formatter';
+import { createPickersReady } from '../../shared/utils/pickers-ready';
 
 export interface MiniAccount {
   id: number;
@@ -365,7 +366,9 @@ export interface MiniAccount {
 
                 <ion-item fill="outline">
                   <ion-label position="stacked">{{ 'CLIENTS.VALID_FROM' | translate }}</ion-label>
-                  <ion-datetime-button datetime="validFrom-picker"></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="validFrom-picker"></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -382,7 +385,9 @@ export interface MiniAccount {
 
                 <ion-item fill="outline">
                   <ion-label position="stacked">{{ 'CLIENTS.VALID_TILL' | translate }}</ion-label>
-                  <ion-datetime-button datetime="validTill-picker"></ion-datetime-button>
+                  @if (pickersReady()) {
+                    <ion-datetime-button datetime="validTill-picker"></ion-datetime-button>
+                  }
                   <ion-modal [keepContentsMounted]="true">
                     <ng-template>
                       <ion-datetime
@@ -455,6 +460,9 @@ export interface MiniAccount {
   ],
 })
 export class StandingInstructionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly instructionsService = inject(StandingInstructionsService);
   private readonly officesService = inject(OfficesService);
   private readonly clientService = inject(ClientService);

--- a/src/app/features/working-capital/loan-products/wc-loan-product-form.component.ts
+++ b/src/app/features/working-capital/loan-products/wc-loan-product-form.component.ts
@@ -58,6 +58,7 @@ import {
   formatDateToFineract,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Create / edit form for a working-capital loan product. Covers the core mandatory
@@ -488,7 +489,9 @@ import {
                     <ion-label position="stacked">{{
                       'WC_LOAN_PRODUCTS.START_DATE' | translate
                     }}</ion-label>
-                    <ion-datetime-button datetime="wc-product-start-date"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button datetime="wc-product-start-date"></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -508,7 +511,9 @@ import {
                     <ion-label position="stacked">{{
                       'WC_LOAN_PRODUCTS.CLOSE_DATE' | translate
                     }}</ion-label>
-                    <ion-datetime-button datetime="wc-product-close-date"></ion-datetime-button>
+                    @if (pickersReady()) {
+                      <ion-datetime-button datetime="wc-product-close-date"></ion-datetime-button>
+                    }
                     <ion-modal [keepContentsMounted]="true">
                       <ng-template>
                         <ion-datetime
@@ -600,6 +605,9 @@ import {
   ],
 })
 export class WcLoanProductFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly productService = inject(WorkingCapitalLoanProductsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/working-capital/loans/wc-breach-action-form.component.ts
+++ b/src/app/features/working-capital/loans/wc-breach-action-form.component.ts
@@ -48,6 +48,7 @@ import {
   FINERACT_LOCALE,
   formatDateToFineract,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 const ACTIONS = WorkingCapitalLoanBreachActionData.ActionEnum;
 const FREQUENCY_TYPES = WorkingCapitalLoanBreachActionData.FrequencyTypeEnum;
@@ -117,7 +118,9 @@ const MINIMUM_PAYMENT_TYPES = WorkingCapitalLoanBreachActionData.MinimumPaymentT
                 <ion-label position="stacked">{{
                   'WC_LOANS.BREACH_ACTION.START_DATE' | appTranslate
                 }}</ion-label>
-                <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -138,7 +141,9 @@ const MINIMUM_PAYMENT_TYPES = WorkingCapitalLoanBreachActionData.MinimumPaymentT
                 <ion-label position="stacked">{{
                   'WC_LOANS.BREACH_ACTION.END_DATE' | appTranslate
                 }}</ion-label>
-                <ion-datetime-button datetime="endDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="endDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -254,6 +259,9 @@ const MINIMUM_PAYMENT_TYPES = WorkingCapitalLoanBreachActionData.MinimumPaymentT
   ],
 })
 export class WcBreachActionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly breachActionsService = inject(WorkingCapitalLoanBreachActionsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/working-capital/loans/wc-delinquency-action-form.component.ts
+++ b/src/app/features/working-capital/loans/wc-delinquency-action-form.component.ts
@@ -48,6 +48,7 @@ import {
   FINERACT_LOCALE,
   formatDateToFineract,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 const ACTIONS = WorkingCapitalLoanDelinquencyActionData.ActionEnum;
 const FREQUENCY_TYPES = WorkingCapitalLoanDelinquencyActionData.FrequencyTypeEnum;
@@ -117,7 +118,9 @@ const MINIMUM_PAYMENT_TYPES = WorkingCapitalLoanDelinquencyActionData.MinimumPay
                 <ion-label position="stacked">{{
                   'WC_LOANS.DELINQUENCY_ACTION.START_DATE' | appTranslate
                 }}</ion-label>
-                <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="startDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -138,7 +141,9 @@ const MINIMUM_PAYMENT_TYPES = WorkingCapitalLoanDelinquencyActionData.MinimumPay
                 <ion-label position="stacked">{{
                   'WC_LOANS.DELINQUENCY_ACTION.END_DATE' | appTranslate
                 }}</ion-label>
-                <ion-datetime-button datetime="endDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="endDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -256,6 +261,9 @@ const MINIMUM_PAYMENT_TYPES = WorkingCapitalLoanDelinquencyActionData.MinimumPay
   ],
 })
 export class WcDelinquencyActionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly delinquencyActionsService = inject(WorkingCapitalLoanDelinquencyActionsService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/working-capital/loans/wc-loan-action-form.component.ts
+++ b/src/app/features/working-capital/loans/wc-loan-action-form.component.ts
@@ -51,6 +51,7 @@ import {
   formatDateToFineract,
   toIsoDate,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Handles WC loan lifecycle commands (approve, reject, undoapproval, disburse, undodisbursal)
@@ -92,7 +93,9 @@ import {
                 <ion-label position="stacked">{{
                   'WC_LOANS.ACTIONS.APPROVED_ON_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="approvedOnDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="approvedOnDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -124,9 +127,11 @@ import {
                 <ion-label position="stacked">{{
                   'WC_LOANS.ACTIONS.EXPECTED_DISBURSEMENT_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button
-                  datetime="expectedDisbursementDate-picker"
-                ></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button
+                    datetime="expectedDisbursementDate-picker"
+                  ></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -143,7 +148,11 @@ import {
                 <ion-label position="stacked">{{
                   'WC_LOANS.ACTIONS.ACTUAL_DISBURSEMENT_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="actualDisbursementDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button
+                    datetime="actualDisbursementDate-picker"
+                  ></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -187,7 +196,9 @@ import {
                 <ion-label position="stacked">{{
                   'WC_LOANS.ACTIONS.REJECTED_ON_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="rejectedOnDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="rejectedOnDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -208,7 +219,9 @@ import {
                 <ion-label position="stacked">{{
                   'WC_LOANS.ACTIONS.TRANSACTION_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button datetime="transactionDate-picker"></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -279,9 +292,11 @@ import {
                 <ion-label position="stacked">{{
                   'WC_LOANS.ACTIONS.EFFECTIVE_DATE' | translate
                 }}</ion-label>
-                <ion-datetime-button
-                  datetime="paymentRateEffectiveDate-picker"
-                ></ion-datetime-button>
+                @if (pickersReady()) {
+                  <ion-datetime-button
+                    datetime="paymentRateEffectiveDate-picker"
+                  ></ion-datetime-button>
+                }
                 <ion-modal [keepContentsMounted]="true">
                   <ng-template>
                     <ion-datetime
@@ -370,6 +385,9 @@ import {
   ],
 })
 export class WcLoanActionFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly loansService = inject(WorkingCapitalLoansService);
   private readonly transactionsService = inject(WorkingCapitalLoanTransactionsService);
   private readonly route = inject(ActivatedRoute);

--- a/src/app/features/working-capital/loans/wc-loan-charge-form.component.ts
+++ b/src/app/features/working-capital/loans/wc-loan-charge-form.component.ts
@@ -47,6 +47,7 @@ import {
   FINERACT_LOCALE,
   formatDateToFineract,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /** Adds a charge to a single Working Capital loan, from the options offered by its template. */
 @Component({
@@ -110,7 +111,9 @@ import {
               <ion-label position="stacked">{{
                 'WC_LOANS.CHARGE.DUE_DATE' | appTranslate
               }}</ion-label>
-              <ion-datetime-button datetime="dueDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="dueDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -162,6 +165,9 @@ import {
   ],
 })
 export class WcLoanChargeFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly chargesService = inject(WorkingCapitalLoanChargesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);

--- a/src/app/features/working-capital/loans/wc-loan-form.component.ts
+++ b/src/app/features/working-capital/loans/wc-loan-form.component.ts
@@ -54,6 +54,7 @@ import {
   FINERACT_DATE_FORMAT,
   FINERACT_LOCALE,
 } from '../../../core/utils/date-formatter';
+import { createPickersReady } from '../../../shared/utils/pickers-ready';
 
 /**
  * Create form for a Working Capital Loan application. Required fields are
@@ -133,7 +134,9 @@ import {
               <ion-label position="stacked">{{
                 'WC_LOANS.SUBMITTED_ON_DATE' | translate
               }}</ion-label>
-              <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button datetime="submittedOnDate-picker"></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -151,7 +154,11 @@ import {
               <ion-label position="stacked">{{
                 'WC_LOANS.EXPECTED_DISBURSEMENT_DATE' | translate
               }}</ion-label>
-              <ion-datetime-button datetime="expectedDisbursementDate-picker"></ion-datetime-button>
+              @if (pickersReady()) {
+                <ion-datetime-button
+                  datetime="expectedDisbursementDate-picker"
+                ></ion-datetime-button>
+              }
               <ion-modal [keepContentsMounted]="true">
                 <ng-template>
                   <ion-datetime
@@ -327,6 +334,9 @@ import {
   ],
 })
 export class WcLoanFormComponent implements OnInit {
+  /** See `createPickersReady` — the date buttons must not outrun their pickers. */
+  readonly pickersReady = createPickersReady();
+
   private readonly loansService = inject(WorkingCapitalLoansService);
   private readonly nearBreachService = inject(WorkingCapitalNearBreachService);
   private readonly router = inject(Router);

--- a/src/app/shared/utils/pickers-ready.ts
+++ b/src/app/shared/utils/pickers-ready.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Signal, afterNextRender, signal } from '@angular/core';
+
+/**
+ * Guards `ion-datetime-button` against initializing before the `ion-datetime` it points at exists.
+ *
+ * The button resolves its target exactly once, in `componentWillLoad`, through a global
+ * `getElementById`, and gives up for good when that lookup misses. Our pickers live inside
+ * `ion-modal[keepContentsMounted]`, whose contents Angular mounts later in the change-detection
+ * pass. On a first visit to a routed page the button's lazy Ionic chunk is still loading, which
+ * delays it past that point; on a revisit the chunk is cached, so the button initializes first,
+ * finds nothing, and renders a blank control that never opens.
+ *
+ * Hold the buttons behind this flag -- `@if (pickersReady()) { <ion-datetime-button ... }` -- so
+ * they are created one render after the pickers they look for. Call it as a field initializer,
+ * which runs inside the component's injection context:
+ *
+ * ```ts
+ * readonly pickersReady = createPickersReady();
+ * ```
+ *
+ * See https://github.com/apache/fineract-backoffice-ui/issues/541.
+ */
+export function createPickersReady(): Signal<boolean> {
+  const ready = signal(false);
+  afterNextRender(() => ready.set(true));
+  return ready.asReadonly();
+}


### PR DESCRIPTION
## What changed

- add `createPickersReady()` in `src/app/shared/utils/pickers-ready.ts`
- hold every `ion-datetime-button` behind `@if (pickersReady())` across the **50 routed components** that carry the pattern — 72 buttons
- add an e2e spec that enters the office and staff forms three times each without a reload, registered to run at **both the desktop and mobile viewports**

Picker IDs are unchanged. The client form is fixed separately in #546; this PR leaves it alone to avoid a conflicting edit.

## Why

`ion-datetime-button` resolves its target `ion-datetime` exactly once, in `componentWillLoad`, through a global `getElementById`, and gives up for good when that lookup misses. The pickers live inside `ion-modal[keepContentsMounted]`, whose contents Angular mounts later in the change-detection pass.

On a first visit to a routed page the button's lazy Ionic chunk is still loading, which delays it past that point. On a revisit the chunk is cached, so the button initializes first, finds nothing, and renders a blank control that never opens. Reaching **any** of these forms a second time left every date field unusable until a full page reload — #541 is the client-form instance of it, reported because that is the busiest path.

## Scope, measured rather than assumed

- **51 routed components, 75 buttons** carry the defect. Confirmed by browser repro on two unrelated pages: the client form (#541) and `/organization/offices/create`, which renders its opening-date picker on the first visit and a dead blank control on every visit after. No submit required — Cancel and re-enter is enough. 50 components / 72 buttons are in this PR; the client form's 3 are in #546.
- **11 dialog components are not affected** and are left untouched. Opening `create-office-dialog` three times in a row renders correctly each time and logs nothing: an overlay mounts its contents before the button initializes. Verified, not inferred.

## Testing

- `npm run build`, `npm run lint`, `npm run test:unit` (241 files, 1464 tests passing)
- `npm run i18n:check`, `npm run check:icons`, `npm run check:a11y-names`, `bash scripts/check-license.sh`
- `npx playwright test date-picker-revisit --project=mocked` and `--project=mobile` — 2 passing each
- With the component changes stashed, the spec fails at **both** viewports with `visit 2 left a picker unbound`, so the coverage is real in both

`npm run format:check` reports pre-existing warnings under `_scratch/` and `LIVE_UI_BUGS.md`; no file in this change is listed.

The spec reads each button's shadow root rather than its `textContent`, which is always empty and cannot tell a bound control from a dead one.

## Notes for review

- `DUAL_VIEWPORT_SPECS` gains the glob `**/*date-picker-revisit.spec.ts` rather than a filename, so it also picks up the client-form spec in #546. Both PRs make that identical one-line edit, which merges cleanly in either order.
- Two loose ends found while sweeping, deliberately not folded in: `loanMenu-trigger` is used as an `ion-popover` trigger ID by both `loan-view` and `wc-loan-view` (latent — overlays resolve `trigger` through the same one-shot `getElementById`, so two live pages would collide), and `loans/bulk-reassignment/bulk-reassignment.component.ts` appears to be dead code, referenced only by its own test while the routed component is `bulk-loan-reassignment.component.ts`.

Related: #541, #546, #544