### PR TITLE
fix(ci): stop the e2e summary reporting asserted failures as failures

### DIFF
--- a/scripts/e2e-summary.mjs
+++ b/scripts/e2e-summary.mjs
@@ -65,7 +65,29 @@ const ICON = {
   timedOut: '⏱️',
   skipped: '⏭️',
   interrupted: '⚠️',
+  expectedFailure: '🔒',
+  unexpectedPass: '❌',
 };
+
+/**
+ * Reconciles what a test *did* with what it was *asked* to do.
+ *
+ * A `test.fail()` case documents a known bug: Playwright runs it, requires it to fail, and
+ * exits zero when it does. Reading `result.status` alone renders that as a failure, so a green
+ * run reports "1 failing" — and a report that cries wolf on a passing suite is one nobody reads.
+ *
+ * The inverse matters just as much. When such a test starts passing, the marker is stale and
+ * Playwright fails the run; that must surface as a failure here too, not as a quiet pass, or
+ * the report would disagree with the exit code.
+ */
+export function classifyStatus(resultStatus, expectedStatus) {
+  const didFail = resultStatus === 'failed' || resultStatus === 'timedOut';
+  if (expectedStatus === 'failed') {
+    if (didFail) return 'expectedFailure';
+    if (resultStatus === 'passed') return 'unexpectedPass';
+  }
+  return resultStatus;
+}
 
 /**
  * Strips ANSI escape sequences.
@@ -96,7 +118,10 @@ function collect(suite, out, titlePath = []) {
         title: [...path, spec.title].join(' › '),
         file: spec.file ?? suite.file ?? '',
         project: test.projectName ?? '',
-        status: test.status === 'skipped' ? 'skipped' : (result?.status ?? test.status),
+        status:
+          test.status === 'skipped'
+            ? 'skipped'
+            : classifyStatus(result?.status ?? test.status, test.expectedStatus),
         expected: test.expectedStatus,
         // A test that failed and then passed on retry is green overall but worth surfacing:
         // it is the shape a flake takes, and flakes are what a sharded suite hides best.
@@ -164,6 +189,28 @@ function failureSection(failed) {
   return lines;
 }
 
+/**
+ * Known failures are green, but they are not nothing: each one is a bug someone chose to
+ * document rather than fix, and an undated list of them is how a `test.fail()` becomes
+ * permanent. Naming them keeps the cost visible on every run.
+ */
+function knownFailureSection(knownFailures) {
+  if (!knownFailures.length) return [];
+  const lines = [
+    '### 🔒 Known failures',
+    '',
+    'Marked `test.fail()`: the suite asserts the bug is still present, and turns red when it',
+    'is fixed so the marker can be removed.',
+    '',
+  ];
+  for (const test of knownFailures.slice(0, 15)) {
+    lines.push(`- **${cell(test.title)}** — \`${cell(test.file)}\``);
+  }
+  if (knownFailures.length > 15) lines.push(`- …and ${knownFailures.length - 15} more.`);
+  lines.push('');
+  return lines;
+}
+
 function flakySection(flaky) {
   if (!flaky.length) return [];
   const lines = [
@@ -184,17 +231,22 @@ function perFileSection(files) {
   const lines = [
     '### By spec file',
     '',
-    '| Spec | ✅ | ❌ | ⏭️ | Time |',
-    '| --- | ---: | ---: | ---: | ---: |',
+    '| Spec | ✅ | ❌ | ⏭️ | 🔒 | Time |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
   ];
   for (const [file, tests] of files) {
     const pass = tests.filter((t) => t.status === 'passed').length;
-    const fail = tests.filter((t) => t.status === 'failed' || t.status === 'timedOut').length;
+    const fail = tests.filter(
+      (t) => t.status === 'failed' || t.status === 'timedOut' || t.status === 'unexpectedPass',
+    ).length;
     const skip = tests.filter((t) => t.status === 'skipped').length;
+    // Carried in its own column rather than folded into ❌ or ⏭️: a known failure is neither a
+    // broken run nor a test that did not run, and the per-file counts must still add up.
+    const known = tests.filter((t) => t.status === 'expectedFailure').length;
     const ms = tests.reduce((total, t) => total + t.durationMs, 0);
     // A file whose tests all failed is worth spotting from the table alone.
     const name = fail ? `**${cell(file)}**` : cell(file);
-    lines.push(`| ${name} | ${pass} | ${fail} | ${skip} | ${humanDuration(ms)} |`);
+    lines.push(`| ${name} | ${pass} | ${fail} | ${skip} | ${known} | ${humanDuration(ms)} |`);
   }
   lines.push('');
   return lines;
@@ -278,9 +330,12 @@ function main() {
     return;
   }
 
-  const failed = tests.filter((t) => t.status === 'failed' || t.status === 'timedOut');
+  const failed = tests.filter(
+    (t) => t.status === 'failed' || t.status === 'timedOut' || t.status === 'unexpectedPass',
+  );
   const passed = tests.filter((t) => t.status === 'passed' && t.expected !== 'skipped').length;
   const skipped = tests.filter((t) => t.status === 'skipped').length;
+  const knownFailures = tests.filter((t) => t.status === 'expectedFailure');
   const flaky = tests.filter((t) => t.status === 'passed' && t.retries > 0);
   const seconds = Math.round((report.stats?.duration ?? 0) / 1000);
   const files = byFile(tests);
@@ -291,6 +346,7 @@ function main() {
     '## 🎭 E2E Tests',
     '',
     `**${verdict}** — ${passed} passed · ${failed.length} failed · ${skipped} skipped` +
+      `${knownFailures.length ? ` · ${knownFailures.length} known-failing` : ''}` +
       `${flaky.length ? ` · ${flaky.length} flaky` : ''}, ` +
       `across ${files.size} spec files in ${humanDuration(seconds * 1000)}.`,
     '',
@@ -300,6 +356,7 @@ function main() {
   // thing fits the budget, and the drop is always announced.
   const sections = [
     { name: 'failures', lines: failureSection(failed) },
+    { name: 'known failures', lines: knownFailureSection(knownFailures) },
     { name: 'flaky', lines: flakySection(flaky) },
     { name: 'the per-file table', lines: perFileSection(files) },
     { name: 'the full test listing', lines: fullListingSection(files, tests.length) },

--- a/scripts/reporting.test.mjs
+++ b/scripts/reporting.test.mjs
@@ -33,7 +33,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { cell, humanDuration } from './e2e-summary.mjs';
+import { cell, classifyStatus, humanDuration } from './e2e-summary.mjs';
 import { safeId, safeText, escapeRegExp } from './pr-sequence-diagram.mjs';
 
 test('cell escapes a pipe so it cannot end the table cell', () => {
@@ -102,4 +102,24 @@ test('importing either script renders nothing', async () => {
   const diagram = await import('./pr-sequence-diagram.mjs');
   assert.equal(typeof summary.cell, 'function');
   assert.equal(typeof diagram.safeId, 'function');
+});
+
+test('classifyStatus keeps an asserted failure out of the failure count', () => {
+  // The regression this guards: reading result.status alone reported "1 failing" on a run
+  // Playwright exited zero for, which trains people to ignore the report.
+  assert.equal(classifyStatus('failed', 'failed'), 'expectedFailure');
+  assert.equal(classifyStatus('timedOut', 'failed'), 'expectedFailure');
+});
+
+test('classifyStatus flags a test.fail() case that has started passing', () => {
+  // Playwright fails the run when this happens, so the report has to agree with the exit code
+  // rather than quietly counting it as a pass and leaving a stale marker in place.
+  assert.equal(classifyStatus('passed', 'failed'), 'unexpectedPass');
+});
+
+test('classifyStatus leaves ordinary results untouched', () => {
+  assert.equal(classifyStatus('passed', 'passed'), 'passed');
+  assert.equal(classifyStatus('failed', 'passed'), 'failed');
+  assert.equal(classifyStatus('timedOut', 'passed'), 'timedOut');
+  assert.equal(classifyStatus('skipped', 'skipped'), 'skipped');
 });


### PR DESCRIPTION
## What changed

`scripts/e2e-summary.mjs` now reconciles what a test *did* with what it was *asked* to do, instead of reading `result.status` alone.

- an asserted failure (`test.fail()`) no longer counts toward the failure total
- it gets its own **🔒 Known failures** section and a column in the per-file table
- a `test.fail()` case that has started passing is now reported as a failure

## Why

A `test.fail()` case documents a known bug: Playwright runs it, requires it to fail, and exits zero when it does. The summary counted it as a failure anyway, so a completely green run rendered as:

> ❌ 1 failing — 358 passed · 1 failed · 1 skipped

while all 31 checks, every E2E shard included, were green. Seen on #549. A report that cries wolf on a passing suite is one people stop reading, which defeats the point of the summary existing.

The inverse matters as much. When such a test starts passing the marker is stale and Playwright fails the run — the report has to agree with the exit code rather than quietly counting it as a pass.

Known failures are kept visible rather than folded into green: each one is a bug someone chose to document instead of fix, and an unnamed list of them is how a `test.fail()` becomes permanent. The per-file table gets its own column for the same reason — a known failure is neither a broken run nor a test that did not run, and the counts should still add up.

## Testing

Verified against a **real** Playwright JSON report containing an expected failure, produced by running the #549 spec locally, rather than a synthetic fixture. The report confirms the shape the fix keys on: `expectedStatus: "failed"`, `results[].status: "failed"`, run exit code 0.

Before → after on that report:

```
❌ 1 failing — 0 passed · 1 failed · 0 skipped
✅ All green — 1 passed · 0 failed · 0 skipped · 1 known-failing
```

With the same report's result flipped to `passed` — the stale-marker case — it correctly reads `❌ 1 failing`.

Also run: `npm run test:scripts` (31 passing, including three new cases for `classifyStatus`), `npm run lint`, `prettier --check`.

Found while landing #549, which adds the repository's first `test.fail()` case. Kept separate from that PR rather than folded in, since this is tooling that any future expected-failure test would hit.

Related: #549, #548