### PR TITLE
test(e2e): cover more routed forms in the date picker revisit spec

### DIFF
--- a/e2e/date-picker-revisit.spec.ts
+++ b/e2e/date-picker-revisit.spec.ts
@@ -77,9 +77,20 @@ test.describe('Date pickers on revisited forms', () => {
       }),
     );
 
-    await page.route('**/api/v1/staff**', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
-    );
+    // The list pages these forms are reached through only need to render; an empty collection is
+    // enough, and keeps each new page from dragging in its own fixture.
+    for (const collection of [
+      'staff',
+      'floatingrates',
+      'holidays',
+      'tellers',
+      'glclosures',
+      'currencies',
+    ]) {
+      await page.route(`**/api/v1/${collection}**`, (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+      );
+    }
 
     await page.goto('/login');
     if (!page.url().includes('/dashboard')) {
@@ -118,10 +129,45 @@ test.describe('Date pickers on revisited forms', () => {
       createButton: 'Create Staff Member',
       createRole: 'link' as const,
     },
+    {
+      name: 'holiday',
+      listUrl: '/settings/holidays',
+      createButton: 'Create Holiday',
+      createRole: 'button' as const,
+    },
+    {
+      name: 'teller',
+      listUrl: '/tellers',
+      createButton: 'Create Teller',
+      createRole: 'button' as const,
+    },
+    {
+      name: 'accounting closure',
+      listUrl: '/accounting/closures',
+      createButton: 'Close Period',
+      createRole: 'button' as const,
+    },
+    {
+      name: 'floating rate',
+      listUrl: '/products/floating-rates',
+      createButton: 'Create Floating Rate',
+      createRole: 'button' as const,
+      // This form's pickers live inside a @for over rate periods, so they are created after the
+      // first render rather than with the page. The button and its modal then mount in the same
+      // change-detection pass and the button binds to nothing -- #548, which `createPickersReady`
+      // does not reach because the flag is already true by the time a row is added. Expected to
+      // fail until that is fixed; when it starts passing, drop the marker with the fix.
+      knownBroken: true,
+      prepare: async (page: import('@playwright/test').Page) => {
+        await page.getByRole('button', { name: 'Add Period', exact: true }).click();
+      },
+    },
   ];
 
-  for (const { name, listUrl, createButton, createRole } of cases) {
+  for (const { name, listUrl, createButton, createRole, prepare, knownBroken } of cases) {
     test(`${name} form keeps its pickers usable on every visit`, async ({ page }) => {
+      if (knownBroken) test.fail();
+
       const pickerErrors: string[] = [];
       page.on('console', (message) => {
         const text = message.text();
@@ -133,6 +179,7 @@ test.describe('Date pickers on revisited forms', () => {
       for (const visit of [1, 2, 3]) {
         await page.getByRole(createRole, { name: createButton, exact: true }).click();
         await expect(page).toHaveURL(`${listUrl}/create`);
+        await prepare?.(page);
         await expect(page.locator('ion-datetime-button').first()).toBeAttached();
 
         await expect


### PR DESCRIPTION
## What changed

Broadens the regression coverage for #541 from two routed forms to six, spread across feature areas rather than concentrated in one:

| Form | Route | Pickers |
| --- | --- | ---: |
| Office | `/organization/offices/create` | 1 |
| Staff | `/organization/staff/create` | 1 |
| Holiday | `/settings/holidays/create` | 3 |
| Teller | `/tellers/create` | 1 |
| Accounting closure | `/accounting/closures/create` | 1 |
| Floating rate | `/products/floating-rates/create` | 1 (see below) |

Each case enters its form three times without a reload and asserts no `ion-datetime-button` is left unbound. The spec is matched by `DUAL_VIEWPORT_SPECS`, so every case runs at **both the desktop and mobile viewports**.

The list pages behind the new cases only need to render, so they are mocked as empty collections rather than dragging in a fixture per feature.

## The coverage is not vacuous

Each new case was checked against the broken shape: with `@if (pickersReady())` stripped from `holiday-form` and `teller-form`, both fail with `visit 2 left a picker unbound`. A test that cannot fail is not coverage, so this matters more than the count.

## A second bug this turned up — #548

The floating rate form is covered with `test.fail()`, because its pickers are genuinely broken and this PR does not fix them.

Its date controls live inside `@for (period of periods(); track $index)`, so they are created when the user clicks **Add Period**, not with the page. The button and its `ion-modal[keepContentsMounted]` then mount in the same change-detection pass, the modal's contents are not in the DOM yet, and the button binds to nothing. It fails on the **first** visit — no revisit needed.

`createPickersReady()` does not reach this: it gates the initial render, and by the time a row is added the flag is already `true`. Confirmed **pre-existing, not a regression from #547** — with the `@if` wrapper removed the picker fails identically. Moving `<ion-modal>` ahead of the button does not help either. Fixing it needs a per-instance deferral, which is a refactor rather than a test change, so it is filed as #548 with the analysis.

`test.fail()` rather than a skip is deliberate: the case runs, the suite asserts the bug is still there, and it turns red the moment someone fixes it — prompting removal of the marker instead of leaving a quietly skipped test behind.

#548 also records that the same `@for` gives every rate period the identical picker ID, so two periods put two `id="periodfromDate-picker"` elements in the document and both rows' buttons target the first one.

## Testing

- `npx playwright test date-picker-revisit --project=mocked` — 7 passed (6 cases plus the client-form spec; the floating rate case fails as expected)
- `npx playwright test --project=mobile` — 23 passed, the whole mobile project
- `npm run typecheck:e2e`, `prettier --check`

Related: #541, #546, #547, #548